### PR TITLE
search: sort by title

### DIFF
--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -50,7 +50,7 @@ export const defaultConfig = {
         },
         {
           title: 'Vendor',
-          field: 'vendor.name.keyword',
+          field: 'vendor.name',
           aggName: 'vendor',
         },
         {
@@ -128,7 +128,7 @@ export const defaultConfig = {
           },
           {
             default_order: 'asc',
-            field: 'name.keyword',
+            field: 'name',
             order: 2,
             title: 'Name',
           },
@@ -249,6 +249,12 @@ export const defaultConfig = {
             order: 5,
             title: 'Publication year',
           },
+          {
+            default_order: 'asc',
+            field: 'title',
+            order: 6,
+            title: 'Title',
+          },
         ],
       },
       sortOrder: ['asc', 'desc'],
@@ -322,6 +328,12 @@ export const defaultConfig = {
             title: 'Best match',
             default_order: 'asc',
           },
+          {
+            field: 'title',
+            order: 3,
+            title: 'Title',
+            default_order: 'asc',
+          },
         ],
       },
       sortOrder: ['asc', 'desc'],
@@ -346,7 +358,7 @@ export const defaultConfig = {
         },
         {
           title: 'Library',
-          field: 'library.name.keyword',
+          field: 'library.name',
           aggName: 'library',
         },
         {
@@ -418,7 +430,7 @@ export const defaultConfig = {
           },
           {
             default_order: 'asc',
-            field: 'name.keyword',
+            field: 'name',
             order: 2,
             title: 'Name',
           },
@@ -490,6 +502,12 @@ export const defaultConfig = {
             field: 'bestmatch',
             order: 2,
             title: 'Best match',
+          },
+          {
+            default_order: 'asc',
+            field: 'title',
+            order: 3,
+            title: 'Title',
           },
         ],
       },
@@ -641,6 +659,12 @@ export const defaultConfig = {
             field: 'bestmatch',
             order: 2,
             title: 'Best match',
+            default_order: 'asc',
+          },
+          {
+            field: 'title',
+            order: 3,
+            title: 'Title',
             default_order: 'asc',
           },
         ],


### PR DESCRIPTION
* added config fields to allow sorting the catalogue by titles (available in both frontsite and backoffice)
* depends on inveniosoftware/invenio-app-ils#923
* closes #111