### PR TITLE
backoffice: Fixes ILL section in patron details page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5274,6 +5274,11 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha1-9AIvyPlwDGgCnVQghK+69CWj8+M="
+    },
     "cssnano": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
@@ -9329,6 +9334,15 @@
         }
       }
     },
+    "jest-canvas-mock": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.3.0.tgz",
+      "integrity": "sha512-3TMyR66VG2MzAW8Negzec03bbcIjVJMfGNvKzrEnbws1CYKqMNkvIJ8LbkoGYfp42tKqDmhIpQq3v+MNLW2A2w==",
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "jest-changed-files": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
@@ -11536,6 +11550,21 @@
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
       "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
       "dev": true
+    },
+    "moo-color": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.2.tgz",
+      "integrity": "sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==",
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "format": "prettier --config ./.prettierrc --ignore-path ./.prettierignore --write \"**/*.js\"",
     "watch": "NODE_ENV=production rollup --watch -c"
   },
-  "dependencies": {},
+  "dependencies": {
+    "jest-canvas-mock": "^2.3.0"
+  },
   "peerDependencies": {
     "@babel/runtime": "^7.9.2",
     "axios": "^0.19.2",

--- a/src/lib/modules/Literature/LiteratureTitle.js
+++ b/src/lib/modules/Literature/LiteratureTitle.js
@@ -47,6 +47,7 @@ class LiteratureTitle extends Component {
       showOnlyTitle,
       truncate,
       extraCSS,
+      width,
     } = this.props;
     const cmp = (
       <div className={`document-title ${extraCSS}`}>
@@ -58,7 +59,7 @@ class LiteratureTitle extends Component {
     );
 
     return truncate ? (
-      <Truncate lines={2} ellipsis="... ">
+      <Truncate lines={2} width={width} ellipsis="... ">
         {cmp}
       </Truncate>
     ) : (
@@ -73,6 +74,7 @@ LiteratureTitle.propTypes = {
   publicationYear: PropTypes.string,
   showOnlyTitle: PropTypes.bool,
   truncate: PropTypes.bool,
+  width: PropTypes.number,
   extraCSS: PropTypes.string,
 };
 
@@ -82,6 +84,7 @@ LiteratureTitle.defaultProps = {
   showOnlyTitle: false,
   truncate: false,
   extraCSS: '',
+  width: 0,
 };
 
 export default Overridable.component('LiteratureTitle', LiteratureTitle);

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/PatronCurrentBorrowingRequests.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/PatronCurrentBorrowingRequests.js
@@ -58,6 +58,8 @@ export default class PatronCurrentBorrowingRequests extends Component {
           title={row.metadata.document.title}
           edition={row.metadata.document.edition}
           publicationYear={row.metadata.document.publication_year}
+          truncate
+          width={300}
         />
       </Link>
     );

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/PatronCurrentBorrowingRequests.test.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/PatronCurrentBorrowingRequests.test.js
@@ -6,6 +6,8 @@ import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import PatronCurrentBorrowingRequests from './PatronCurrentBorrowingRequests';
+// jest-canvas-mock is needed to prevent errors while using the Truncate component from react-truncate
+import 'jest-canvas-mock';
 
 jest.mock('@config');
 ILLRoutes.borrowingRequestDetailsFor = jest.fn(pid => `url/${pid}`);

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
@@ -749,6 +749,8 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                           edition="1"
                                           publicationYear="1950"
                                           title="The Gulf: The Making of An American Sea"
+                                          truncate={true}
+                                          width={300}
                                         >
                                           <LiteratureTitle
                                             edition="1"
@@ -756,33 +758,66 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                             publicationYear="1950"
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
-                                            truncate={false}
+                                            truncate={true}
+                                            width={300}
                                           >
-                                            <div
-                                              className="document-title "
+                                            <Truncate
+                                              ellipsis="... "
+                                              lines={2}
+                                              trimWhitespace={false}
+                                              width={300}
                                             >
-                                              The Gulf: The Making of An American Sea
-                                               
-                                              <EditionYear
-                                                edition="1"
-                                                publicationYear="1950"
+                                              <span
+                                                width={300}
                                               >
-                                                (
-                                                <Overridable(LiteratureEdition)
-                                                  edition="1"
-                                                >
-                                                  <LiteratureEdition
-                                                    edition="1"
-                                                    withLabel={false}
+                                                <span>
+                                                  <span
+                                                    key="0"
                                                   >
-                                                    ed. 1
-                                                  </LiteratureEdition>
-                                                </Overridable(LiteratureEdition)>
-                                                 - 
-                                                1950
-                                                )
-                                              </EditionYear>
-                                            </div>
+                                                    The Gulf: The Making of An American Sea (ed. 1 - 1950)
+                                                  </span>
+                                                </span>
+                                                <span>
+                                                  <div
+                                                    className="document-title "
+                                                  >
+                                                    The Gulf: The Making of An American Sea
+                                                     
+                                                    <EditionYear
+                                                      edition="1"
+                                                      publicationYear="1950"
+                                                    >
+                                                      (
+                                                      <Overridable(LiteratureEdition)
+                                                        edition="1"
+                                                      >
+                                                        <LiteratureEdition
+                                                          edition="1"
+                                                          withLabel={false}
+                                                        >
+                                                          ed. 1
+                                                        </LiteratureEdition>
+                                                      </Overridable(LiteratureEdition)>
+                                                       - 
+                                                      1950
+                                                      )
+                                                    </EditionYear>
+                                                  </div>
+                                                </span>
+                                                <span
+                                                  style={
+                                                    Object {
+                                                      "left": 0,
+                                                      "position": "fixed",
+                                                      "top": 0,
+                                                      "visibility": "hidden",
+                                                    }
+                                                  }
+                                                >
+                                                  ... 
+                                                </span>
+                                              </span>
+                                            </Truncate>
                                           </LiteratureTitle>
                                         </Overridable(LiteratureTitle)>
                                       </a>
@@ -967,6 +1002,8 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                           edition="1"
                                           publicationYear="1950"
                                           title="The Gulf: The Making of An American Sea"
+                                          truncate={true}
+                                          width={300}
                                         >
                                           <LiteratureTitle
                                             edition="1"
@@ -974,33 +1011,66 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                             publicationYear="1950"
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
-                                            truncate={false}
+                                            truncate={true}
+                                            width={300}
                                           >
-                                            <div
-                                              className="document-title "
+                                            <Truncate
+                                              ellipsis="... "
+                                              lines={2}
+                                              trimWhitespace={false}
+                                              width={300}
                                             >
-                                              The Gulf: The Making of An American Sea
-                                               
-                                              <EditionYear
-                                                edition="1"
-                                                publicationYear="1950"
+                                              <span
+                                                width={300}
                                               >
-                                                (
-                                                <Overridable(LiteratureEdition)
-                                                  edition="1"
-                                                >
-                                                  <LiteratureEdition
-                                                    edition="1"
-                                                    withLabel={false}
+                                                <span>
+                                                  <span
+                                                    key="0"
                                                   >
-                                                    ed. 1
-                                                  </LiteratureEdition>
-                                                </Overridable(LiteratureEdition)>
-                                                 - 
-                                                1950
-                                                )
-                                              </EditionYear>
-                                            </div>
+                                                    The Gulf: The Making of An American Sea (ed. 1 - 1950)
+                                                  </span>
+                                                </span>
+                                                <span>
+                                                  <div
+                                                    className="document-title "
+                                                  >
+                                                    The Gulf: The Making of An American Sea
+                                                     
+                                                    <EditionYear
+                                                      edition="1"
+                                                      publicationYear="1950"
+                                                    >
+                                                      (
+                                                      <Overridable(LiteratureEdition)
+                                                        edition="1"
+                                                      >
+                                                        <LiteratureEdition
+                                                          edition="1"
+                                                          withLabel={false}
+                                                        >
+                                                          ed. 1
+                                                        </LiteratureEdition>
+                                                      </Overridable(LiteratureEdition)>
+                                                       - 
+                                                      1950
+                                                      )
+                                                    </EditionYear>
+                                                  </div>
+                                                </span>
+                                                <span
+                                                  style={
+                                                    Object {
+                                                      "left": 0,
+                                                      "position": "fixed",
+                                                      "top": 0,
+                                                      "visibility": "hidden",
+                                                    }
+                                                  }
+                                                >
+                                                  ... 
+                                                </span>
+                                              </span>
+                                            </Truncate>
                                           </LiteratureTitle>
                                         </Overridable(LiteratureTitle)>
                                       </a>
@@ -1951,6 +2021,8 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                           edition="1"
                                           publicationYear="1950"
                                           title="The Gulf: The Making of An American Sea"
+                                          truncate={true}
+                                          width={300}
                                         >
                                           <LiteratureTitle
                                             edition="1"
@@ -1958,33 +2030,66 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                             publicationYear="1950"
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
-                                            truncate={false}
+                                            truncate={true}
+                                            width={300}
                                           >
-                                            <div
-                                              className="document-title "
+                                            <Truncate
+                                              ellipsis="... "
+                                              lines={2}
+                                              trimWhitespace={false}
+                                              width={300}
                                             >
-                                              The Gulf: The Making of An American Sea
-                                               
-                                              <EditionYear
-                                                edition="1"
-                                                publicationYear="1950"
+                                              <span
+                                                width={300}
                                               >
-                                                (
-                                                <Overridable(LiteratureEdition)
-                                                  edition="1"
-                                                >
-                                                  <LiteratureEdition
-                                                    edition="1"
-                                                    withLabel={false}
+                                                <span>
+                                                  <span
+                                                    key="0"
                                                   >
-                                                    ed. 1
-                                                  </LiteratureEdition>
-                                                </Overridable(LiteratureEdition)>
-                                                 - 
-                                                1950
-                                                )
-                                              </EditionYear>
-                                            </div>
+                                                    The Gulf: The Making of An American Sea (ed. 1 - 1950)
+                                                  </span>
+                                                </span>
+                                                <span>
+                                                  <div
+                                                    className="document-title "
+                                                  >
+                                                    The Gulf: The Making of An American Sea
+                                                     
+                                                    <EditionYear
+                                                      edition="1"
+                                                      publicationYear="1950"
+                                                    >
+                                                      (
+                                                      <Overridable(LiteratureEdition)
+                                                        edition="1"
+                                                      >
+                                                        <LiteratureEdition
+                                                          edition="1"
+                                                          withLabel={false}
+                                                        >
+                                                          ed. 1
+                                                        </LiteratureEdition>
+                                                      </Overridable(LiteratureEdition)>
+                                                       - 
+                                                      1950
+                                                      )
+                                                    </EditionYear>
+                                                  </div>
+                                                </span>
+                                                <span
+                                                  style={
+                                                    Object {
+                                                      "left": 0,
+                                                      "position": "fixed",
+                                                      "top": 0,
+                                                      "visibility": "hidden",
+                                                    }
+                                                  }
+                                                >
+                                                  ... 
+                                                </span>
+                                              </span>
+                                            </Truncate>
                                           </LiteratureTitle>
                                         </Overridable(LiteratureTitle)>
                                       </a>

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
@@ -722,6 +722,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
                                             truncate={false}
+                                            width={0}
                                           >
                                             <div
                                               className="document-title "
@@ -924,6 +925,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
                                             truncate={false}
+                                            width={0}
                                           >
                                             <div
                                               className="document-title "
@@ -1857,6 +1859,7 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
                                             truncate={false}
+                                            width={0}
                                           >
                                             <div
                                               className="document-title "

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
@@ -665,6 +665,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
                                             truncate={false}
+                                            width={0}
                                           >
                                             <div
                                               className="document-title "
@@ -806,6 +807,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
                                             truncate={false}
+                                            width={0}
                                           >
                                             <div
                                               className="document-title "
@@ -1613,6 +1615,7 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                                             showOnlyTitle={false}
                                             title="The Gulf: The Making of An American Sea"
                                             truncate={false}
+                                            width={0}
                                           >
                                             <div
                                               className="document-title "


### PR DESCRIPTION
* Adds width prop to LiteratureTitle
* Adds "jest-canvas-mock" to test

### Before
![image](https://user-images.githubusercontent.com/15194802/94828773-1a28d600-040a-11eb-8ea0-7a5d6c1a4371.png)
### After
![image](https://user-images.githubusercontent.com/15194802/94828787-1dbc5d00-040a-11eb-9a53-f7683bf77cf3.png)
