### PR TITLE
backoffice: Adds loan request to item details page

### DIFF
--- a/src/lib/modules/Loan/actions.js
+++ b/src/lib/modules/Loan/actions.js
@@ -4,6 +4,7 @@ import {
   sendErrorNotification,
   sendSuccessNotification,
 } from '@components/Notifications';
+import { fetchItemDetails } from './../../pages/backoffice/Item/ItemDetails/state/actions';
 
 export const ACTION_IS_LOADING = 'loanAction/IS_LOADING';
 export const ACTION_SUCCESS = 'loanAction/SUCCESS';
@@ -38,7 +39,7 @@ export const performLoanAction = (
   actionURL,
   documentPid,
   patronPid,
-  { itemPid = null, cancelReason = null } = {}
+  { itemPid = null, cancelReason = null, shouldFetchItemDetails = null } = {}
 ) => {
   return async dispatch => {
     dispatch({
@@ -60,7 +61,9 @@ export const performLoanAction = (
         type: ACTION_SUCCESS,
         payload: response.data,
       });
-      dispatch(fetchLoanDetails(response.data.metadata.pid));
+      shouldFetchItemDetails
+        ? dispatch(fetchItemDetails(itemPid.value))
+        : dispatch(fetchLoanDetails(response.data.metadata.pid));
       const loanPid = response.data.pid;
       dispatch(
         sendSuccessNotification(

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemActionMenu/ItemActionMenu.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemActionMenu/ItemActionMenu.js
@@ -1,21 +1,21 @@
 import { loanApi } from '@api/loans';
 import { patronApi } from '@api/patrons';
 import { recordToPidType } from '@api/utils';
-import { ESSelectorModal } from '@modules/ESSelector';
-import { serializePatron } from '@modules/ESSelector/serializer';
-import { invenioConfig } from '@config';
-import { goTo } from '@history';
-import { LoanIcon } from '@components/backoffice/icons';
 import { EditButton } from '@components/backoffice/buttons/EditButton';
-import { DeleteRecordModal } from '@components/backoffice/DeleteRecordModal';
 import {
   ScrollingMenu,
   ScrollingMenuItem,
 } from '@components/backoffice/buttons/ScrollingMenu';
+import { DeleteRecordModal } from '@components/backoffice/DeleteRecordModal';
 import { DeleteButton } from '@components/backoffice/DeleteRecordModal/DeleteButton';
+import { LoanIcon } from '@components/backoffice/icons';
+import { invenioConfig } from '@config';
+import { goTo } from '@history';
+import { ESSelectorModal } from '@modules/ESSelector';
+import { serializePatron } from '@modules/ESSelector/serializer';
 import { BackOfficeRoutes } from '@routes/urls';
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Button, Divider } from 'semantic-ui-react';
 
 export default class ItemActionMenu extends Component {
@@ -123,6 +123,7 @@ export default class ItemActionMenu extends Component {
         <ScrollingMenu offset={offset}>
           <ScrollingMenuItem label="Circulation" elementId="circulation" />
           <ScrollingMenuItem label="Metadata" elementId="metadata" />
+          <ScrollingMenuItem label="Loans request" elementId="loans-request" />
           <ScrollingMenuItem label="Loans history" elementId="loans-history" />
         </ScrollingMenu>
       </div>

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemDetails.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemDetails.js
@@ -1,14 +1,14 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { Container, Divider, Grid, Ref, Sticky } from 'semantic-ui-react';
 import { Error } from '@components/Error';
 import { Loader } from '@components/Loader';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Container, Divider, Grid, Ref, Sticky } from 'semantic-ui-react';
 import { ItemActionMenu } from './ItemActionMenu';
 import { ItemCirculation } from './ItemCirculation';
+import { ItemHeader } from './ItemHeader';
 import { ItemMetadata } from './ItemMetadata';
 import { ItemPastLoans } from './ItemPastLoans';
-
-import { ItemHeader } from './ItemHeader';
+import { ItemPendingLoans } from './ItemPendingLoans';
 
 export default class ItemDetails extends Component {
   constructor(props) {
@@ -53,6 +53,7 @@ export default class ItemDetails extends Component {
                         <Container className="spaced">
                           <ItemCirculation />
                           <ItemMetadata />
+                          <ItemPendingLoans />
                           <ItemPastLoans />
                         </Container>
                       </Container>

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/ItemPendingLoans.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/ItemPendingLoans.js
@@ -1,0 +1,179 @@
+import { dateFormatter } from '@api/date';
+import { loanApi } from '@api/loans';
+import { recordToPidType } from '@api/utils';
+import { SeeAllButton } from '@components/backoffice/buttons/SeeAllButton';
+import { Error } from '@components/Error';
+import { Loader } from '@components/Loader';
+import { ResultsTable } from '@components/ResultsTable/ResultsTable';
+import { invenioConfig } from '@config';
+import { BackOfficeRoutes } from '@routes/urls';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Button, Header, Message, Segment } from 'semantic-ui-react';
+
+export default class ItemPendingLoans extends Component {
+  componentDidMount() {
+    const {
+      itemDetails: { metadata },
+      fetchPendingLoans,
+    } = this.props;
+    fetchPendingLoans(metadata.document_pid);
+  }
+
+  seeAllButton = () => {
+    const {
+      itemDetails: { metadata },
+    } = this.props;
+    const path = BackOfficeRoutes.loansListWithQuery(
+      loanApi
+        .query()
+        .withDocPid(metadata.document_pid)
+        .withState(invenioConfig.CIRCULATION.loanRequestStates)
+        .qs()
+    );
+    return <SeeAllButton to={path} />;
+  };
+
+  viewDetails = ({ row }) => {
+    return (
+      <Link
+        to={BackOfficeRoutes.loanDetailsFor(row.metadata.pid)}
+        data-test={row.metadata.pid}
+      >
+        {row.metadata.pid}
+      </Link>
+    );
+  };
+
+  patronDetails = ({ row }) => {
+    return (
+      <Link to={BackOfficeRoutes.patronDetailsFor(row.metadata.patron_pid)}>
+        {row.metadata.patron.name}
+      </Link>
+    );
+  };
+
+  renderNoPendingLoans = () => {
+    return (
+      <Message info icon data-test="no-results">
+        <Message.Content>
+          <Message.Header>No loans requests</Message.Header>
+          There are no loans requests for this item.
+        </Message.Content>
+      </Message>
+    );
+  };
+
+  checkoutItemButton = ({ row }) => {
+    const {
+      performCheckoutAction,
+      itemDetails,
+      isPendingLoansLoading,
+    } = this.props;
+    const itemPid = {
+      type: recordToPidType(itemDetails),
+      value: itemDetails.metadata.pid,
+    };
+    return (
+      <Button
+        size="mini"
+        color="teal"
+        loading={isPendingLoansLoading}
+        disabled={
+          invenioConfig.CIRCULATION.loanActiveStates.includes(
+            itemDetails.metadata.circulation.state
+          ) ||
+          !invenioConfig.ITEMS.canCirculateStatuses.includes(
+            itemDetails.metadata.status
+          )
+        }
+        onClick={() =>
+          performCheckoutAction(
+            row.availableActions.checkout,
+            row.metadata.document_pid,
+            row.metadata.patron_pid,
+            itemPid,
+            true
+          )
+        }
+      >
+        checkout
+      </Button>
+    );
+  };
+
+  renderTable() {
+    const { data, showMaxPendingLoans } = this.props;
+    const columns = [
+      { title: 'ID', field: 'metadata.pid', formatter: this.viewDetails },
+      {
+        title: 'Patron ID',
+        field: 'metadata.patron.name',
+        formatter: this.patronDetails,
+      },
+      { title: 'State', field: 'metadata.state' },
+      {
+        title: 'Request start date',
+        field: 'metadata.request_start_date',
+        formatter: dateFormatter,
+      },
+      {
+        title: 'Request end date',
+        field: 'metadata.request_expire_date',
+        formatter: dateFormatter,
+      },
+      {
+        title: 'Actions',
+        field: '',
+        formatter: this.checkoutItemButton,
+      },
+    ];
+
+    return (
+      <>
+        <Header as="h3" attached="top" id="loans-request">
+          Loans request
+        </Header>
+        <Segment attached="bottom" className="bo-metadata-segment no-padding">
+          <ResultsTable
+            data={data.hits}
+            columns={columns}
+            totalHitsCount={data.total}
+            name="loans"
+            seeAllComponent={this.seeAllButton()}
+            showMaxRows={showMaxPendingLoans}
+            renderEmptyResultsElement={this.renderNoPendingLoans}
+          />
+        </Segment>
+      </>
+    );
+  }
+
+  render() {
+    const { isLoading, error } = this.props;
+    return (
+      <Loader isLoading={isLoading}>
+        <Error error={error}>{this.renderTable()}</Error>
+      </Loader>
+    );
+  }
+}
+
+ItemPendingLoans.propTypes = {
+  itemDetails: PropTypes.object.isRequired,
+  fetchPendingLoans: PropTypes.func.isRequired,
+  data: PropTypes.object.isRequired,
+  showMaxPendingLoans: PropTypes.number,
+  isLoading: PropTypes.bool,
+  isPendingLoansLoading: PropTypes.bool,
+  error: PropTypes.object,
+  performCheckoutAction: PropTypes.func.isRequired,
+};
+
+ItemPendingLoans.defaultProps = {
+  showMaxPendingLoans: 5,
+  isLoading: false,
+  isPendingLoansLoading: false,
+  error: {},
+};

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/ItemPendingLoans.test.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/ItemPendingLoans.test.js
@@ -1,0 +1,42 @@
+import { BackOfficeRoutes } from '@routes/urls';
+import { mount } from 'enzyme';
+import React from 'react';
+import ItemPendingLoans from './ItemPendingLoans';
+
+jest.mock('react-router-dom');
+jest.mock('@config');
+BackOfficeRoutes.loanDetailsFor = jest.fn(pid => `url/${pid}`);
+
+describe('ItemPendingLoans tests', () => {
+  let component;
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+    }
+  });
+
+  const item = {
+    pid: 222,
+    metadata: {
+      document_pid: 111,
+      pid: 222,
+    },
+  };
+
+  it('should render show a message with no requested loans', () => {
+    component = mount(
+      <ItemPendingLoans
+        itemDetails={item}
+        data={{ hits: [], total: 0 }}
+        fetchPendingLoans={() => {}}
+        performCheckoutAction={() => {}}
+      />
+    );
+
+    expect(component).toMatchSnapshot();
+    const message = component
+      .find('Message')
+      .filterWhere(element => element.prop('data-test') === 'no-results');
+    expect(message).toHaveLength(1);
+  });
+});

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/__snapshots__/ItemPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/__snapshots__/ItemPendingLoans.test.js.snap
@@ -1,0 +1,147 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ItemPendingLoans tests should render show a message with no requested loans 1`] = `
+<ItemPendingLoans
+  data={
+    Object {
+      "hits": Array [],
+      "total": 0,
+    }
+  }
+  error={Object {}}
+  fetchPendingLoans={[Function]}
+  isLoading={false}
+  isPendingLoansLoading={false}
+  itemDetails={
+    Object {
+      "metadata": Object {
+        "document_pid": 111,
+        "pid": 222,
+      },
+      "pid": 222,
+    }
+  }
+  performCheckoutAction={[Function]}
+  showMaxPendingLoans={5}
+>
+  <Overridable(Loader)
+    isLoading={false}
+  >
+    <Loader
+      isLoading={false}
+    >
+      <Overridable
+        id="Loader.layout"
+        isLoading={false}
+      >
+        <Error
+          error={Object {}}
+        >
+          <Header
+            as="h3"
+            attached="top"
+            id="loans-request"
+          >
+            <h3
+              className="ui top attached header"
+              id="loans-request"
+            >
+              Loans request
+            </h3>
+          </Header>
+          <Segment
+            attached="bottom"
+            className="bo-metadata-segment no-padding"
+          >
+            <div
+              className="ui bottom attached segment bo-metadata-segment no-padding"
+            >
+              <ResultsTable
+                columns={
+                  Array [
+                    Object {
+                      "field": "metadata.pid",
+                      "formatter": [Function],
+                      "title": "ID",
+                    },
+                    Object {
+                      "field": "metadata.patron.name",
+                      "formatter": [Function],
+                      "title": "Patron ID",
+                    },
+                    Object {
+                      "field": "metadata.state",
+                      "title": "State",
+                    },
+                    Object {
+                      "field": "metadata.request_start_date",
+                      "formatter": [Function],
+                      "title": "Request start date",
+                    },
+                    Object {
+                      "field": "metadata.request_expire_date",
+                      "formatter": [Function],
+                      "title": "Request end date",
+                    },
+                    Object {
+                      "field": "",
+                      "formatter": [Function],
+                      "title": "Actions",
+                    },
+                  ]
+                }
+                currentPage={1}
+                data={Array []}
+                fixed={false}
+                headerActionComponent={null}
+                name="loans"
+                paginationComponent={null}
+                renderEmptyResultsElement={[Function]}
+                seeAllComponent={
+                  <SeeAllButton
+                    disabled={false}
+                    fluid={false}
+                    to="/backoffice/loans?q=(document_pid:111 AND state:(PENDING))"
+                  />
+                }
+                showAllResults={false}
+                showMaxRows={5}
+                singleLine={true}
+                subtitle=""
+                title=""
+                totalHitsCount={0}
+              >
+                <Message
+                  data-test="no-results"
+                  icon={true}
+                  info={true}
+                >
+                  <div
+                    className="ui icon info message"
+                    data-test="no-results"
+                  >
+                    <MessageContent>
+                      <div
+                        className="content"
+                      >
+                        <MessageHeader>
+                          <div
+                            className="header"
+                          >
+                            No loans requests
+                          </div>
+                        </MessageHeader>
+                        There are no loans requests for this item.
+                      </div>
+                    </MessageContent>
+                  </div>
+                </Message>
+              </ResultsTable>
+            </div>
+          </Segment>
+        </Error>
+      </Overridable>
+    </Loader>
+  </Overridable(Loader)>
+</ItemPendingLoans>
+`;

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/index.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/index.js
@@ -1,0 +1,34 @@
+import { performLoanAction } from '@modules/Loan/actions';
+import { connect } from 'react-redux';
+import { fetchPendingLoans } from './../../../Document/DocumentDetails/DocumentPendingLoans/state/actions';
+import ItemPendingLoansComponent from './ItemPendingLoans';
+
+const mapStateToProps = state => ({
+  data: state.documentPendingLoans.data,
+  itemDetails: state.itemDetails.data,
+  error: state.documentPendingLoans.error,
+  isLoading: state.documentPendingLoans.isLoading,
+  hasError: state.documentPendingLoans.hasError,
+  isPendingLoansLoading: state.loanActions.isLoading,
+});
+const mapDispatchToProps = dispatch => ({
+  fetchPendingLoans: documentPid => dispatch(fetchPendingLoans(documentPid)),
+  performCheckoutAction: (
+    url,
+    documentPid,
+    patronPid,
+    itemPid,
+    shouldFetchItemDetails
+  ) =>
+    dispatch(
+      performLoanAction(url, documentPid, patronPid, {
+        itemPid: itemPid,
+        shouldFetchItemDetails: shouldFetchItemDetails,
+      })
+    ),
+});
+
+export const ItemPendingLoans = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ItemPendingLoansComponent);


### PR DESCRIPTION
* Adds new box in the item detail page to
  show the list of loan requests and the
  checkout button for each one

* closes #85
--------------
![image](https://user-images.githubusercontent.com/15194802/87673733-46bb4300-c775-11ea-8d70-9cae116f1bb3.png)
-------------
### LOADING
![image](https://user-images.githubusercontent.com/15194802/87673883-7ff3b300-c775-11ea-9c97-5e1304c775ac.png)
-------------
### ITEM ON LOAN
![image](https://user-images.githubusercontent.com/15194802/87673922-8d10a200-c775-11ea-8409-f0b6e8915774.png)
-------------
### NO LOAN REQUEST
![image](https://user-images.githubusercontent.com/15194802/87674464-54bd9380-c776-11ea-8497-1d1da7eba712.png)
