### PR TITLE
backoffice: Fixes tags redirection

### DIFF
--- a/src/lib/modules/Document/DocumentTags.js
+++ b/src/lib/modules/Document/DocumentTags.js
@@ -1,4 +1,4 @@
-import { FrontSiteRoutes } from '@routes/urls';
+import { BackOfficeRoutes, FrontSiteRoutes } from '@routes/urls';
 import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -8,7 +8,7 @@ import { Label } from 'semantic-ui-react';
 
 class DocumentTags extends Component {
   render() {
-    const { metadata, ...uiProps } = this.props;
+    const { metadata, isBackOffice, ...uiProps } = this.props;
 
     if (_isEmpty(metadata.tags)) return null;
 
@@ -18,9 +18,15 @@ class DocumentTags extends Component {
           {metadata.tags.map(tag => (
             <Label className="highlighted" key={tag} {...uiProps}>
               <Link
-                to={FrontSiteRoutes.documentsListWithQuery(
-                  `&sort=mostrecent&order=desc&f=tag%3A${tag}`
-                )}
+                to={
+                  isBackOffice
+                    ? BackOfficeRoutes.documentsListWithQuery(
+                        `&sort=mostrecent&order=desc&f=tag%3A${tag}`
+                      )
+                    : FrontSiteRoutes.documentsListWithQuery(
+                        `&sort=mostrecent&order=desc&f=tag%3A${tag}`
+                      )
+                }
               >
                 {tag}
               </Link>
@@ -34,6 +40,7 @@ class DocumentTags extends Component {
 
 DocumentTags.propTypes = {
   metadata: PropTypes.object.isRequired,
+  isBackOffice: PropTypes.bool.isRequired,
 };
 
 export default Overridable.component('DocumentTags', DocumentTags);

--- a/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
+++ b/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
@@ -136,7 +136,7 @@ export default class DocumentListEntry extends Component {
             </Grid.Column>
           </Grid>
           <Item.Extra>
-            <DocumentTags metadata={document.metadata} />
+            <DocumentTags isBackOffice metadata={document.metadata} />
           </Item.Extra>
         </Item.Content>
         <div className="pid-field discrete">#{document.metadata.pid}</div>

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
@@ -66,7 +66,7 @@ export class DocumentHeader extends Component {
         }
         recordInfo={recordInfo}
       >
-        <DocumentTags metadata={data.metadata} />
+        <DocumentTags isBackOffice metadata={data.metadata} />
       </DetailsHeader>
     );
   }

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentMetadataGeneral.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentMetadataGeneral.js
@@ -41,7 +41,9 @@ export class DocumentMetadataGeneral extends Component {
       },
       {
         name: 'Tags',
-        value: <DocumentTags size="mini" metadata={document.metadata} />,
+        value: (
+          <DocumentTags isBackOffice size="mini" metadata={document.metadata} />
+        ),
       },
       {
         name: 'Edition',

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesHeader.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesHeader.js
@@ -61,7 +61,7 @@ export class SeriesHeader extends Component {
         }
         recordInfo={recordInfo}
       >
-        <DocumentTags metadata={data.metadata} />
+        <DocumentTags isBackOffice metadata={data.metadata} />
       </DetailsHeader>
     );
   }

--- a/src/lib/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
+++ b/src/lib/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
@@ -129,7 +129,7 @@ export class SeriesListEntry extends Component {
             </Grid.Column>
           </Grid>
           <Item.Extra>
-            <DocumentTags metadata={series.metadata} />
+            <DocumentTags isBackOffice metadata={series.metadata} />
           </Item.Extra>
         </Item.Content>
         <div className="pid-field">#{series.metadata.pid}</div>


### PR DESCRIPTION
* Adds new prop to `DocumentTags`
* Fixes the redirection of the tags
* closes #18