### PR TITLE
global: minor fixes

### DIFF
--- a/src/lib/config/common.js
+++ b/src/lib/config/common.js
@@ -27,3 +27,12 @@ export const ITEM_MEDIUMS = [
   { value: 'PAPERBACK', text: 'Paperback' },
   { value: 'HARDCOVER', text: 'Hardcover' },
 ];
+
+export const DOCUMENT_RELATIONS = [
+  { value: 'edition', text: 'By edition' },
+  { value: 'multipart_monograph', text: 'By series (completed)' },
+  { value: 'serial', text: 'By series (periodic)' },
+  { value: 'language', text: 'By language' },
+  { value: 'previous', text: 'By predecessors' },
+  { value: 'next', text: 'By continuation' },
+];

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -3,6 +3,7 @@ import {
   DEFAULT_CURRENCY,
   ILL_BORROWING_REQUESTS_STATUSES,
   ITEM_MEDIUMS,
+  DOCUMENT_RELATIONS,
 } from './common';
 
 export const APP_CONFIG = {
@@ -172,18 +173,18 @@ export const defaultConfig = {
       fields: {},
     },
     frontsiteMaxLinks: 5, // maximum number of links to show on details page
-    types: [
-      { value: 'BOOK', text: 'Book' },
-      { value: 'PROCEEDING', text: 'Proceeding' },
-      { value: 'STANDARD', text: 'Standard' },
-      { value: 'PERIODICAL_ISSUE', text: 'Periodical issue' },
-    ],
     search: {
       filters: [
         {
           title: 'Document types',
           field: 'document_type',
           aggName: 'doctype',
+          labels: [
+            { value: 'BOOK', text: 'Book' },
+            { value: 'PROCEEDING', text: 'Proceeding' },
+            { value: 'STANDARD', text: 'Standard' },
+            { value: 'PERIODICAL_ISSUE', text: 'Periodical issue' },
+          ],
         },
         {
           title: 'Availability',
@@ -201,19 +202,15 @@ export const defaultConfig = {
           aggName: 'language',
         },
         {
-          title: 'Relations',
+          title: 'Related content',
           field: 'relations',
           aggName: 'relation',
+          labels: DOCUMENT_RELATIONS,
         },
         {
           title: 'Medium',
           field: 'stock.mediums',
           aggName: 'medium',
-        },
-        {
-          title: 'Restricted',
-          field: 'restricted',
-          aggName: 'access',
         },
       ],
       sortBy: {
@@ -626,6 +623,7 @@ export const defaultConfig = {
           title: 'Relations',
           field: 'relations',
           aggName: 'relation',
+          labels: DOCUMENT_RELATIONS,
         },
       ],
       sortBy: {

--- a/src/lib/modules/SearchControls/SearchAggregationsCards.js
+++ b/src/lib/modules/SearchControls/SearchAggregationsCards.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox, Label, List } from 'semantic-ui-react';
 import { getSearchConfig } from '@config';
+import _get from 'lodash/get';
 
 /**
  * Component wrapping BucketAggregation to provide custom display for
@@ -12,7 +13,7 @@ import { getSearchConfig } from '@config';
  * it will display the label mapped for current bucket key
  */
 export default class SearchAggregationsCards extends Component {
-  _renderValueElement = (
+  _renderValueElement = labels => (
     bucket,
     isSelected,
     onFilterClicked,
@@ -20,6 +21,11 @@ export default class SearchAggregationsCards extends Component {
   ) => {
     const childAggCmps = getChildAggCmps(bucket);
     const key = bucket.key_as_string ? bucket.key_as_string : bucket.key;
+    const text = _get(
+      labels.find(e => e.value === key),
+      'text',
+      key
+    );
     return (
       <List.Item key={bucket.key}>
         <List.Content floated="right">
@@ -27,7 +33,7 @@ export default class SearchAggregationsCards extends Component {
         </List.Content>
         <List.Content>
           <Checkbox
-            label={key}
+            label={text}
             value={key}
             onClick={() => onFilterClicked(key)}
             checked={isSelected}
@@ -50,7 +56,9 @@ export default class SearchAggregationsCards extends Component {
           key={filter.field}
           title={filter.title}
           agg={{ field: filter.field, aggName: filter.aggName }}
-          renderValueElement={this._renderValueElement}
+          renderValueElement={this._renderValueElement(
+            _get(filter, 'labels', [])
+          )}
         />
       );
     });

--- a/src/lib/pages/backoffice/Location/LocationForms/LocationEditor/LocationEditor.js
+++ b/src/lib/pages/backoffice/Location/LocationForms/LocationEditor/LocationEditor.js
@@ -18,7 +18,9 @@ export class LocationEditor extends Component {
 
   componentDidMount() {
     const {
-      match: { params: locationPid },
+      match: {
+        params: { locationPid },
+      },
     } = this.props;
     if (locationPid) {
       this.fetchLocation(locationPid);

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
@@ -16,6 +16,7 @@ import { Container, Grid, Icon, Responsive } from 'semantic-ui-react';
 import { DocumentItems } from './DocumentItems';
 import { DocumentMetadata } from './DocumentMetadata';
 import DocumentPanel from './DocumentPanel/DocumentPanel';
+import { NotFound } from '@components/NotFound';
 
 const DocumentDetailsLayout = ({ error, isLoading, documentDetails }) => {
   const breadcrumbs = () => [
@@ -156,8 +157,11 @@ class DocumentDetails extends Component {
   };
 
   render() {
-    const { isLoading, error, documentDetails } = this.props;
+    const { isLoading, hasError, error, documentDetails } = this.props;
     const { searchQuery } = this.state;
+    if (hasError && error.response.status === 404) {
+      return <NotFound />;
+    }
     return (
       <>
         <Overridable
@@ -194,6 +198,7 @@ DocumentDetails.propTypes = {
   fetchDocumentsDetails: PropTypes.func.isRequired,
   documentDetails: PropTypes.object.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  hasError: PropTypes.bool.isRequired,
   error: PropTypes.object,
   match: PropTypes.shape({
     params: PropTypes.shape({

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/index.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/index.js
@@ -11,6 +11,7 @@ const mapStateToProps = state => ({
   isLoading: state.documentDetailsFront.isLoading,
   documentDetails: state.documentDetailsFront.data,
   hasError: state.documentDetailsFront.hasError,
+  error: state.documentDetailsFront.error,
 });
 
 export const DocumentDetails = connect(

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
@@ -14,6 +14,7 @@ import { Link } from 'react-router-dom';
 import { Container, Grid, Icon, Responsive } from 'semantic-ui-react';
 import { SeriesMetadata } from './SeriesMetadata';
 import SeriesPanel from './SeriesPanel/SeriesPanel';
+import { NotFound } from '@components/NotFound';
 
 const SeriesDetailsLayout = ({ error, isLoading, series }) => {
   const breadcrumbs = () => [
@@ -133,8 +134,11 @@ class SeriesDetails extends React.Component {
   };
 
   render() {
-    const { error, isLoading, series } = this.props;
+    const { hasError, error, isLoading, series } = this.props;
     const { searchQuery } = this.state;
+    if (hasError && error.response.status === 404) {
+      return <NotFound />;
+    }
     return (
       <>
         <Container fluid className="literature-search-container">
@@ -171,6 +175,7 @@ SeriesDetails.propTypes = {
       seriesPid: PropTypes.string,
     }),
   }).isRequired,
+  hasError: PropTypes.bool.isRequired,
   error: PropTypes.object,
 };
 

--- a/src/lib/pages/frontsite/Series/SeriesDetails/index.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/index.js
@@ -10,6 +10,7 @@ const mapStateToProps = state => ({
   isLoading: state.seriesDetailsFront.isLoading,
   series: state.seriesDetailsFront.data,
   hasError: state.seriesDetailsFront.hasError,
+  error: state.seriesDetailsFront.error,
 });
 
 export const SeriesDetails = connect(


### PR DESCRIPTION
* displays 404 page when literature or series is not found on the frontsite (closes #42)
* removed "Restricted" facet from the frontsite search (closes #108)
* support for configurable search filters labels, renamed the "Relation" filter (closes #109)
* repaired link to location editor