### PR TITLE
Minor bugfixes

### DIFF
--- a/src/lib/components/backoffice/ExportSearchResults/ExportSearchResults.js
+++ b/src/lib/components/backoffice/ExportSearchResults/ExportSearchResults.js
@@ -105,6 +105,7 @@ class ExportSearchResultsWithState extends Component {
 
     // append the `format` param
     const params = Qs.parse(queryString);
+    params['page'] = 1; // Start from the first page
     params['format'] = format;
     const args = Qs.stringify(params);
 

--- a/src/lib/components/backoffice/buttons/ScrollingMenu/ScrollingMenu.js
+++ b/src/lib/components/backoffice/buttons/ScrollingMenu/ScrollingMenu.js
@@ -5,7 +5,7 @@ import { Menu } from 'semantic-ui-react';
 export default class ScrollingMenuItem extends Component {
   constructor(props) {
     super(props);
-    this.state = { activeItem: props.children[0].elementId };
+    this.state = { activeItem: props.children[0].props.elementId };
   }
 
   setActiveLink = elementId => {

--- a/src/lib/modules/Document/DocumentAuthors.js
+++ b/src/lib/modules/Document/DocumentAuthors.js
@@ -171,12 +171,13 @@ class DocumentAuthors extends Component {
     } = this.props;
     const { isExpanded } = this.state;
 
-    let displayedAuthors = authors;
+    const allAuthors = authors ? authors : [];
+    let displayedAuthors = allAuthors;
     if (!isExpanded) {
-      displayedAuthors = authors.slice(0, limit);
+      displayedAuthors = allAuthors.slice(0, limit);
     }
 
-    const isShowingAllAuthors = displayedAuthors.length === authors.length;
+    const isShowingAllAuthors = displayedAuthors.length === allAuthors.length;
     const showAllAuthorsCmp =
       !isShowingAllAuthors && expandable ? (
         <>

--- a/src/lib/modules/ESSelector/ESSelector.js
+++ b/src/lib/modules/ESSelector/ESSelector.js
@@ -132,6 +132,7 @@ class ESSelector extends Component {
       delay,
       alwaysWildcard,
       minCharacters,
+      focus,
       serializer,
       onSearchChange,
       onResults,
@@ -148,6 +149,7 @@ class ESSelector extends Component {
           alwaysWildcard={alwaysWildcard}
           minCharacters={minCharacters}
           placeholder={placeholder}
+          focus={focus}
           serializer={serializer}
           onResults={onResults}
           onSelect={this.onSelectResult}
@@ -186,6 +188,7 @@ ESSelector.propTypes = {
   name: PropTypes.string,
   selectionInfoText: PropTypes.string,
   emptySelectionInfoText: PropTypes.string,
+  focus: PropTypes.bool,
 };
 
 ESSelector.defaultProps = {
@@ -196,6 +199,7 @@ ESSelector.defaultProps = {
   emptySelectionInfoText: null,
   selectionInfoText: null,
   onResults: null,
+  focus: false,
 };
 
 export default Overridable.component('ESSelector', ESSelector);

--- a/src/lib/modules/ESSelector/ESSelectorLoanRequest.js
+++ b/src/lib/modules/ESSelector/ESSelectorLoanRequest.js
@@ -115,7 +115,7 @@ export default class ESSelectorLoanRequest extends Component {
 
   render() {
     const { title, content, selectorComponent, size, trigger } = this.props;
-    const { visible, missingPatron } = this.state;
+    const { visible, missingPatron, selections } = this.state;
     const modalTrigger = React.cloneElement(trigger, {
       onClick: this.toggle,
     });
@@ -157,7 +157,9 @@ export default class ESSelectorLoanRequest extends Component {
                 <Button color="black" onClick={this.toggle}>
                   Close
                 </Button>
-                <Button onClick={this.save}>Request</Button>
+                <Button onClick={this.save} disabled={_isEmpty(selections)}>
+                  Request
+                </Button>
               </Modal.Actions>
             </Segment>
           </Segment.Group>

--- a/src/lib/modules/ESSelector/HitsSearch.js
+++ b/src/lib/modules/ESSelector/HitsSearch.js
@@ -38,11 +38,12 @@ export class HitsSearch extends Component {
     }
   }
 
-  componentDidMount() {
-    if (this.searchInputRef) {
+  componentDidMount = () => {
+    const { focus } = this.props;
+    if (focus && this.searchInputRef) {
       this.searchInputRef.focus();
     }
-  }
+  };
 
   clear = () => this.setState(initialState);
 
@@ -201,6 +202,7 @@ HitsSearch.propTypes = {
   onSelect: PropTypes.func,
   open: PropTypes.bool,
   query: PropTypes.func.isRequired,
+  focus: PropTypes.bool,
 };
 
 HitsSearch.defaultProps = {

--- a/src/lib/modules/Literature/LiteratureCover.js
+++ b/src/lib/modules/Literature/LiteratureCover.js
@@ -17,21 +17,31 @@ class LiteratureCover extends Component {
   };
 
   render() {
-    const { asItem, isRestricted, linkTo, size, url, ...uiProps } = this.props;
+    const {
+      asItem,
+      isRestricted,
+      linkTo,
+      size,
+      url,
+      isLoading,
+      ...uiProps
+    } = this.props;
     const Cmp = asItem ? Item.Image : Image;
     const link = linkTo ? { as: Link, to: linkTo } : {};
     return url ? (
       <Overridable id="LiteratureCover.layout" {...this.props}>
-        <Cmp
-          centered
-          disabled={isRestricted}
-          label={this.getLabel(isRestricted)}
-          {...link}
-          onError={e => (e.target.style.display = 'none')}
-          src={url}
-          size={size}
-          {...uiProps}
-        />
+        {!isLoading && (
+          <Cmp
+            centered
+            disabled={isRestricted}
+            label={this.getLabel(isRestricted)}
+            {...link}
+            onError={e => (e.target.style.display = 'none')}
+            src={url}
+            size={size}
+            {...uiProps}
+          />
+        )}
       </Overridable>
     ) : (
       <Overridable id="LiteratureCover.placeholder" {...this.props}>
@@ -49,6 +59,7 @@ LiteratureCover.propTypes = {
   linkTo: PropTypes.string,
   size: PropTypes.string,
   url: PropTypes.string,
+  isLoading: PropTypes.bool,
 };
 
 LiteratureCover.defaultProps = {
@@ -57,6 +68,7 @@ LiteratureCover.defaultProps = {
   linkTo: null,
   size: 'large',
   url: null,
+  isLoading: false,
 };
 
 export default Overridable.component('LiteratureCover', LiteratureCover);

--- a/src/lib/modules/SearchControls/overridden/SearchSortOrderElementMobile.js
+++ b/src/lib/modules/SearchControls/overridden/SearchSortOrderElementMobile.js
@@ -6,7 +6,8 @@ export class SearchSortOrderElementMobile extends Component {
   constructor(props) {
     super(props);
     const { currentSortOrder, options, onValueChange } = this.props;
-    options.map((element, index) => {
+    this.buttons = {};
+    options.forEach((element, index) => {
       this.buttons[element.value] = (
         <Button
           icon
@@ -27,7 +28,6 @@ export class SearchSortOrderElementMobile extends Component {
           />
         </Button>
       );
-      return this.buttons;
     });
   }
 

--- a/src/lib/modules/Series/__snapshots__/SeriesCard.test.js.snap
+++ b/src/lib/modules/Series/__snapshots__/SeriesCard.test.js.snap
@@ -46,6 +46,7 @@ exports[`SeriesCard tests should go to book details when clicking on a book 1`] 
       >
         <LiteratureCover
           asItem={false}
+          isLoading={false}
           isRestricted={false}
           linkTo={null}
           size="small"
@@ -54,6 +55,7 @@ exports[`SeriesCard tests should go to book details when clicking on a book 1`] 
           <Overridable
             asItem={false}
             id="LiteratureCover.placeholder"
+            isLoading={false}
             isRestricted={false}
             linkTo={null}
             size="small"
@@ -211,6 +213,7 @@ exports[`SeriesCard tests should render the SeriesCard 1`] = `
       >
         <LiteratureCover
           asItem={false}
+          isLoading={false}
           isRestricted={false}
           linkTo={null}
           size="small"
@@ -219,6 +222,7 @@ exports[`SeriesCard tests should render the SeriesCard 1`] = `
           <Overridable
             asItem={false}
             id="LiteratureCover.placeholder"
+            isLoading={false}
             isRestricted={false}
             linkTo={null}
             size="small"

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/BorrowingRequestPatronLoan.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/BorrowingRequestPatronLoan.js
@@ -86,12 +86,16 @@ class CreateLoan extends React.Component {
   constructor(props) {
     super(props);
     this.today = toShortDate(DateTime.local());
-    this.state = {
+    this.state = this.initialState();
+  }
+
+  initialState = () => {
+    return {
       modalOpen: false,
       startDate: this.today,
       endDate: '',
     };
-  }
+  };
 
   handleStartDateChange = value => {
     this.setState({ startDate: value });
@@ -106,7 +110,7 @@ class CreateLoan extends React.Component {
   };
 
   handleCloseModal = () => {
-    this.setState({ modalOpen: false });
+    this.setState(this.initialState());
   };
 
   isSelectionValid = () => {

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/ItemPendingLoans.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/ItemPendingLoans.js
@@ -86,7 +86,8 @@ export default class ItemPendingLoans extends Component {
           ) ||
           !invenioConfig.ITEMS.canCirculateStatuses.includes(
             itemDetails.metadata.status
-          )
+          ) ||
+          isPendingLoansLoading
         }
         onClick={() =>
           performCheckoutAction(

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanMetadata/LoanMetadata.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanMetadata/LoanMetadata.js
@@ -109,6 +109,7 @@ export class LoanMetadata extends Component {
 
   prepareRightData(data) {
     const { cancel_reason: reason, state } = data.metadata;
+    const toShortDateOpt = date => (isFinite(date) ? toShortDate(date) : '-');
     const rows = [
       {
         name: 'Transaction date',
@@ -132,13 +133,13 @@ export class LoanMetadata extends Component {
       rows.push(
         {
           name: 'Start date',
-          value: toShortDate(data.metadata.start_date),
+          value: toShortDateOpt(data.metadata.start_date),
         },
         {
           name: 'End date',
           value: (
             <>
-              {toShortDate(data.metadata.end_date)}
+              {toShortDateOpt(data.metadata.end_date)}
               {data.metadata.is_overdue && <Icon name="warning" />}
             </>
           ),

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanel.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanel.js
@@ -34,6 +34,7 @@ class DocumentPanel extends Component {
                   <Grid.Column>
                     <LiteratureCover
                       url={_get(doc, 'metadata.cover_metadata.urls.large')}
+                      isLoading={isLoading}
                     />
                   </Grid.Column>
                   <Grid.Column>

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentDocumentRequests/PatronCurrentDocumentRequests.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentDocumentRequests/PatronCurrentDocumentRequests.js
@@ -279,15 +279,17 @@ class PatronCurrentDocumentRequests extends Component {
                 currentPage={activePage}
                 renderEmptyResultsElement={this.renderNoResults}
               />
-              <Container textAlign="center">
-                <Pagination
-                  currentPage={activePage}
-                  currentSize={rowsPerPage}
-                  loading={isLoading}
-                  onPageChange={this.onPageChange}
-                  totalResults={documentRequests.total}
-                />
-              </Container>
+              {documentRequests.total > 0 && (
+                <Container textAlign="center">
+                  <Pagination
+                    currentPage={activePage}
+                    currentSize={rowsPerPage}
+                    loading={isLoading}
+                    onPageChange={this.onPageChange}
+                    totalResults={documentRequests.total}
+                  />
+                </Container>
+              )}
             </Error>
           </ILSItemPlaceholder>
         </>

--- a/src/lib/pages/frontsite/PatronProfile/PatronPastDocumentRequests/PatronPastDocumentRequests.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronPastDocumentRequests/PatronPastDocumentRequests.js
@@ -115,15 +115,17 @@ class PatronPastDocumentRequests extends Component {
                 currentPage={activePage}
                 renderEmptyResultsElement={this.renderNoResults}
               />
-              <Container textAlign="center">
-                <Pagination
-                  currentPage={activePage}
-                  currentSize={rowsPerPage}
-                  loading={isLoading}
-                  onPageChange={this.onPageChange}
-                  totalResults={documentRequests.total}
-                />
-              </Container>
+              {documentRequests.total > 0 && (
+                <Container textAlign="center">
+                  <Pagination
+                    currentPage={activePage}
+                    currentSize={rowsPerPage}
+                    loading={isLoading}
+                    onPageChange={this.onPageChange}
+                    totalResults={documentRequests.total}
+                  />
+                </Container>
+              )}
             </Error>
           </ILSItemPlaceholder>
         </>


### PR DESCRIPTION
* addresses #172
* DocumentAuthors component raising exception
* "checkout" button in loan requests not disabled during loading
* LiteratureCover flickering on page change (closes #135)
* hide navigation buttons in patron loans on empty result set
* BorrowingRequestPatronLoan state not reset
* ESSelectorLoanRequest request button not disabled
* SearchSortOrderElementMobile uninitialized attribute
* ExportSearchResults not starting from the first page
* ScrollingMenu first element not selected due to typo
* HitsSearch & ESSelector toggleable initial focus, disabled by default
* LoanMetadata invalid dates displayed