### PR TITLE
backoffice: patron details overridable metadata

### DIFF
--- a/src/lib/components/SearchBar/SearchBar.js
+++ b/src/lib/components/SearchBar/SearchBar.js
@@ -42,13 +42,15 @@ class SearchBar extends Component {
 
   render() {
     const {
-      queryString,
-      updateQueryString,
+      buttonColor,
+      currentQueryString,
+      executeSearch: parentSearch,
+      onKeyPressHandler,
       placeholder,
       queryHelperFields,
-      buttonColor,
-      onKeyPressHandler,
+      queryString,
       updateQueryOnChange,
+      updateQueryString,
       ...otherProps
     } = this.props;
     const { currentValue } = this.state;
@@ -58,7 +60,7 @@ class SearchBar extends Component {
           action={{
             color: buttonColor,
             icon: 'search',
-            onClick: this.executeSearch,
+            onClick: parentSearch || this.executeSearch,
           }}
           size="big"
           fluid
@@ -79,7 +81,7 @@ class SearchBar extends Component {
         {queryHelperFields.length > 0 && (
           <QueryBuildHelper
             fields={queryHelperFields}
-            currentQueryString={queryString}
+            currentQueryString={currentQueryString || queryString}
             updateQueryString={this.onInputChange}
           />
         )}
@@ -89,22 +91,26 @@ class SearchBar extends Component {
 }
 
 SearchBar.propTypes = {
-  queryString: PropTypes.string,
-  updateQueryString: PropTypes.func.isRequired,
+  buttonColor: PropTypes.string,
+  executeSearch: PropTypes.func,
+  currentQueryString: PropTypes.string,
+  onKeyPressHandler: PropTypes.func,
   placeholder: PropTypes.string,
   queryHelperFields: PropTypes.array,
-  buttonColor: PropTypes.string,
+  queryString: PropTypes.string,
   updateQueryOnChange: PropTypes.bool,
-  onKeyPressHandler: PropTypes.func,
+  updateQueryString: PropTypes.func.isRequired,
 };
 
 SearchBar.defaultProps = {
+  buttonColor: null,
+  currentQueryString: null,
+  executeSearch: null,
+  onKeyPressHandler: null,
+  placeholder: 'Search for books, series, articles, publications...',
+  queryHelperFields: [],
   queryString: '',
   updateQueryOnChange: false,
-  queryHelperFields: [],
-  buttonColor: null,
-  placeholder: 'Search for books, series, articles, publications...',
-  onKeyPressHandler: null,
 };
 
 export default SearchBar;

--- a/src/lib/components/SearchBar/__snapshots__/SearchBar.test.js.snap
+++ b/src/lib/components/SearchBar/__snapshots__/SearchBar.test.js.snap
@@ -3,6 +3,8 @@
 exports[`LoansSearch SearchBar tests should render search bar with query helper 1`] = `
 <SearchBar
   buttonColor={null}
+  currentQueryString={null}
+  executeSearch={null}
   onKeyPressHandler={null}
   placeholder="Search"
   queryHelperFields={
@@ -186,6 +188,8 @@ exports[`LoansSearch SearchBar tests should render search bar with query helper 
 exports[`LoansSearch SearchBar tests should render the current query string 1`] = `
 <SearchBar
   buttonColor={null}
+  currentQueryString={null}
+  executeSearch={null}
   onKeyPressHandler={null}
   placeholder="Search"
   queryHelperFields={Array []}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -13,6 +13,8 @@ export { add, remove } from '@api/relations';
 export { seriesApi } from '@api/series';
 export { circulationStatsApi, statsApi } from '@api/stats';
 export { vocabularyApi } from '@api/vocabularies';
+export { ScrollingMenuItem } from '@components/backoffice/buttons/ScrollingMenu';
+export { MetadataTable } from '@components/backoffice/MetadataTable';
 export {
   getSearchConfig,
   getStaticPageByName,

--- a/src/lib/pages/backoffice/Patron/PatronDetails/ItemsSearch/ItemsSearch.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/ItemsSearch/ItemsSearch.js
@@ -76,16 +76,14 @@ export default class ItemsSearch extends Component {
     const { patronDetails, clearResults, isLoadingSearch } = this.props;
     const { executedSearch } = this.state;
     return (
-      <div className="results-list">
-        <ItemsResultsList
-          patronPid={patronDetails.user_pid}
-          clearResults={clearResults}
-          results={results}
-          isLoading={isLoadingSearch}
-          executedSearch={executedSearch}
-          clearSearchQuery={this.clearSearchQuery}
-        />
-      </div>
+      <ItemsResultsList
+        patronPid={patronDetails.user_pid}
+        clearResults={clearResults}
+        results={results}
+        isLoading={isLoadingSearch}
+        executedSearch={executedSearch}
+        clearSearchQuery={this.clearSearchQuery}
+      />
     );
   };
 
@@ -105,10 +103,9 @@ export default class ItemsSearch extends Component {
       queryString,
       updateQueryString,
     } = this.props;
-
     return (
       <>
-        <Container className="search-bar spaced">
+        <Container className="spaced">
           <SearchBar
             action={{
               icon: 'search',
@@ -120,12 +117,10 @@ export default class ItemsSearch extends Component {
             onKeyPressHandler={this.onKeyPressHandler}
             updateQueryString={updateQueryString}
             placeholder="Type or paste to search for physical copies..."
-            onPaste={e => {
-              this.onPasteHandler(e);
-            }}
+            onPaste={e => this.onPasteHandler(e)}
           />
         </Container>
-        <Grid columns={1} stackable relaxed className="items-search-container">
+        <Grid columns={1} stackable relaxed>
           <Grid.Column width={16}>
             <Loader isLoading={isLoading}>
               <Error error={error}>
@@ -142,21 +137,21 @@ export default class ItemsSearch extends Component {
 }
 
 ItemsSearch.propTypes = {
-  updateQueryString: PropTypes.func.isRequired,
-  queryString: PropTypes.string.isRequired,
-  items: PropTypes.object,
-  fetchItems: PropTypes.func.isRequired,
-  clearResults: PropTypes.func.isRequired,
   checkoutItem: PropTypes.func.isRequired,
-  patronDetails: PropTypes.object.isRequired,
-  isLoadingSearch: PropTypes.bool,
-  isLoading: PropTypes.bool,
+  clearResults: PropTypes.func.isRequired,
   error: PropTypes.object,
+  fetchItems: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
+  isLoadingSearch: PropTypes.bool,
+  items: PropTypes.object,
+  patronDetails: PropTypes.object.isRequired,
+  queryString: PropTypes.string.isRequired,
+  updateQueryString: PropTypes.func.isRequired,
 };
 
 ItemsSearch.defaultProps = {
-  items: null,
-  isLoadingSearch: false,
-  isLoading: false,
   error: null,
+  isLoading: false,
+  isLoadingSearch: false,
+  items: null,
 };

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronActionMenu/PatronActionMenu.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronActionMenu/PatronActionMenu.js
@@ -2,8 +2,9 @@ import {
   ScrollingMenu,
   ScrollingMenuItem,
 } from '@components/backoffice/buttons/ScrollingMenu';
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Overridable from 'react-overridable';
 
 export default class PatronActionMenu extends Component {
   render() {
@@ -11,6 +12,7 @@ export default class PatronActionMenu extends Component {
     return (
       <div className="bo-action-menu">
         <ScrollingMenu offset={offset}>
+          <Overridable id="Backoffice.PatronDetails.Metadata.ActionMenuItem" />
           <ScrollingMenuItem label="Checkout" elementId="patron-checkout" />
           <ScrollingMenuItem label="Ongoing loans" elementId="ongoing-loans" />
           <ScrollingMenuItem

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronDetails.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronDetails.js
@@ -2,6 +2,7 @@ import { Error } from '@components/Error';
 import { Loader } from '@components/Loader';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import Overridable from 'react-overridable';
 import {
   Container,
   Divider,
@@ -13,14 +14,14 @@ import {
 } from 'semantic-ui-react';
 import { ItemsCheckout } from './ItemsCheckout';
 import { ItemsSearch } from './ItemsSearch';
+import { PatronActionMenu } from './PatronActionMenu';
+import { PatronCurrentBorrowingRequests } from './PatronCurrentBorrowingRequests';
 import { PatronCurrentLoans } from './PatronCurrentLoans';
 import { PatronDocumentRequests } from './PatronDocumentRequests';
-import { PatronPendingLoans } from './PatronPendingLoans';
-import { PatronActionMenu } from './PatronActionMenu';
 import { PatronHeader } from './PatronHeader';
-import { PatronPastLoans } from './PatronPastLoans';
-import { PatronCurrentBorrowingRequests } from './PatronCurrentBorrowingRequests';
 import { PatronPastBorrowingRequests } from './PatronPastBorrowingRequests';
+import { PatronPastLoans } from './PatronPastLoans';
+import { PatronPendingLoans } from './PatronPendingLoans';
 
 export default class PatronDetails extends Component {
   constructor(props) {
@@ -63,6 +64,11 @@ export default class PatronDetails extends Component {
                   <Grid columns={2}>
                     <Grid.Column width={13}>
                       <Container className="spaced">
+                        <Overridable
+                          id="Backoffice.PatronDetails.Metadata"
+                          patron={data}
+                        />
+
                         <Header attached="top" as="h3">
                           Checkout
                         </Header>
@@ -75,68 +81,71 @@ export default class PatronDetails extends Component {
                           <ItemsSearch />
                         </Segment>
 
-                        <Container className="spaced">
-                          <Header attached="top" as="h3">
-                            Ongoing loans
-                          </Header>
-                          <Segment
-                            attached
-                            id="ongoing-loans"
-                            className="bo-metadata-segment no-padding"
-                          >
-                            <PatronCurrentLoans />
-                          </Segment>
-                          <Header attached="top" as="h3">
-                            Pending loans requests
-                          </Header>
-                          <Segment
-                            attached
-                            id="loan-requests"
-                            className="bo-metadata-segment no-padding"
-                          >
-                            <PatronPendingLoans />
-                          </Segment>
-                          <Header attached="top" as="h3">
-                            Ongoing interlibrary loans
-                          </Header>
-                          <Segment
-                            attached
-                            id="ongoing-borrowing-requests"
-                            className="bo-metadata-segment no-padding"
-                          >
-                            <PatronCurrentBorrowingRequests />
-                          </Segment>
-                          <Header attached="top" as="h3">
-                            Requests for new literature
-                          </Header>
-                          <Segment
-                            attached
-                            id="literature-requests"
-                            className="bo-metadata-segment no-padding"
-                          >
-                            <PatronDocumentRequests />
-                          </Segment>
-                          <Header attached="top" as="h3">
-                            Loans history
-                          </Header>
-                          <Segment
-                            attached
-                            id="loans-history"
-                            className="bo-metadata-segment no-padding"
-                          >
-                            <PatronPastLoans />
-                          </Segment>
-                          <Header attached="top" as="h3">
-                            Interlibrary loans history
-                          </Header>
-                          <Segment
-                            attached
-                            id="borrowing-requests-history"
-                            className="bo-metadata-segment no-padding"
-                          >
-                            <PatronPastBorrowingRequests />
-                          </Segment>
-                        </Container>
+                        <Header attached="top" as="h3">
+                          Ongoing loans
+                        </Header>
+                        <Segment
+                          attached
+                          id="ongoing-loans"
+                          className="bo-metadata-segment no-padding"
+                        >
+                          <PatronCurrentLoans />
+                        </Segment>
+
+                        <Header attached="top" as="h3">
+                          Pending loans requests
+                        </Header>
+                        <Segment
+                          attached
+                          id="loan-requests"
+                          className="bo-metadata-segment no-padding"
+                        >
+                          <PatronPendingLoans />
+                        </Segment>
+
+                        <Header attached="top" as="h3">
+                          Ongoing interlibrary loans
+                        </Header>
+                        <Segment
+                          attached
+                          id="ongoing-borrowing-requests"
+                          className="bo-metadata-segment no-padding"
+                        >
+                          <PatronCurrentBorrowingRequests />
+                        </Segment>
+
+                        <Header attached="top" as="h3">
+                          Requests for new literature
+                        </Header>
+                        <Segment
+                          attached
+                          id="literature-requests"
+                          className="bo-metadata-segment no-padding"
+                        >
+                          <PatronDocumentRequests />
+                        </Segment>
+
+                        <Header attached="top" as="h3">
+                          Loans history
+                        </Header>
+                        <Segment
+                          attached
+                          id="loans-history"
+                          className="bo-metadata-segment no-padding"
+                        >
+                          <PatronPastLoans />
+                        </Segment>
+
+                        <Header attached="top" as="h3">
+                          Interlibrary loans history
+                        </Header>
+                        <Segment
+                          attached
+                          id="borrowing-requests-history"
+                          className="bo-metadata-segment no-padding"
+                        >
+                          <PatronPastBorrowingRequests />
+                        </Segment>
                       </Container>
                     </Grid.Column>
                     <Grid.Column width={3}>


### PR DESCRIPTION
- NEW overridable components for Patron details metadata and action menu item
- FIX currentQueryString and executeSearch Warning: React does not recognize the prop on a DOM element. Also props that were passed from the parent were ignored.
- BETTER global export ScrollingMenuItem and MetadataTable
- addresses CERNDocumentServer/cds-ils#145
- required by CERNDocumentServer/cds-ils#149