### PR TITLE
backoffice: checkout

### DIFF
--- a/src/lib/api/patrons/patron.js
+++ b/src/lib/api/patrons/patron.js
@@ -1,5 +1,7 @@
 import { http, apiConfig } from '@api/base';
 import { serializer } from './serializer';
+import { invenioConfig } from '@config';
+import { prepareSumQuery } from '@api/utils';
 
 const listUrl = '/patrons/';
 // Here we use a different url to access Patron details
@@ -14,8 +16,10 @@ const get = async patronPid => {
   return response;
 };
 
-const list = async queryText => {
-  const response = await http.get(`${listUrl}?q=${queryText}*`);
+const list = async (queryText, wildcard = true) => {
+  const response = await http.get(
+    `${listUrl}?q=${queryText}${wildcard ? '*' : ''}`
+  );
   response.data.total = response.data.hits.total;
   response.data.hits = response.data.hits.hits.map(hit =>
     serializer.fromJSON(hit)
@@ -23,8 +27,52 @@ const list = async queryText => {
   return response;
 };
 
+class QueryBuilder {
+  constructor() {
+    this.patronQuery = [];
+    this.emailQuery = [];
+    this.nameQuery = [];
+    this.patronUniqueIDQuery = [];
+  }
+
+  withEmail(email, wildcard = false) {
+    if (!email) {
+      throw TypeError('Email argument missing');
+    }
+    this.patronQuery.push(`email:${email}${wildcard ? '*' : ''}`);
+    return this;
+  }
+
+  withName(name, wildcard = false) {
+    if (!name) {
+      throw TypeError('Name argument missing');
+    }
+    this.patronQuery.push(`name:${name}${wildcard ? '*' : ''}`);
+    return this;
+  }
+
+  withPatronUniqueID(patronID) {
+    if (!patronID) {
+      throw TypeError('Patron Unique ID argument missing');
+    }
+    this.patronQuery.push(
+      `${invenioConfig.PATRONS.patronUniqueID.field}:${patronID}`
+    );
+    return this;
+  }
+
+  qs() {
+    return `${prepareSumQuery(this.patronQuery)}`;
+  }
+}
+
+const queryBuilder = () => {
+  return new QueryBuilder();
+};
+
 export const patronApi = {
   searchBaseURL: `${apiConfig.baseURL}${listUrl}`,
   get: get,
   list: list,
+  query: queryBuilder,
 };

--- a/src/lib/api/patrons/patron.js
+++ b/src/lib/api/patrons/patron.js
@@ -2,6 +2,7 @@ import { http, apiConfig } from '@api/base';
 import { serializer } from './serializer';
 import { invenioConfig } from '@config';
 import { prepareSumQuery } from '@api/utils';
+import _forOwn from 'lodash/forOwn';
 
 const listUrl = '/patrons/';
 // Here we use a different url to access Patron details
@@ -30,9 +31,6 @@ const list = async (queryText, wildcard = true) => {
 class QueryBuilder {
   constructor() {
     this.patronQuery = [];
-    this.emailQuery = [];
-    this.nameQuery = [];
-    this.patronUniqueIDQuery = [];
   }
 
   withEmail(email, wildcard = false) {
@@ -51,12 +49,19 @@ class QueryBuilder {
     return this;
   }
 
-  withPatronUniqueID(patronID) {
-    if (!patronID) {
-      throw TypeError('Patron Unique ID argument missing');
+  withPid(pid) {
+    if (!pid) {
+      throw TypeError('PID argument is missing');
     }
-    this.patronQuery.push(
-      `${invenioConfig.PATRONS.patronUniqueID.field}:${patronID}`
+    this.patronQuery.push(`pid:${pid}`);
+    return this;
+  }
+  withCustomField(term) {
+    if (!term) {
+      throw TypeError('Custom field term argument is missing');
+    }
+    _forOwn(invenioConfig.PATRONS.customFields, (value, key) =>
+      this.patronQuery.push(`${value.field}:${term}`)
     );
     return this;
   }

--- a/src/lib/api/patrons/patron.test.js
+++ b/src/lib/api/patrons/patron.test.js
@@ -1,0 +1,68 @@
+import { patronApi } from './patron';
+import { invenioConfig } from '@config';
+
+describe('Patron query builder tests', () => {
+  it('should build query string with patron name', () => {
+    const query = patronApi
+      .query()
+      .withName('Vader')
+      .qs();
+    expect(query).toEqual('(name:Vader)');
+  });
+
+  it('should build query string with matching patron name', () => {
+    const query = patronApi
+      .query()
+      .withName('Vader', true)
+      .qs();
+    expect(query).toEqual('(name:Vader*)');
+  });
+
+  it('should build query string for the exact patron email', () => {
+    const query = patronApi
+      .query()
+      .withEmail('test@email.com')
+      .qs();
+    expect(query).toEqual('(email:test@email.com)');
+  });
+
+  it('should build query string for searching mathing patron email', () => {
+    const query = patronApi
+      .query()
+      .withEmail('test', true)
+      .qs();
+    expect(query).toEqual('(email:test*)');
+  });
+
+  it('should build query string with configured patron unique ID', () => {
+    const query = patronApi
+      .query()
+      .withPatronUniqueID('UniqueID')
+      .qs();
+    expect(query).toEqual(
+      `(${invenioConfig.PATRONS.patronUniqueID.field}:UniqueID)`
+    );
+  });
+
+  it('should build a query with combination of params', () => {
+    const query = patronApi
+      .query()
+      .withName('Vader', true)
+      .withEmail('Vader', true)
+      .withPatronUniqueID('Vader')
+      .qs();
+    expect(query).toEqual(
+      `(name:Vader* OR email:Vader* OR ${invenioConfig.PATRONS.patronUniqueID.field}:Vader)`
+    );
+  });
+
+  it('should not return anything for empty params', () => {
+    expect(() => {
+      patronApi
+        .query()
+        .withState()
+        .qs()
+        .toThrow();
+    });
+  });
+});

--- a/src/lib/api/patrons/patron.test.js
+++ b/src/lib/api/patrons/patron.test.js
@@ -1,6 +1,8 @@
 import { patronApi } from './patron';
 import { invenioConfig } from '@config';
 
+jest.mock('@config');
+
 describe('Patron query builder tests', () => {
   it('should build query string with patron name', () => {
     const query = patronApi
@@ -34,25 +36,27 @@ describe('Patron query builder tests', () => {
     expect(query).toEqual('(email:test*)');
   });
 
-  it('should build query string with configured patron unique ID', () => {
+  it('should build query string with configured custom fields', () => {
+    const mockValue = 'TestID';
     const query = patronApi
       .query()
-      .withPatronUniqueID('UniqueID')
+      .withCustomField(mockValue)
       .qs();
     expect(query).toEqual(
-      `(${invenioConfig.PATRONS.patronUniqueID.field}:UniqueID)`
+      `(${invenioConfig.PATRONS.customFields.mockField.field}:${mockValue})`
     );
   });
 
   it('should build a query with combination of params', () => {
+    const term = 'Vader';
     const query = patronApi
       .query()
-      .withName('Vader', true)
-      .withEmail('Vader', true)
-      .withPatronUniqueID('Vader')
+      .withName(term, true)
+      .withEmail(term, true)
+      .withCustomField(term)
       .qs();
     expect(query).toEqual(
-      `(name:Vader* OR email:Vader* OR ${invenioConfig.PATRONS.patronUniqueID.field}:Vader)`
+      `(name:${term}* OR email:${term}* OR ${invenioConfig.PATRONS.customFields.mockField.field}:${term})`
     );
   });
 

--- a/src/lib/api/patrons/serializer.js
+++ b/src/lib/api/patrons/serializer.js
@@ -5,8 +5,6 @@ export function serializeResponse(hit) {
   if (!_isEmpty(hit)) {
     result['user_pid'] = hit.id.toString();
     result['links'] = hit.links;
-    result['email'] = hit.email;
-    result['active'] = hit.active;
     if (!_isEmpty(hit.metadata)) {
       result['metadata'] = hit.metadata;
     }

--- a/src/lib/components/Loader/Loader.js
+++ b/src/lib/components/Loader/Loader.js
@@ -5,13 +5,14 @@ import PropTypes from 'prop-types';
 
 class Loader extends Component {
   render() {
-    const { isLoading } = this.props;
+    const { isLoading, children } = this.props;
     return (
       <Overridable id="Loader.layout" {...this.props}>
         {isLoading ? (
           <UILoader active size="huge" inline="centered" />
         ) : (
-          <>{this.props.children}</>
+          // eslint-disable-next-line react/jsx-no-useless-fragment
+          <>{children}</>
         )}
       </Overridable>
     );

--- a/src/lib/components/backoffice/Sidebar/Sidebar.js
+++ b/src/lib/components/backoffice/Sidebar/Sidebar.js
@@ -38,6 +38,8 @@ class Sidebar extends Component {
     const seriesActive = activePath.includes(BackOfficeRoutes.seriesList);
     const statsActive = activePath.includes(BackOfficeRoutes.stats.home);
     const checkInActive = activePath.includes(BackOfficeRoutes.checkIn);
+    const checkOutActive = activePath.includes(BackOfficeRoutes.checkOut);
+
     return (
       <Overridable id="Sidebar.layout">
         <>
@@ -65,9 +67,16 @@ class Sidebar extends Component {
                       Check-in
                       <div className="menu-item-description">Return copies</div>
                     </Menu.Item>
+                    <Menu.Item
+                      as={Link}
+                      active={checkOutActive}
+                      to={BackOfficeRoutes.checkOut}
+                    >
+                      Check-out
+                      <div className="menu-item-description">Create loan</div>
+                    </Menu.Item>
                   </Menu.Menu>
                 </Menu.Item>
-
                 <Menu.Item>
                   <Menu.Header>Library</Menu.Header>
                   <Menu.Menu>

--- a/src/lib/config/__mocks__/index.js
+++ b/src/lib/config/__mocks__/index.js
@@ -37,6 +37,14 @@ const mockExtensionsConfig = {
       },
     },
   },
+  PATRONS: {
+    customFields: {
+      mockField: {
+        field: 'test-pid',
+        label: 'Test Label',
+      },
+    },
+  },
 };
 
 const mockConfig = _merge({}, defaultConfig, mockExtensionsConfig);

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -649,10 +649,7 @@ export const defaultConfig = {
     },
   },
   PATRONS: {
-    patronUniqueID: {
-      field: 'pid',
-      label: 'Scan ID',
-    },
+    customFields: {},
     search: {
       filters: [],
       sortBy: {

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -649,6 +649,10 @@ export const defaultConfig = {
     },
   },
   PATRONS: {
+    patronUniqueID: {
+      field: 'pid',
+      label: 'Scan ID',
+    },
     search: {
       filters: [],
       sortBy: {

--- a/src/lib/modules/ESSelector/ESSelector.js
+++ b/src/lib/modules/ESSelector/ESSelector.js
@@ -134,6 +134,7 @@ class ESSelector extends Component {
       minCharacters,
       serializer,
       onSearchChange,
+      onResults,
     } = this.props;
     const { selections } = this.state;
     return (
@@ -148,6 +149,7 @@ class ESSelector extends Component {
           minCharacters={minCharacters}
           placeholder={placeholder}
           serializer={serializer}
+          onResults={onResults}
           onSelect={this.onSelectResult}
           onSearchChange={onSearchChange}
           ref={element => (this.searchRef = element)}
@@ -173,6 +175,7 @@ ESSelector.propTypes = {
   placeholder: PropTypes.string,
   query: PropTypes.func.isRequired,
   onSearchChange: PropTypes.func,
+  onResults: PropTypes.func,
   onSelectResult: PropTypes.func,
   onSelectionsUpdate: PropTypes.func,
   onRemoveSelection: PropTypes.func,
@@ -181,8 +184,8 @@ ESSelector.propTypes = {
   serializer: PropTypes.func,
   id: PropTypes.string,
   name: PropTypes.string,
-  selectionInfoText: PropTypes.func,
-  emptySelectionInfoText: PropTypes.func,
+  selectionInfoText: PropTypes.string,
+  emptySelectionInfoText: PropTypes.string,
 };
 
 ESSelector.defaultProps = {
@@ -192,6 +195,7 @@ ESSelector.defaultProps = {
   onSelectionsUpdate: () => {},
   emptySelectionInfoText: null,
   selectionInfoText: null,
+  onResults: null,
 };
 
 export default Overridable.component('ESSelector', ESSelector);

--- a/src/lib/modules/ESSelector/ESSelectorModal.js
+++ b/src/lib/modules/ESSelector/ESSelectorModal.js
@@ -4,14 +4,21 @@ import { Button, Modal } from 'semantic-ui-react';
 import ESSelector from './ESSelector';
 
 export default class ESSelectorModal extends Component {
-  state = {
-    selections: [],
-    visible: false,
-  };
+  constructor(props) {
+    super(props);
+    const { modalOpened } = this.props;
+    this.state = {
+      selections: [],
+      visible: modalOpened,
+    };
+  }
 
   onSelectionsUpdate = selections => this.setState({ selections });
 
-  toggle = () => this.setState({ visible: !this.state.visible });
+  toggle = () => {
+    const { visible } = this.state;
+    this.setState({ visible: !visible });
+  };
 
   save = () => {
     const { onSave } = this.props;
@@ -79,6 +86,7 @@ ESSelectorModal.propTypes = {
   initialSelections: PropTypes.array,
   onSelectResult: PropTypes.func,
   onSave: PropTypes.func,
+  modalOpened: PropTypes.bool,
   selectorComponent: PropTypes.elementType,
   saveButtonContent: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 };
@@ -88,6 +96,7 @@ ESSelectorModal.defaultProps = {
   saveButtonContent: 'Save',
   title: '',
   selectorComponent: ESSelector,
+  modalOpened: false,
   content: null,
   initialSelections: [],
   onSelectResult: null,

--- a/src/lib/modules/ESSelector/HitsSearch.js
+++ b/src/lib/modules/ESSelector/HitsSearch.js
@@ -38,6 +38,12 @@ export class HitsSearch extends Component {
     }
   }
 
+  componentDidMount() {
+    if (this.searchInputRef) {
+      this.searchInputRef.focus();
+    }
+  }
+
   clear = () => this.setState(initialState);
 
   onSelectResult = (event, { result }) => {
@@ -119,12 +125,6 @@ export class HitsSearch extends Component {
     this.setState({ isLoading: true, value: value, query: value, open: true });
     this.search(value);
   };
-
-  componentDidMount() {
-    if (this.searchInputRef) {
-      this.searchInputRef.focus();
-    }
-  }
 
   renderResults = ({ id, title, description, extra, ...props }) => {
     const { resultRenderer } = this.props;

--- a/src/lib/modules/Loan/backoffice/LoanList/LoanList.js
+++ b/src/lib/modules/Loan/backoffice/LoanList/LoanList.js
@@ -30,11 +30,12 @@ export default class LoanList extends Component {
 
 LoanList.propTypes = {
   hits: PropTypes.arrayOf(PropTypes.object),
-  renderListEntryElement: PropTypes.func.isRequired,
+  renderListEntryElement: PropTypes.func,
   target: PropTypes.string,
 };
 
 LoanList.defaultProps = {
   hits: [],
+  renderListEntryElement: null,
   target: '',
 };

--- a/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/ItemsSearch.js
+++ b/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/ItemsSearch.js
@@ -18,6 +18,7 @@ export default class ItemsSearch extends Component {
       clearSearchBar,
     } = this.props;
     queryString = queryString || propsQueryString;
+    if (queryString.trim() === '') return;
     await checkin(queryString);
     clearSearchBar();
   };

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOut.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOut.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import { CheckOutSearch } from './CheckOutSearch';
+import { CheckOutResults } from './CheckOutResults';
+import { Header } from 'semantic-ui-react';
+
+export class CheckOut extends Component {
+  render() {
+    return (
+      <>
+        <Header as="h2">Check-out physical copies</Header>
+        <CheckOutSearch />
+        <CheckOutResults />
+      </>
+    );
+  }
+}

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/CheckOutResults.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/CheckOutResults.js
@@ -1,0 +1,52 @@
+import { Loader } from '@components/Loader';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Header, Segment } from 'semantic-ui-react';
+import { ItemList } from './ItemList';
+import { PatronList } from './PatronList';
+
+export default class CheckOutResults extends Component {
+  componentDidMount() {
+    const { clearResults } = this.props;
+    clearResults();
+  }
+
+  /**
+   * NOTE: In case there is only one result in itemList or patronList we will be
+   * redirected to the relevant details page. If we have more than one result
+   * (exceptional case) we display them so librarian can choose.
+   */
+  render() {
+    const { itemList, isLoading, patronList } = this.props;
+    const hasMoreThanOneItem = itemList.length > 1;
+    const hasPatrons = patronList.length > 1;
+    const hasResults = hasMoreThanOneItem || hasPatrons;
+
+    return (
+      <Loader isLoading={isLoading}>
+        {hasPatrons && <PatronList patrons={patronList} />}
+        {hasMoreThanOneItem && <ItemList items={itemList} />}
+        {!hasResults && (
+          <Segment placeholder>
+            <Header textAlign="center">
+              Insert patron id/email or physical copy barcode
+            </Header>
+          </Segment>
+        )}
+      </Loader>
+    );
+  }
+}
+
+CheckOutResults.propTypes = {
+  clearResults: PropTypes.func.isRequired,
+  patronList: PropTypes.arrayOf(PropTypes.object),
+  itemList: PropTypes.arrayOf(PropTypes.object),
+  isLoading: PropTypes.bool,
+};
+
+CheckOutResults.defaultProps = {
+  patronList: [],
+  itemList: [],
+  isLoading: false,
+};

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/CheckOutResults.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/CheckOutResults.js
@@ -1,7 +1,7 @@
 import { Loader } from '@components/Loader';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Header, Segment } from 'semantic-ui-react';
+import { Icon, Header, Segment } from 'semantic-ui-react';
 import { ItemList } from './ItemList';
 import { PatronList } from './PatronList';
 
@@ -17,19 +17,19 @@ export default class CheckOutResults extends Component {
    * (exceptional case) we display them so librarian can choose.
    */
   render() {
-    const { itemList, isLoading, patronList } = this.props;
+    const { itemList, isLoading, patronList, resultMessage } = this.props;
     const hasMoreThanOneItem = itemList.length > 1;
-    const hasPatrons = patronList.length > 1;
-    const hasResults = hasMoreThanOneItem || hasPatrons;
+    const hasMoreThanOnePatrons = patronList.length > 1;
 
     return (
       <Loader isLoading={isLoading}>
-        {hasPatrons && <PatronList patrons={patronList} />}
+        {hasMoreThanOnePatrons && <PatronList patrons={patronList} />}
         {hasMoreThanOneItem && <ItemList items={itemList} />}
-        {!hasResults && (
-          <Segment placeholder>
-            <Header textAlign="center">
-              Insert patron id/email or physical copy barcode
+        {!hasMoreThanOneItem && !hasMoreThanOnePatrons && (
+          <Segment placeholder textAlign="center">
+            <Header icon>
+              <Icon name="search" />
+              {resultMessage}
             </Header>
           </Segment>
         )}
@@ -41,6 +41,7 @@ export default class CheckOutResults extends Component {
 CheckOutResults.propTypes = {
   clearResults: PropTypes.func.isRequired,
   patronList: PropTypes.arrayOf(PropTypes.object),
+  resultMessage: PropTypes.string.isRequired,
   itemList: PropTypes.arrayOf(PropTypes.object),
   isLoading: PropTypes.bool,
 };

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/ItemList.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/ItemList.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Item, Header, Segment } from 'semantic-ui-react';
+import { ItemListEntry } from '@modules/Items/backoffice/ItemListEntry';
+
+export const ItemList = ({ items }) => (
+  <>
+    <Header>Physical copies</Header>
+    <Segment>
+      <Item.Group divided className="bo-item-search">
+        {items.map(item => (
+          <ItemListEntry
+            item={item}
+            key={item.id}
+            withPendingLoans={item.has_pending_loans}
+            target="_blank"
+          />
+        ))}
+      </Item.Group>
+    </Segment>
+  </>
+);
+
+ItemList.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object),
+};
+
+ItemList.defaultProps = {
+  items: [],
+};

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/PatronList.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/PatronList.js
@@ -1,6 +1,7 @@
 import { ResultsTable } from '@components/ResultsTable/ResultsTable';
 import { invenioConfig } from '@config';
 import { BackOfficeRoutes } from '@routes/urls';
+import _forOwn from 'lodash/forOwn';
 import _get from 'lodash/get';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -26,15 +27,18 @@ viewDetails.propTypes = {
 
 export const PatronList = ({ patrons }) => {
   const columns = [
-    {
-      title: invenioConfig.PATRONS.patronUniqueID.label,
-      field: `metadata.${invenioConfig.PATRONS.patronUniqueID.field}`,
-      formatter: viewDetails,
-    },
     { title: 'Name', field: 'metadata.name', formatter: viewDetails },
     { title: 'E-mail', field: 'metadata.email' },
     { title: '#ID', field: 'metadata.id' },
   ];
+
+  _forOwn(invenioConfig.PATRONS.customFields, (value, key) =>
+    columns.push({
+      title: value.label,
+      field: `metadata.${value.field}`,
+      formatter: viewDetails,
+    })
+  );
 
   return (
     <>

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/PatronList.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/PatronList.js
@@ -1,0 +1,57 @@
+import { ResultsTable } from '@components/ResultsTable/ResultsTable';
+import { invenioConfig } from '@config';
+import { BackOfficeRoutes } from '@routes/urls';
+import _get from 'lodash/get';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Header, Item, Segment } from 'semantic-ui-react';
+
+const viewDetails = ({ row, col }) => {
+  return (
+    <Link
+      as={Link}
+      to={BackOfficeRoutes.patronDetailsFor(row.metadata.id)}
+      icon="info"
+    >
+      {_get(row, col.field)}
+    </Link>
+  );
+};
+
+viewDetails.propTypes = {
+  row: PropTypes.object.isRequired,
+  col: PropTypes.object.isRequired,
+};
+
+export const PatronList = ({ patrons }) => {
+  const columns = [
+    {
+      title: invenioConfig.PATRONS.patronUniqueID.label,
+      field: `metadata.${invenioConfig.PATRONS.patronUniqueID.field}`,
+      formatter: viewDetails,
+    },
+    { title: 'Name', field: 'metadata.name', formatter: viewDetails },
+    { title: 'E-mail', field: 'metadata.email' },
+    { title: '#ID', field: 'metadata.id' },
+  ];
+
+  return (
+    <>
+      <Header>Patrons</Header>
+      <Segment>
+        <Item.Group divided className="bo-item-search">
+          <ResultsTable data={patrons} columns={columns} />
+        </Item.Group>
+      </Segment>
+    </>
+  );
+};
+
+PatronList.propTypes = {
+  patrons: PropTypes.arrayOf(PropTypes.object),
+};
+
+PatronList.defaultProps = {
+  patrons: [],
+};

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/index.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/index.js
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux';
+import CheckOutResultsComponent from './CheckOutResults';
+import { clearResults } from '../state/actions';
+
+const mapDispatchToProps = dispatch => ({
+  clearResults: () => dispatch(clearResults()),
+});
+
+const mapStateToProps = state => ({
+  itemList: state.checkOut.itemList,
+  patronList: state.checkOut.patronList,
+  isLoading: state.checkOut.isLoading,
+});
+
+export const CheckOutResults = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CheckOutResultsComponent);

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/index.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutResults/index.js
@@ -10,6 +10,7 @@ const mapStateToProps = state => ({
   itemList: state.checkOut.itemList,
   patronList: state.checkOut.patronList,
   isLoading: state.checkOut.isLoading,
+  resultMessage: state.checkOut.resultMessage,
 });
 
 export const CheckOutResults = connect(

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutSearch/CheckOutSearch.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutSearch/CheckOutSearch.js
@@ -1,0 +1,49 @@
+import { SearchBar } from '@components/SearchBar';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+export default class CheckOutSearch extends Component {
+  onInputChange = queryString => {
+    const { updateQueryString } = this.props;
+    updateQueryString(queryString);
+  };
+
+  executeSearchAndClearInput = async query => {
+    const { checkOutSearch, queryString, clearSearch } = this.props;
+    query = query || queryString;
+    if (query.trim() === '') return;
+    await checkOutSearch(query);
+    clearSearch();
+  };
+
+  onPasteHandler = async event => {
+    const queryString = (event.clipboardData || window.clipboardData).getData(
+      'text'
+    );
+    this.executeSearchAndClearInput(queryString);
+  };
+
+  render() {
+    const { queryString } = this.props;
+    return (
+      <SearchBar
+        action={{
+          icon: 'search',
+          onClick: this.executeSearchAndClearInput,
+        }}
+        currentQueryString={queryString}
+        onInputChange={this.onInputChange}
+        executeSearch={this.executeSearchAndClearInput}
+        placeholder="Insert patron id/email or physical copy barcode to start check-out..."
+        onPaste={this.onPasteHandler}
+      />
+    );
+  }
+}
+
+CheckOutSearch.propTypes = {
+  updateQueryString: PropTypes.func.isRequired,
+  queryString: PropTypes.string.isRequired,
+  checkOutSearch: PropTypes.func.isRequired,
+  clearSearch: PropTypes.func.isRequired,
+};

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutSearch/CheckOutSearch.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutSearch/CheckOutSearch.js
@@ -9,11 +9,10 @@ export default class CheckOutSearch extends Component {
   };
 
   executeSearchAndClearInput = async query => {
-    const { checkOutSearch, queryString, clearSearch } = this.props;
+    const { checkOutSearch, queryString } = this.props;
     query = query || queryString;
     if (query.trim() === '') return;
     await checkOutSearch(query);
-    clearSearch();
   };
 
   onPasteHandler = async event => {
@@ -45,5 +44,4 @@ CheckOutSearch.propTypes = {
   updateQueryString: PropTypes.func.isRequired,
   queryString: PropTypes.string.isRequired,
   checkOutSearch: PropTypes.func.isRequired,
-  clearSearch: PropTypes.func.isRequired,
 };

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutSearch/index.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutSearch/index.js
@@ -1,0 +1,26 @@
+import { connect } from 'react-redux';
+import CheckOutSearchComponent from './CheckOutSearch';
+import {
+  checkOutSearch,
+  clearSearch,
+  updateQueryString,
+} from '../state/actions';
+
+const mapDispatchToProps = dispatch => ({
+  checkOutSearch: term => dispatch(checkOutSearch(term)),
+  updateQueryString: qs => dispatch(updateQueryString(qs)),
+  clearSearch: () => dispatch(clearSearch()),
+});
+
+const mapStateToProps = state => ({
+  queryString: state.checkOut.queryString,
+  item: state.checkOut.item,
+  patron: state.checkOut.patron,
+  isLoading: state.checkOut.isLoading,
+  error: state.checkOut.error,
+});
+
+export const CheckOutSearch = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(CheckOutSearchComponent);

--- a/src/lib/pages/backoffice/Actions/CheckOut/CheckOutSearch/index.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/CheckOutSearch/index.js
@@ -1,15 +1,10 @@
 import { connect } from 'react-redux';
 import CheckOutSearchComponent from './CheckOutSearch';
-import {
-  checkOutSearch,
-  clearSearch,
-  updateQueryString,
-} from '../state/actions';
+import { checkOutSearch, updateQueryString } from '../state/actions';
 
 const mapDispatchToProps = dispatch => ({
   checkOutSearch: term => dispatch(checkOutSearch(term)),
   updateQueryString: qs => dispatch(updateQueryString(qs)),
-  clearSearch: () => dispatch(clearSearch()),
 });
 
 const mapStateToProps = state => ({

--- a/src/lib/pages/backoffice/Actions/CheckOut/reducer.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/reducer.js
@@ -1,0 +1,1 @@
+export { default as checkOutReducer } from './state/reducer';

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/actions.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/actions.js
@@ -1,0 +1,119 @@
+import { itemApi } from '@api/items';
+import { patronApi } from '@api/patrons';
+import {
+  addNotification,
+  sendErrorNotification,
+} from '@components/Notifications';
+import { invenioConfig } from '@config';
+import { goTo } from '@history';
+import { BackOfficeRoutes } from '@routes/urls';
+
+export const CLEAR_SEARCH = 'checkOutSearch/CLEAR_SEARCH';
+export const CLEAR_RESULTS = 'checkOutSearch/CLEAR_RESULTS';
+export const QUERY_STRING_UPDATE = 'checkOutSearch/QUERY_STRING_UPDATE';
+export const SEARCH_IS_LOADING = 'checkOutSearch/SEARCH_IS_LOADING';
+export const SEARCH_HAS_ERROR = 'checkOutSearch/SEARCH_HAS_ERROR';
+export const SEARCH_PATRON_SUCCESS = 'checkOutSearch/SEARCH_PATRON_SUCCESS  ';
+export const SEARCH_ITEM_SUCCESS = 'checkOutSearch/SEARCH_ITEM_SUCCESS  ';
+
+export const updateQueryString = queryString => {
+  return dispatch => {
+    dispatch({
+      type: QUERY_STRING_UPDATE,
+      payload: queryString,
+    });
+  };
+};
+
+export const clearSearch = () => {
+  return dispatch => {
+    dispatch({
+      type: CLEAR_SEARCH,
+    });
+  };
+};
+
+export const clearResults = () => {
+  return dispatch => {
+    dispatch({
+      type: CLEAR_RESULTS,
+    });
+  };
+};
+
+const searchPatrons = async (dispatch, term) => {
+  const response = await patronApi.list(
+    patronApi
+      .query()
+      .withEmail(term, true)
+      .withName(term, true)
+      .withPatronUniqueID(term)
+      .qs(),
+    false
+  );
+  dispatch({
+    type: SEARCH_PATRON_SUCCESS,
+    payload: response.data.hits,
+  });
+
+  return response.data.hits;
+};
+
+const searchItems = async (dispatch, term) => {
+  const response = await itemApi.list(
+    itemApi
+      .query()
+      .withBarcode(term)
+      .qs()
+  );
+
+  dispatch({
+    type: SEARCH_ITEM_SUCCESS,
+    payload: response.data.hits,
+  });
+
+  return response.data.hits;
+};
+
+const handleError = (dispatch, term, error) => {
+  if (!error.response) {
+    dispatch(
+      addNotification(
+        'Error',
+        `${term} did not match any patron ${invenioConfig.PATRONS.patronUniqueID.label}, or any physical copy barcode.`,
+        'error'
+      )
+    );
+  }
+  dispatch({
+    type: SEARCH_HAS_ERROR,
+    payload: error,
+  });
+  dispatch(sendErrorNotification('Error'));
+};
+
+export const checkOutSearch = term => {
+  return async dispatch => {
+    dispatch({
+      type: SEARCH_IS_LOADING,
+    });
+    let patrons = [];
+    let items = [];
+
+    try {
+      patrons = await searchPatrons(dispatch, term);
+      if (patrons.length === 1) {
+        return goTo(BackOfficeRoutes.patronDetailsFor(patrons[0].metadata.pid));
+      }
+
+      items = await searchItems(dispatch, term);
+      if (items.length === 1) {
+        return goTo(BackOfficeRoutes.itemDetailsFor(items[0].metadata.pid));
+      }
+
+      if (patrons.length === 0 && items.length === 0) throw Error('No match');
+    } catch (error) {
+      handleError(dispatch, term, error);
+    }
+  };
+};

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/actions.test.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/actions.test.js
@@ -21,11 +21,12 @@ describe('Check Out tests', () => {
     await store.dispatch(actions.updateQueryString('New query'));
     expect(store.getActions()[0]).toEqual(expectedAction);
   });
-  it('should dispatch an action to clear search', async () => {
+  it('should dispatch an action updating the result message', async () => {
     const expectedAction = {
-      type: actions.CLEAR_SEARCH,
+      type: actions.UPDATE_RESULT_MESSAGE,
+      payload: 'No results found',
     };
-    await store.dispatch(actions.clearSearch());
+    await store.dispatch(actions.updateResultMessage('No results found'));
     expect(store.getActions()[0]).toEqual(expectedAction);
   });
   it('should dispatch an action to clear results', async () => {

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/actions.test.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/actions.test.js
@@ -1,0 +1,38 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './actions';
+import { initialState } from './reducer';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+let store;
+beforeEach(() => {
+  store = mockStore(initialState);
+  store.clearActions();
+});
+
+describe('Check Out tests', () => {
+  it('should dispatch an action updating the query', async () => {
+    const expectedAction = {
+      type: actions.QUERY_STRING_UPDATE,
+      payload: 'New query',
+    };
+    await store.dispatch(actions.updateQueryString('New query'));
+    expect(store.getActions()[0]).toEqual(expectedAction);
+  });
+  it('should dispatch an action to clear search', async () => {
+    const expectedAction = {
+      type: actions.CLEAR_SEARCH,
+    };
+    await store.dispatch(actions.clearSearch());
+    expect(store.getActions()[0]).toEqual(expectedAction);
+  });
+  it('should dispatch an action to clear results', async () => {
+    const expectedAction = {
+      type: actions.CLEAR_RESULTS,
+    };
+    await store.dispatch(actions.clearResults());
+    expect(store.getActions()[0]).toEqual(expectedAction);
+  });
+});

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/reducer.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/reducer.js
@@ -1,42 +1,29 @@
 import {
-  CLEAR_SEARCH,
   CLEAR_RESULTS,
   QUERY_STRING_UPDATE,
-  SEARCH_PATRON_SUCCESS,
-  SEARCH_ITEM_SUCCESS,
   SEARCH_HAS_ERROR,
   SEARCH_IS_LOADING,
+  SEARCH_ITEM_SUCCESS,
+  SEARCH_PATRON_SUCCESS,
+  UPDATE_RESULT_MESSAGE,
 } from './actions';
 
 export const initialState = {
-  isLoading: false,
-  hasError: false,
-  queryString: '',
-  patronList: [],
-  itemList: [],
   error: {},
+  hasError: false,
+  isLoading: false,
+  itemList: [],
+  patronList: [],
+  queryString: '',
+  resultMessage: 'Insert patron id/email or physical copy barcode',
 };
 
 export default (state = initialState, action) => {
   switch (action.type) {
-    case SEARCH_IS_LOADING:
-      return { ...state, isLoading: true, patronList: [], itemList: [] };
+    case CLEAR_RESULTS:
+      return { ...state, queryString: '', itemList: [], patronList: [] };
     case QUERY_STRING_UPDATE:
       return { ...state, queryString: action.payload };
-    case SEARCH_PATRON_SUCCESS:
-      return {
-        ...state,
-        isLoading: false,
-        patronList: action.payload,
-        error: {},
-      };
-    case SEARCH_ITEM_SUCCESS:
-      return {
-        ...state,
-        isLoading: false,
-        itemList: action.payload,
-        error: {},
-      };
     case SEARCH_HAS_ERROR:
       return {
         ...state,
@@ -44,10 +31,24 @@ export default (state = initialState, action) => {
         error: action.payload,
         hasError: true,
       };
-    case CLEAR_SEARCH:
-      return { ...state, queryString: '' };
-    case CLEAR_RESULTS:
-      return { ...state, itemList: [], patronList: [] };
+    case SEARCH_IS_LOADING:
+      return { ...state, isLoading: true, patronList: [], itemList: [] };
+    case SEARCH_ITEM_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        itemList: action.payload,
+        error: {},
+      };
+    case SEARCH_PATRON_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        patronList: action.payload,
+        error: {},
+      };
+    case UPDATE_RESULT_MESSAGE:
+      return { ...state, resultMessage: action.payload };
     default:
       return state;
   }

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/reducer.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/reducer.js
@@ -1,0 +1,54 @@
+import {
+  CLEAR_SEARCH,
+  CLEAR_RESULTS,
+  QUERY_STRING_UPDATE,
+  SEARCH_PATRON_SUCCESS,
+  SEARCH_ITEM_SUCCESS,
+  SEARCH_HAS_ERROR,
+  SEARCH_IS_LOADING,
+} from './actions';
+
+export const initialState = {
+  isLoading: false,
+  hasError: false,
+  queryString: '',
+  patronList: [],
+  itemList: [],
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case SEARCH_IS_LOADING:
+      return { ...state, isLoading: true, patronList: [], itemList: [] };
+    case QUERY_STRING_UPDATE:
+      return { ...state, queryString: action.payload };
+    case SEARCH_PATRON_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        patronList: action.payload,
+        error: {},
+      };
+    case SEARCH_ITEM_SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        itemList: action.payload,
+        error: {},
+      };
+    case SEARCH_HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    case CLEAR_SEARCH:
+      return { ...state, queryString: '' };
+    case CLEAR_RESULTS:
+      return { ...state, itemList: [], patronList: [] };
+    default:
+      return state;
+  }
+};

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/reducer.test.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/reducer.test.js
@@ -1,0 +1,107 @@
+import reducer, { initialState } from './reducer';
+import {
+  CLEAR_SEARCH,
+  CLEAR_RESULTS,
+  QUERY_STRING_UPDATE,
+  SEARCH_IS_LOADING,
+  SEARCH_HAS_ERROR,
+  SEARCH_PATRON_SUCCESS,
+  SEARCH_ITEM_SUCCESS,
+} from './actions';
+import _clone from 'lodash/clone';
+
+let inputState;
+
+beforeEach(async () => {
+  inputState = _clone(initialState);
+});
+
+describe('Check Out reducer', () => {
+  it('should have initial state', () => {
+    expect(reducer(undefined, {})).toEqual(initialState);
+  });
+
+  it('should clear search query on CLEAR_SEARCH action', () => {
+    inputState.queryString = 'A sample query';
+    const action = {
+      type: CLEAR_SEARCH,
+    };
+    expect(reducer(inputState, action)).toEqual({
+      ...inputState,
+      queryString: '',
+    });
+  });
+
+  it('should clear search results on CLEAR_RESULTS action', () => {
+    inputState.itemList = [{ pid: 'item-pid' }];
+    inputState.patronList = [{ pid: 'patron-pid' }];
+    const action = {
+      type: CLEAR_RESULTS,
+    };
+    expect(reducer(inputState, action)).toEqual({
+      ...inputState,
+      itemList: [],
+      patronList: [],
+    });
+  });
+
+  it('should updat search query on QUERY_STRING_UPDATE action', () => {
+    const action = {
+      type: QUERY_STRING_UPDATE,
+      payload: 'updated query',
+    };
+    expect(reducer(inputState, action)).toEqual({
+      ...inputState,
+      queryString: 'updated query',
+    });
+  });
+
+  it('should start loader on SEARCH_IS_LOADING action', () => {
+    const action = {
+      type: SEARCH_IS_LOADING,
+    };
+    expect(reducer(inputState, action)).toEqual({
+      ...inputState,
+      isLoading: true,
+    });
+  });
+
+  it('should return the error on SEARCH_HAS_ERROR action', () => {
+    const action = {
+      type: SEARCH_HAS_ERROR,
+      payload: 'Error',
+    };
+    expect(reducer(inputState, action)).toEqual({
+      ...inputState,
+      isLoading: false,
+      error: action.payload,
+      hasError: true,
+    });
+  });
+
+  it('should stop the loader and return the patron on SEARCH_PATRON_SUCCESS action', () => {
+    const action = {
+      type: SEARCH_PATRON_SUCCESS,
+      payload: [{ pid: 'patron-pid' }],
+    };
+    expect(reducer(inputState, action)).toEqual({
+      ...inputState,
+      isLoading: false,
+      patronList: [{ pid: 'patron-pid' }],
+      error: {},
+    });
+  });
+
+  it('should stop the loader and return the item on SEARCH_ITEM_SUCCESS action', () => {
+    const action = {
+      type: SEARCH_ITEM_SUCCESS,
+      payload: [{ pid: 'item-pid' }],
+    };
+    expect(reducer(inputState, action)).toEqual({
+      ...inputState,
+      isLoading: false,
+      itemList: [{ pid: 'item-pid' }],
+      error: {},
+    });
+  });
+});

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/reducer.test.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/reducer.test.js
@@ -1,12 +1,12 @@
 import reducer, { initialState } from './reducer';
 import {
-  CLEAR_SEARCH,
   CLEAR_RESULTS,
   QUERY_STRING_UPDATE,
   SEARCH_IS_LOADING,
   SEARCH_HAS_ERROR,
   SEARCH_PATRON_SUCCESS,
   SEARCH_ITEM_SUCCESS,
+  UPDATE_RESULT_MESSAGE,
 } from './actions';
 import _clone from 'lodash/clone';
 
@@ -19,17 +19,6 @@ beforeEach(async () => {
 describe('Check Out reducer', () => {
   it('should have initial state', () => {
     expect(reducer(undefined, {})).toEqual(initialState);
-  });
-
-  it('should clear search query on CLEAR_SEARCH action', () => {
-    inputState.queryString = 'A sample query';
-    const action = {
-      type: CLEAR_SEARCH,
-    };
-    expect(reducer(inputState, action)).toEqual({
-      ...inputState,
-      queryString: '',
-    });
   });
 
   it('should clear search results on CLEAR_RESULTS action', () => {
@@ -52,7 +41,18 @@ describe('Check Out reducer', () => {
     };
     expect(reducer(inputState, action)).toEqual({
       ...inputState,
-      queryString: 'updated query',
+      queryString: action.payload,
+    });
+  });
+
+  it('should updat search query on UPDATE_RESULT_MESSAGE action', () => {
+    const action = {
+      type: UPDATE_RESULT_MESSAGE,
+      payload: 'There are no results',
+    };
+    expect(reducer(inputState, action)).toEqual({
+      ...inputState,
+      resultMessage: action.payload,
     });
   });
 
@@ -100,7 +100,7 @@ describe('Check Out reducer', () => {
     expect(reducer(inputState, action)).toEqual({
       ...inputState,
       isLoading: false,
-      itemList: [{ pid: 'item-pid' }],
+      itemList: action.payload,
       error: {},
     });
   });

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemActionMenu/index.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemActionMenu/index.js
@@ -7,6 +7,7 @@ const mapStateToProps = state => ({
   isLoading: state.itemDetails.isLoading,
   error: state.itemDetails.error,
   item: state.itemDetails.data,
+  checkOutitemList: state.checkOut.itemList,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/lib/pages/backoffice/Patron/PatronDetails/ItemsSearch/ItemsSearch.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/ItemsSearch/ItemsSearch.js
@@ -33,16 +33,20 @@ export default class ItemsSearch extends Component {
   };
 
   onPasteHandler = async event => {
-    const { checkoutItem, patronDetails, items: hits } = this.props;
+    const { checkoutItem, patronDetails } = this.props;
     let queryString = event.clipboardData.getData('Text');
 
     if (queryString) {
       await this.executeSearch(queryString);
+      const {
+        items: { hits },
+      } = this.props;
 
       const hasOneHit =
         !_isEmpty(hits) &&
         hits.length === 1 &&
         hits[0].metadata.status === 'CAN_CIRCULATE';
+
       if (hasOneHit) {
         const documentPid = hits[0].metadata.document.pid;
         const itemPid = {

--- a/src/lib/routes/backoffice/BackOfficeRoutesSwitch.js
+++ b/src/lib/routes/backoffice/BackOfficeRoutesSwitch.js
@@ -5,6 +5,7 @@ import { BackOfficeRoutes, AcquisitionRoutes, ILLRoutes } from '@routes/urls';
 import { BorrowingRequestDetails } from '@pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails';
 import { BorrowingRequestEditor } from '@pages/backoffice/ILL/BorrowingRequest/BorrowingRequestEditor/BorrowingRequestEditor';
 import { BorrowingRequestSearch } from '@pages/backoffice/ILL/BorrowingRequest/BorrowingRequestSearch/BorrowingRequestSearch';
+import { CheckOut } from '@pages/backoffice/Actions/CheckOut/CheckOut';
 import { DocumentDetails } from '@pages/backoffice/Document/DocumentDetails';
 import { DocumentEditor } from '@pages/backoffice/Document/DocumentForms';
 import { DocumentSearch } from '@pages/backoffice/Document/DocumentSearch';
@@ -252,6 +253,7 @@ export default class BackOfficeRoutesSwitch extends Component {
         />
         <Route exact path={BackOfficeRoutes.stats.home} component={Stats} />
         <Route exact path={BackOfficeRoutes.checkIn} component={CheckIn} />
+        <Route exact path={BackOfficeRoutes.checkOut} component={CheckOut} />
         <Route>
           <NotFound />
         </Route>

--- a/src/lib/routes/backoffice/backofficeUrls.js
+++ b/src/lib/routes/backoffice/backofficeUrls.js
@@ -5,6 +5,7 @@ export const BackOfficeBase = '/backoffice';
 const BackOfficeRoutesList = {
   home: BackOfficeBase,
   checkIn: `${BackOfficeBase}/checkin`,
+  checkOut: `${BackOfficeBase}/checkout`,
   documentCreate: `${BackOfficeBase}/documents/create`,
   documentDetails: `${BackOfficeBase}/documents/:documentPid`,
   documentEdit: `${BackOfficeBase}/documents/:documentPid/edit`,

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -59,6 +59,7 @@ import {
   seriesRelationsReducer,
 } from '@pages/backoffice/Series/SeriesDetails/reducer';
 import { itemsCheckInReducer } from '@pages/backoffice/Actions/CheckIn/reducer';
+import { checkOutReducer } from '@pages/backoffice/Actions/CheckOut/reducer';
 import { mostLoanedDocumentsReducer } from '@pages/backoffice/Stats/reducer';
 import { loanRequestFormReducer } from '@pages/frontsite/Documents/DocumentDetails/LoanRequestForm/reducer';
 import { documentDetailsFrontReducer } from '@pages/frontsite/Documents/DocumentDetails/reducer';
@@ -130,6 +131,7 @@ const rootReducer = combineReducers({
   statsMostLoanedDocuments: mostLoanedDocumentsReducer,
   borrowingRequestLoanExtension: borrowingRequestLoanExtensionReducer,
   itemsCheckIn: itemsCheckInReducer,
+  checkOut: checkOutReducer,
 });
 
 const composeEnhancers = composeWithDevTools({


### PR DESCRIPTION
- search bar with search in two indices
- fix patron api list bug with suffixed *
- configurable scan field for Patron search
- results for items and patrons
- checkout search reducer with patron and item
- fix: in PatronDetails if we search for item and is eligible for loan, then we the auto check-out
- demo placeholders
- patron result table with support for configured scan field
- search modal open when auto check-out item scanned
- fix ESSElectorModal propTypes errors
- ESSelector onResults hook
- prevent empty searches
- search on all available props of patron
- closes #36