### PR TITLE
LiteratureTags: make them unclickable

### DIFF
--- a/src/lib/components/backoffice/Sidebar/Sidebar.js
+++ b/src/lib/components/backoffice/Sidebar/Sidebar.js
@@ -60,7 +60,7 @@ class Sidebar extends Component {
                   <Menu.Header>Actions</Menu.Header>
                   <Menu.Menu>
                     <Menu.Item
-                      as={Link}
+                      as={checkInActive ? '' : Link}
                       active={checkInActive}
                       to={BackOfficeRoutes.checkIn}
                     >
@@ -68,7 +68,7 @@ class Sidebar extends Component {
                       <div className="menu-item-description">Return copies</div>
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={checkOutActive ? '' : Link}
                       active={checkOutActive}
                       to={BackOfficeRoutes.checkOut}
                     >
@@ -81,28 +81,28 @@ class Sidebar extends Component {
                   <Menu.Header>Library</Menu.Header>
                   <Menu.Menu>
                     <Menu.Item
-                      as={Link}
+                      as={overviewActive ? '' : Link}
                       active={overviewActive}
                       to={BackOfficeRoutes.home}
                     >
                       Overview
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={loansActive ? '' : Link}
                       active={loansActive}
                       to={BackOfficeRoutes.loansList}
                     >
                       Loans
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={documentRequestsActive ? '' : Link}
                       active={documentRequestsActive}
                       to={BackOfficeRoutes.documentRequestsList}
                     >
                       Requests for new literature
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={locationsActive ? '' : Link}
                       active={locationsActive}
                       to={BackOfficeRoutes.locationsList}
                     >
@@ -115,28 +115,28 @@ class Sidebar extends Component {
                   <Menu.Header>Catalogue</Menu.Header>
                   <Menu.Menu>
                     <Menu.Item
-                      as={Link}
+                      as={documentsActive ? '' : Link}
                       active={documentsActive}
                       to={BackOfficeRoutes.documentsList}
                     >
                       Books / Articles
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={seriesActive ? '' : Link}
                       active={seriesActive}
                       to={BackOfficeRoutes.seriesList}
                     >
                       Series / Monographs
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={itemsActive ? '' : Link}
                       active={itemsActive}
                       to={BackOfficeRoutes.itemsList}
                     >
                       Physical Copies
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={eitemsActive ? '' : Link}
                       active={eitemsActive}
                       to={BackOfficeRoutes.eitemsList}
                     >
@@ -149,14 +149,14 @@ class Sidebar extends Component {
                   <Menu.Header>Acquisition</Menu.Header>
                   <Menu.Menu>
                     <Menu.Item
-                      as={Link}
+                      as={ordersActive ? '' : Link}
                       active={ordersActive}
                       to={AcquisitionRoutes.ordersList}
                     >
                       Purchase Orders
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={vendorsActive ? '' : Link}
                       active={vendorsActive}
                       to={AcquisitionRoutes.vendorsList}
                     >
@@ -169,14 +169,14 @@ class Sidebar extends Component {
                   <Menu.Header>InterLibrary Loans</Menu.Header>
                   <Menu.Menu>
                     <Menu.Item
-                      as={Link}
+                      as={borrowingRequestsActive ? '' : Link}
                       active={borrowingRequestsActive}
                       to={ILLRoutes.borrowingRequestList}
                     >
                       Borrowing Requests
                     </Menu.Item>
                     <Menu.Item
-                      as={Link}
+                      as={librariesActive ? '' : Link}
                       active={librariesActive}
                       to={ILLRoutes.libraryList}
                     >
@@ -189,7 +189,7 @@ class Sidebar extends Component {
                   <Menu.Header>Patrons</Menu.Header>
                   <Menu.Menu>
                     <Menu.Item
-                      as={Link}
+                      as={patronsActive ? '' : Link}
                       active={patronsActive}
                       to={BackOfficeRoutes.patronsList}
                     >
@@ -202,7 +202,7 @@ class Sidebar extends Component {
                   <Menu.Header>Statistics</Menu.Header>
                   <Menu.Menu>
                     <Menu.Item
-                      as={Link}
+                      as={statsActive ? '' : Link}
                       active={statsActive}
                       to={BackOfficeRoutes.stats.home}
                     >

--- a/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
+++ b/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
@@ -137,7 +137,7 @@ export default class DocumentListEntry extends Component {
             </Grid.Column>
           </Grid>
           <Item.Extra>
-            <LiteratureTags isBackOffice tags={document.metadata.tags} />
+            <LiteratureTags tags={document.metadata.tags} />
           </Item.Extra>
         </Item.Content>
         <div className="pid-field discrete">#{document.metadata.pid}</div>

--- a/src/lib/modules/Literature/LiteratureTags.js
+++ b/src/lib/modules/Literature/LiteratureTags.js
@@ -1,14 +1,12 @@
-import { BackOfficeRoutes, FrontSiteRoutes } from '@routes/urls';
 import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Overridable from 'react-overridable';
-import { Link } from 'react-router-dom';
 import { Label } from 'semantic-ui-react';
 
 class LiteratureTags extends Component {
   render() {
-    const { tags, isBackOffice, ...uiProps } = this.props;
+    const { tags, ...uiProps } = this.props;
 
     if (_isEmpty(tags)) return null;
 
@@ -17,19 +15,7 @@ class LiteratureTags extends Component {
         <>
           {tags.map(tag => (
             <Label className="highlighted" key={tag} {...uiProps}>
-              <Link
-                to={
-                  isBackOffice
-                    ? BackOfficeRoutes.documentsListWithQuery(
-                        `&sort=mostrecent&order=desc&f=tag%3A${tag}`
-                      )
-                    : FrontSiteRoutes.documentsListWithQuery(
-                        `&sort=mostrecent&order=desc&f=tag%3A${tag}`
-                      )
-                }
-              >
-                {tag}
-              </Link>
+              {tag}
             </Label>
           ))}
         </>
@@ -40,12 +26,10 @@ class LiteratureTags extends Component {
 
 LiteratureTags.propTypes = {
   tags: PropTypes.array,
-  isBackOffice: PropTypes.bool,
 };
 
 LiteratureTags.defaultProps = {
   tags: [],
-  isBackOffice: true,
 };
 
 export default Overridable.component('LiteratureTags', LiteratureTags);

--- a/src/lib/modules/Series/SeriesListEntry.js
+++ b/src/lib/modules/Series/SeriesListEntry.js
@@ -1,4 +1,5 @@
 import { SeriesAuthors } from '@modules/Series/SeriesAuthors';
+import LiteratureTags from '@modules/Literature/LiteratureTags';
 import LiteratureCover from '@modules/Literature/LiteratureCover';
 import { SeriesLanguages } from '@modules/Series/SeriesLanguages';
 import { FrontSiteRoutes } from '@routes/urls';
@@ -95,6 +96,9 @@ export default class SeriesListEntry extends Component {
               </Grid.Column>
             </Grid>
           </Item.Meta>
+          <Item.Extra>
+            <LiteratureTags tags={this.metadata.tags} />
+          </Item.Extra>
         </Item.Content>
       </Item>
     );

--- a/src/lib/modules/Series/__snapshots__/SeriesListEntry.test.js.snap
+++ b/src/lib/modules/Series/__snapshots__/SeriesListEntry.test.js.snap
@@ -89,6 +89,9 @@ exports[`should render correctly 1`] = `
         </GridColumn>
       </Grid>
     </ItemMeta>
+    <ItemExtra>
+      <Overridable(LiteratureTags) />
+    </ItemExtra>
   </ItemContent>
 </Item>
 `;

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
@@ -66,7 +66,7 @@ export class DocumentHeader extends Component {
         }
         recordInfo={recordInfo}
       >
-        <LiteratureTags isBackOffice tags={data.metadata.tags} />
+        <LiteratureTags tags={data.metadata.tags} />
       </DetailsHeader>
     );
   }

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentContents.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentContents.js
@@ -50,11 +50,7 @@ export class DocumentContents extends Component {
             <>
               <Divider />
               <Header as="h3">Tags</Header>
-              <LiteratureTags
-                isBackOffice
-                size="mini"
-                tags={document.metadata.tags}
-              />
+              <LiteratureTags size="mini" tags={document.metadata.tags} />
             </>
           )}
 

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestSearch/BorrowingRequestSearch.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestSearch/BorrowingRequestSearch.js
@@ -48,66 +48,69 @@ export class BorrowingRequestSearch extends Component {
       },
     ];
     return (
-      <OverridableContext.Provider
-        value={{
-          ...SearchControlsOverridesMap,
-        }}
-      >
-        <ReactSearchKit searchApi={this.searchApi} history={history}>
-          <>
-            <Container fluid className="spaced">
-              <SearchBar
-                placeholder="Search for borrowing requests..."
-                queryHelperFields={helperFields}
-              />
-            </Container>
-            <Container fluid className="bo-search-body">
-              <Grid>
-                <Grid.Row columns={2}>
-                  <ResultsLoader>
-                    <Grid.Column width={3} className="search-aggregations">
-                      <Header content="Filter by" />
-                      <SearchAggregationsCards modelName="ILL_BORROWING_REQUESTS" />
-                    </Grid.Column>
-                    <Grid.Column width={13}>
-                      <Grid columns={2}>
-                        <Grid.Column width={8}>
-                          <NewButton
-                            text="Create new borrowing request"
-                            to={ILLRoutes.borrowingRequestCreate}
-                          />
-                        </Grid.Column>
-                        <Grid.Column width={8} textAlign="right">
-                          <ExportReactSearchKitResults
-                            exportBaseUrl={borrowingRequestApi.searchBaseURL}
-                          />
-                        </Grid.Column>
-                      </Grid>
-                      <EmptyResults
-                        extraContent={
-                          <NewButton
-                            text="Create borrowing request"
-                            to={ILLRoutes.borrowingRequestCreate}
-                          />
-                        }
-                      />
-                      <Error />
-                      <SearchControls
-                        modelName="ILL_BORROWING_REQUESTS"
-                        withLayoutSwitcher={false}
-                      />
-                      <ResultsList
-                        ListEntryElement={BorrowingRequestListEntry}
-                      />
-                      <SearchFooter />
-                    </Grid.Column>
-                  </ResultsLoader>
-                </Grid.Row>
-              </Grid>
-            </Container>
-          </>
-        </ReactSearchKit>
-      </OverridableContext.Provider>
+      <>
+        <Header as="h2">Borrowing Requests</Header>
+        <OverridableContext.Provider
+          value={{
+            ...SearchControlsOverridesMap,
+          }}
+        >
+          <ReactSearchKit searchApi={this.searchApi} history={history}>
+            <>
+              <Container fluid className="spaced">
+                <SearchBar
+                  placeholder="Search for borrowing requests..."
+                  queryHelperFields={helperFields}
+                />
+              </Container>
+              <Container fluid className="bo-search-body">
+                <Grid>
+                  <Grid.Row columns={2}>
+                    <ResultsLoader>
+                      <Grid.Column width={3} className="search-aggregations">
+                        <Header content="Filter by" />
+                        <SearchAggregationsCards modelName="ILL_BORROWING_REQUESTS" />
+                      </Grid.Column>
+                      <Grid.Column width={13}>
+                        <Grid columns={2}>
+                          <Grid.Column width={8}>
+                            <NewButton
+                              text="Create new borrowing request"
+                              to={ILLRoutes.borrowingRequestCreate}
+                            />
+                          </Grid.Column>
+                          <Grid.Column width={8} textAlign="right">
+                            <ExportReactSearchKitResults
+                              exportBaseUrl={borrowingRequestApi.searchBaseURL}
+                            />
+                          </Grid.Column>
+                        </Grid>
+                        <EmptyResults
+                          extraContent={
+                            <NewButton
+                              text="Create borrowing request"
+                              to={ILLRoutes.borrowingRequestCreate}
+                            />
+                          }
+                        />
+                        <Error />
+                        <SearchControls
+                          modelName="ILL_BORROWING_REQUESTS"
+                          withLayoutSwitcher={false}
+                        />
+                        <ResultsList
+                          ListEntryElement={BorrowingRequestListEntry}
+                        />
+                        <SearchFooter />
+                      </Grid.Column>
+                    </ResultsLoader>
+                  </Grid.Row>
+                </Grid>
+              </Container>
+            </>
+          </ReactSearchKit>
+        </OverridableContext.Provider>
+      </>
     );
   }
 }

--- a/src/lib/pages/backoffice/Patron/PatronSearch/PatronSearch.js
+++ b/src/lib/pages/backoffice/Patron/PatronSearch/PatronSearch.js
@@ -45,52 +45,55 @@ export class PatronSearch extends Component {
       },
     ];
     return (
-      <OverridableContext.Provider
-        value={{
-          ...SearchControlsOverridesMap,
-          ResultsList: PatronResultsList,
-        }}
-      >
-        <ReactSearchKit searchApi={this.searchApi}>
-          <>
-            <Container fluid className="spaced">
-              <SearchBar
-                placeholder="Search for patrons"
-                queryHelperFields={helperFields}
-              />
-            </Container>
-            <Grid>
-              <Grid.Row columns={2}>
-                <ResultsLoader>
-                  <Grid.Column width={3}>
-                    <Header content="Filter by" />
-                    <SearchAggregationsCards modelName="PATRONS" />
-                  </Grid.Column>
-                  <Grid.Column width={13}>
-                    <Grid columns={1}>
-                      <Grid.Column textAlign="right">
-                        <ExportReactSearchKitResults
-                          exportBaseUrl={patronApi.searchBaseURL}
-                        />
-                      </Grid.Column>
-                      <Grid.Column>
-                        <EmptyResults />
-                        <Error />
-                        <SearchControls
-                          modelName="PATRONS"
-                          withLayoutSwitcher={false}
-                        />
-                        <ResultsList />
-                        <SearchFooter />
-                      </Grid.Column>
-                    </Grid>
-                  </Grid.Column>
-                </ResultsLoader>
-              </Grid.Row>
-            </Grid>
-          </>
-        </ReactSearchKit>
-      </OverridableContext.Provider>
+      <>
+        <Header as="h2">Patrons</Header>
+        <OverridableContext.Provider
+          value={{
+            ...SearchControlsOverridesMap,
+            ResultsList: PatronResultsList,
+          }}
+        >
+          <ReactSearchKit searchApi={this.searchApi}>
+            <>
+              <Container fluid className="spaced">
+                <SearchBar
+                  placeholder="Search for patrons"
+                  queryHelperFields={helperFields}
+                />
+              </Container>
+              <Grid>
+                <Grid.Row columns={2}>
+                  <ResultsLoader>
+                    <Grid.Column width={3}>
+                      <Header content="Filter by" />
+                      <SearchAggregationsCards modelName="PATRONS" />
+                    </Grid.Column>
+                    <Grid.Column width={13}>
+                      <Grid columns={1}>
+                        <Grid.Column textAlign="right">
+                          <ExportReactSearchKitResults
+                            exportBaseUrl={patronApi.searchBaseURL}
+                          />
+                        </Grid.Column>
+                        <Grid.Column>
+                          <EmptyResults />
+                          <Error />
+                          <SearchControls
+                            modelName="PATRONS"
+                            withLayoutSwitcher={false}
+                          />
+                          <ResultsList />
+                          <SearchFooter />
+                        </Grid.Column>
+                      </Grid>
+                    </Grid.Column>
+                  </ResultsLoader>
+                </Grid.Row>
+              </Grid>
+            </>
+          </ReactSearchKit>
+        </OverridableContext.Provider>
+      </>
     );
   }
 }

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesContent/SeriesContent.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesContent/SeriesContent.js
@@ -28,11 +28,7 @@ export class SeriesContent extends Component {
           <>
             <Divider />
             <Header as="h3">Tags</Header>
-            <LiteratureTags
-              isBackOffice
-              size="mini"
-              tags={series.metadata.tags}
-            />
+            <LiteratureTags size="mini" tags={series.metadata.tags} />
           </>
         )}
 

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesHeader.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesHeader.js
@@ -61,7 +61,7 @@ export class SeriesHeader extends Component {
         }
         recordInfo={recordInfo}
       >
-        <LiteratureTags isBackOffice tags={data.metadata.tags} />
+        <LiteratureTags tags={data.metadata.tags} />
       </DetailsHeader>
     );
   }

--- a/src/lib/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
+++ b/src/lib/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
@@ -129,7 +129,7 @@ export class SeriesListEntry extends Component {
             </Grid.Column>
           </Grid>
           <Item.Extra>
-            <LiteratureTags isBackOffice tags={series.metadata.tags} />
+            <LiteratureTags tags={series.metadata.tags} />
           </Item.Extra>
         </Item.Content>
         <div className="pid-field">#{series.metadata.pid}</div>

--- a/src/lib/routes/backoffice/BackOffice.js
+++ b/src/lib/routes/backoffice/BackOffice.js
@@ -2,13 +2,15 @@ import { Notifications } from '@components/Notifications';
 import { Sidebar } from '@components/backoffice/Sidebar';
 import React, { Component } from 'react';
 import BackOfficeRoutesSwitch from './BackOfficeRoutesSwitch';
+import PropTypes from 'prop-types';
 
 export class BackOffice extends Component {
   render() {
+    const { location } = this.props;
     return (
       <div className="backoffice">
         <div className="bo-sidebar">
-          <Sidebar />
+          <Sidebar location={location} />
         </div>
         <div className="bo-content">
           <Notifications />
@@ -18,3 +20,7 @@ export class BackOffice extends Component {
     );
   }
 }
+
+BackOffice.propTypes = {
+  location: PropTypes.object.isRequired,
+};


### PR DESCRIPTION
- make tags in frontsite/backoffice unclickable
- display tags for series frontsite list view
- fix sidebar active link
- make sidebar links unclickable when active
- add header to borrowing requests and patrons backoffice search pages

Closes #18 