### PR TITLE
global: overridable document extension component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,34 +1,51 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import 'react-app-polyfill/ie11'; // For IE 11 support
 import ReactDOM from 'react-dom';
 import { OverridableContext } from 'react-overridable';
-import { Link } from 'react-router-dom';
 import 'semantic-ui-less/semantic.less';
-import { Item } from 'semantic-ui-react';
 import { InvenioILSApp } from './lib';
+import 'semantic-ui-less/semantic.less';
+import { Divider, Table } from 'semantic-ui-react';
+import _merge from 'lodash/merge';
+import _keys from 'lodash/keys';
 
-const CustomHome = ({ ...props }) => {
-  return <>And this is custom home</>;
-};
+const CDSDocumentMetadataExtensions = ({ extensions }) => {
+  let result = {};
 
-const CustomCover = ({ size, url, isRestricted, asItem, linkTo }) => {
-  const Cmp = asItem ? Item.Image : Image;
-  const link = linkTo ? { as: Link, to: linkTo } : {};
+  _keys(extensions).map(key => {
+    const [objName, objProp] = key.split(':');
+    result[objName] = _merge({}, result[objName]);
+    result[objName][objProp] = extensions[key];
+    return result;
+  });
+
   return (
-    <Cmp
-      centered
-      disabled={isRestricted}
-      {...link}
-      onError={e => (e.target.style.display = 'none')}
-      src={url}
-      size="tiny"
-    />
+    result &&
+    _keys(result).map(property => (
+      <React.Fragment key={property}>
+        <Divider horizontal>{property}</Divider>
+        <Table definition>
+          <Table.Body>
+            {_keys(result[property]).map(key => (
+              <Table.Row key={key}>
+                <Table.Cell width={4}>{key}</Table.Cell>
+                <Table.Cell>{result[property][key]}</Table.Cell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
+      </React.Fragment>
+    ))
   );
 };
 
+CDSDocumentMetadataExtensions.propTypes = {
+  extensions: PropTypes.object.isRequired,
+};
+
 const overriddenCmps = {
-  // 'Home.layout': CustomHome,
-  // 'LiteratureCover.layout': CustomCover,
+  'DocumentMetadata.extensions.layout': CDSDocumentMetadataExtensions,
 };
 
 ReactDOM.render(

--- a/src/lib/config/searchConfig.js
+++ b/src/lib/config/searchConfig.js
@@ -432,19 +432,19 @@ const searchConfig = {
   acqVendors: {
     filters: [],
     sortBy: {
-      onEmptyQuery: 'name',
+      onEmptyQuery: 'bestmatch',
       values: [
         {
           default_order: 'asc',
-          field: 'name',
+          field: 'bestmatch',
           order: 1,
-          title: 'Name',
+          title: 'Best match',
         },
         {
           default_order: 'asc',
-          field: 'bestmatch',
+          field: 'name.keyword',
           order: 2,
-          title: 'Best match',
+          title: 'Name',
         },
       ],
     },
@@ -527,6 +527,12 @@ const searchConfig = {
           field: 'bestmatch',
           order: 1,
           title: 'Best match',
+        },
+        {
+          default_order: 'asc',
+          field: 'name.keyword',
+          order: 2,
+          title: 'Name',
         },
       ],
     },

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentRelations/DocumentSeries.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentRelations/DocumentSeries.js
@@ -5,13 +5,13 @@ import { RelationMultipart } from './RelationMultipartMonograph';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Label, Tab } from 'semantic-ui-react';
+import _get from 'lodash/get';
 
 export default class DocumentSeries extends Component {
   render() {
     const { isLoading, error, documentDetails, relations } = this.props;
-
-    const multipart = relations['multipart_monograph'] || [];
-    const serial = relations['serial'] || [];
+    const multipart = _get(relations, 'multipart_monograph', []);
+    const serial = _get(relations, 'serial', []);
 
     const panes = [
       {

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentRelations/DocumentSiblings.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentRelations/DocumentSiblings.js
@@ -6,14 +6,15 @@ import { RelationLanguages } from './RelationLanguages';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Label, Tab } from 'semantic-ui-react';
+import _get from 'lodash/get';
 
 export default class DocumentSiblings extends Component {
   render() {
     const { isLoading, error, documentDetails, relations } = this.props;
 
-    const languages = relations['language'] || [];
-    const editions = relations['edition'] || [];
-    const other = relations['other'] || [];
+    const languages = _get(relations, 'language', []);
+    const editions = _get(relations, 'edition', []);
+    const other = _get(relations, 'other', []);
 
     const panes = [
       {

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
@@ -98,7 +98,11 @@ const DocumentDetailsLayout = ({ error, isLoading, documentDetails }) => {
 DocumentDetailsLayout.propTypes = {
   documentDetails: PropTypes.object.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  error: PropTypes.bool.isRequired,
+  error: PropTypes.object,
+};
+
+DocumentDetailsLayout.defaultProps = {
+  error: {},
 };
 
 class DocumentDetails extends Component {
@@ -180,7 +184,11 @@ DocumentDetails.propTypes = {
   fetchDocumentsDetails: PropTypes.func.isRequired,
   documentDetails: PropTypes.object.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  error: PropTypes.bool.isRequired,
+  error: PropTypes.object,
+};
+
+DocumentDetails.defaultProps = {
+  error: {},
 };
 
 export default Overridable.component('DocumentDetails', DocumentDetails);

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentItems/DocumentItems.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentItems/DocumentItems.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 import _has from 'lodash/has';
 import Overridable from 'react-overridable';
@@ -92,13 +93,8 @@ class DocumentItems extends Component {
 
   renderLibraries = () => {
     const { activeLibrary } = this.state;
-    const {
-      documentDetails: {
-        metadata: {
-          items: { on_shelf: onShelf },
-        },
-      },
-    } = this.props;
+    const { documentDetails } = this.props;
+    const onShelf = _get(documentDetails, 'metadata.items.on_shelf', {});
     const libraries = [];
 
     Object.entries(onShelf).forEach(([locationName, locationObj]) => {
@@ -130,13 +126,8 @@ class DocumentItems extends Component {
   };
 
   renderItems = () => {
-    const {
-      documentDetails: {
-        metadata: {
-          items: { on_shelf: onShelf },
-        },
-      },
-    } = this.props;
+    const { documentDetails } = this.props;
+    const onShelf = _get(documentDetails, 'metadata.items.on_shelf', {});
     const { activeLibrary, activeInternalLocation } = this.state;
 
     if (!_isEmpty(onShelf)) {

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentMetadata/DocumentMetadataTabs/DocumentMetadataTabs.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentMetadata/DocumentMetadataTabs/DocumentMetadataTabs.js
@@ -1,6 +1,7 @@
 import LiteratureRelations from '@modules/Literature/LiteratureRelations';
 import { LiteratureNotes } from '@modules/Literature/LiteratureNotes';
 import _get from 'lodash/get';
+import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Overridable from 'react-overridable';
@@ -20,7 +21,7 @@ class DocumentMetadataTabs extends Component {
       {
         menuItem: 'Details',
         render: () => (
-          <Tab.Pane attached={false}>
+          <Tab.Pane>
             <LiteratureRelations relations={metadata.relations} />
             <DocumentInfo metadata={metadata} />
           </Tab.Pane>
@@ -29,7 +30,7 @@ class DocumentMetadataTabs extends Component {
       {
         menuItem: 'Identifiers',
         render: () => (
-          <Tab.Pane attached={false}>
+          <Tab.Pane>
             <Identifiers identifiers={identifiers.concat(altIdentifiers)} />
           </Tab.Pane>
         ),
@@ -37,7 +38,7 @@ class DocumentMetadataTabs extends Component {
       {
         menuItem: 'Content',
         render: () => (
-          <Tab.Pane attached={false}>
+          <Tab.Pane>
             <DocumentTableOfContent
               toc={metadata.table_of_content}
               abstract={metadata.abstract}
@@ -47,14 +48,12 @@ class DocumentMetadataTabs extends Component {
       },
       {
         menuItem: 'Publications',
-        render: () => (
-          <Tab.Pane attached={false}>We wait for the schema!</Tab.Pane>
-        ),
+        render: () => <Tab.Pane>We wait for the schema!</Tab.Pane>,
       },
       {
         menuItem: 'Conference',
         render: () => (
-          <Tab.Pane attached={false}>
+          <Tab.Pane>
             <DocumentConference
               conference={metadata.conference_info}
               documentType={metadata.document_type}
@@ -65,7 +64,7 @@ class DocumentMetadataTabs extends Component {
       {
         menuItem: 'Notes',
         render: () => (
-          <Tab.Pane attached={false}>
+          <Tab.Pane>
             <LiteratureNotes content={metadata.note} />
           </Tab.Pane>
         ),
@@ -77,8 +76,23 @@ class DocumentMetadataTabs extends Component {
       panes.push({
         menuItem: 'Files',
         render: () => (
-          <Tab.Pane attached={false}>
+          <Tab.Pane>
             <DocumentLinks dividers eitems={eitems} />
+          </Tab.Pane>
+        ),
+      });
+    }
+
+    const extensions = _get(metadata, 'extensions', {});
+    if (!_isEmpty(extensions)) {
+      panes.push({
+        menuItem: 'Extensions',
+        render: () => (
+          <Tab.Pane>
+            <Overridable
+              id="DocumentMetadata.extensions.layout"
+              extensions={extensions}
+            />
           </Tab.Pane>
         ),
       });

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
@@ -85,7 +85,7 @@ const SeriesDetailsLayout = ({ error, isLoading, series }) => {
 
 SeriesDetailsLayout.propTypes = {
   series: PropTypes.object.isRequired,
-  error: PropTypes.bool.isRequired,
+  error: PropTypes.object.isRequired,
   isLoading: PropTypes.bool.isRequired,
 };
 
@@ -151,7 +151,7 @@ class SeriesDetails extends React.Component {
 SeriesDetails.propTypes = {
   /* redux */
   series: PropTypes.object.isRequired,
-  error: PropTypes.bool.isRequired,
+  error: PropTypes.object.isRequired,
   isLoading: PropTypes.bool.isRequired,
   fetchSeriesDetails: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
- searchConfig.js sort option for `acqVendors` and `IllLibaries` as keyword
- fix props types for error
- fix for missing on_shelf for items
- fix for document details relations
- added conditional Tab pane for document details 
- added override document metadata extensions component
- no support for mobile
- addresses #8

![Screenshot 2020-06-09 13 48 00](https://user-images.githubusercontent.com/230805/84144155-138be280-aa58-11ea-866f-c0d1fea4e262.png)
