### PR TITLE
global: minor tweaks + patron page statistics loading

### DIFF
--- a/src/lib/config/common.js
+++ b/src/lib/config/common.js
@@ -19,7 +19,6 @@ export const ILL_BORROWING_REQUESTS_STATUSES = [
 
 export const ITEM_MEDIUMS = [
   { value: 'NOT_SPECIFIED', text: 'Not specified' },
-  { value: 'ONLINE', text: 'Online' },
   { value: 'PAPER', text: 'Paper' },
   { value: 'CDROM', text: 'CD-ROM' },
   { value: 'DVD', text: 'DVD' },

--- a/src/lib/modules/Document/DocumentInfo.js
+++ b/src/lib/modules/Document/DocumentInfo.js
@@ -12,7 +12,7 @@ export class DocumentInfo extends Component {
       return (
         <Table.Row>
           <Table.Cell>Languages</Table.Cell>
-          <Table.Cell>{metadata.languages.map(lang => lang + ', ')}</Table.Cell>
+          <Table.Cell>{metadata.languages.join(', ')}</Table.Cell>
         </Table.Row>
       );
     }

--- a/src/lib/modules/ESSelector/ESSelectorModal.js
+++ b/src/lib/modules/ESSelector/ESSelectorModal.js
@@ -31,7 +31,7 @@ export default class ESSelectorModal extends Component {
       saveButtonContent,
       trigger,
     } = this.props;
-    const { visible } = this.state;
+    const { visible, selections } = this.state;
     const modalTrigger = React.cloneElement(trigger, {
       onClick: this.toggle,
     });
@@ -60,6 +60,7 @@ export default class ESSelectorModal extends Component {
           </Button>
           <Button
             positive
+            disabled={!selections || selections.length === 0}
             icon="checkmark"
             labelPosition="left"
             content={saveButtonContent}
@@ -76,6 +77,7 @@ ESSelectorModal.propTypes = {
   title: PropTypes.string,
   size: PropTypes.string,
   content: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  isSelectionRequired: PropTypes.bool,
   initialSelections: PropTypes.array,
   onSelectResult: PropTypes.func,
   onSave: PropTypes.func,
@@ -89,6 +91,7 @@ ESSelectorModal.defaultProps = {
   title: '',
   selectorComponent: ESSelector,
   content: null,
+  isSelectionRequired: true,
   initialSelections: [],
   onSelectResult: null,
   onSave: null,

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
@@ -86,7 +86,7 @@ export default class LoanActions extends Component {
         <InfoMessage
           fluid
           header="No actions available."
-          content={"The loan can't be changed in it's current state."}
+          content={"The loan can't be changed in its current state."}
         />
       );
     }

--- a/src/lib/pages/frontsite/PatronProfile/PatronOverview/PatronOverview.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronOverview/PatronOverview.js
@@ -1,39 +1,42 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Container, Statistic } from 'semantic-ui-react';
+import { Container, Loader, Statistic } from 'semantic-ui-react';
 
 export default class PatronOverview extends Component {
+  renderStatistic(stat, quantifiableLabel) {
+    const {
+      isLoading,
+      data: { total },
+    } = stat;
+    return (
+      <Statistic>
+        <Statistic.Value>
+          {isLoading ? <Loader active inline /> : total}
+        </Statistic.Value>
+        <Statistic.Label>
+          {isLoading ? <>&nbsp;</> : quantifiableLabel(total !== 1)}
+        </Statistic.Label>
+      </Statistic>
+    );
+  }
+
   render() {
     const { currentLoans, loanRequests, documentRequests } = this.props;
-    const loansCount = currentLoans.data.total || 0;
-    const loansTextPlural = loansCount !== 1;
-
-    const loanRequestsCount = loanRequests.data.total || 0;
-    const loanRequestsTextPlural = loanRequestsCount !== 1;
-
-    const docRequestsCount = documentRequests.data.total || 0;
-    const docRequestsTextPlural = docRequestsCount !== 1;
     return (
       <Container className="spaced">
         <Statistic.Group widths="three" size="small">
-          <Statistic>
-            <Statistic.Value>{loansCount}</Statistic.Value>
-            <Statistic.Label>
-              ongoing loan{loansTextPlural && 's'}
-            </Statistic.Label>
-          </Statistic>
-          <Statistic>
-            <Statistic.Value>{loanRequestsCount}</Statistic.Value>
-            <Statistic.Label>
-              loan request{loanRequestsTextPlural && 's'}
-            </Statistic.Label>
-          </Statistic>
-          <Statistic>
-            <Statistic.Value>{docRequestsCount}</Statistic.Value>
-            <Statistic.Label>
-              Request{docRequestsTextPlural && 's'} for new literature
-            </Statistic.Label>
-          </Statistic>
+          {this.renderStatistic(
+            currentLoans,
+            isPlural => `ongoing loan${isPlural ? 's' : ''}`
+          )}
+          {this.renderStatistic(
+            loanRequests,
+            isPlural => `loan request${isPlural ? 's' : ''}`
+          )}
+          {this.renderStatistic(
+            documentRequests,
+            isPlural => `Request${isPlural ? 's' : ''} for new literature`
+          )}
         </Statistic.Group>
       </Container>
     );


### PR DESCRIPTION
* fixed a typo
* added a prop to selector modal to disallow empty selections (closes #105)
* fixed config client/server mismatch (closes #129)
* fixed trailing comma in enumeration (closes #94)
* patron page: added loading state to statistics

(loading state)
![image](https://user-images.githubusercontent.com/9027075/88777257-4bc1be80-d187-11ea-9b22-609accbc84bc.png)

(final state; note that the alignment stays the same)
![image](https://user-images.githubusercontent.com/9027075/88777373-6eec6e00-d187-11ea-8fcc-6e05abb3a140.png)
