### PR TITLE
forms: fix delete button overlap with dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7556,9 +7556,9 @@
       }
     },
     "formik": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-2.1.5.tgz",
-      "integrity": "sha512-bWpo3PiqVDYslvrRjTq0Isrm0mFXHiO33D8MS6t6dWcqSFGeYF52nlpCM2xwOJ6tRVRznDkL+zz/iHPL4LDuvQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.1.6.tgz",
+      "integrity": "sha512-m9DcxlZw/58p4xuhH3dzUzQWaC4dig0RKX7yNQOJt4VRhXn7p+YRrs3o17r3YwzvOLua3zC53VMbfupLsDwO5w==",
       "dev": true,
       "requires": {
         "deepmerge": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "@babel/runtime": "^7.9.2",
     "axios": "^0.19.2",
-    "formik": "^2.1.4",
+    "formik": "^2.1.6",
     "less": "^3.11.1",
     "less-loader": "^5.0.0",
     "lodash": "^4.17.15",
@@ -73,7 +73,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^4.0.4",
-    "formik": "^2.1.4",
+    "formik": "^2.1.6",
     "json": "^9.0.6",
     "less": "^3.11.1",
     "less-loader": "^5.0.0",

--- a/src/lib/forms/core/ObjectListField.js
+++ b/src/lib/forms/core/ObjectListField.js
@@ -74,5 +74,9 @@ ObjectListField.propTypes = {
   fieldPath: PropTypes.string.isRequired,
   onItemChange: PropTypes.func.isRequired,
   keyField: PropTypes.string.isRequired,
-  activeIndex: PropTypes.number.isRequired,
+  activeIndex: PropTypes.number,
+};
+
+ObjectListField.defaultProps = {
+  activeIndex: null,
 };

--- a/src/lib/forms/core/SubForm.js
+++ b/src/lib/forms/core/SubForm.js
@@ -53,22 +53,24 @@ export class SubForm extends Component {
 
 SubForm.propTypes = {
   basePath: PropTypes.string.isRequired,
+  initialErrors: PropTypes.object,
+  initialStatus: PropTypes.object,
   initialValues: PropTypes.object,
+  notRemovable: PropTypes.bool,
   onRemove: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
-  submitButtonText: PropTypes.string,
-  initialErrors: PropTypes.array,
-  initialStatus: PropTypes.string,
-  validationSchema: PropTypes.object,
   render: PropTypes.func,
-  notRemovable: PropTypes.bool,
+  submitButtonText: PropTypes.string,
+  validationSchema: PropTypes.object,
 };
 
 SubForm.defaultProps = {
-  submitButtonText: 'Save',
-  initialValues: null,
-  onRemove: null,
   initialErrors: null,
   initialStatus: null,
+  initialValues: null,
   notRemovable: false,
+  onRemove: null,
+  render: null,
+  submitButtonText: 'Save',
+  validationSchema: null,
 };

--- a/src/lib/modules/ESSelector/ESSelectorLoanRequest.js
+++ b/src/lib/modules/ESSelector/ESSelectorLoanRequest.js
@@ -88,19 +88,17 @@ export default class ESSelectorLoanRequest extends Component {
     );
     const disabled = _isEmpty(selections);
     return (
-      <div>
-        <Segment.Inline>
-          <div>Optionally, select a limit date for your request</div>
-          <LocationDatePicker
-            locationPid={locationPid}
-            disabledInput={disabled}
-            minDate={toShortDate(today)}
-            maxDate={toShortDate(max)}
-            placeholder="Request limit date"
-            handleDateChange={this.handleRequestEndDateChange}
-          />
-        </Segment.Inline>
-      </div>
+      <Form.Field>
+        <label>Optionally, select a limit date for your request</label>
+        <LocationDatePicker
+          locationPid={locationPid}
+          disabledInput={disabled}
+          minDate={toShortDate(today)}
+          maxDate={toShortDate(max)}
+          placeholder="Request limit date"
+          handleDateChange={this.handleRequestEndDateChange}
+        />
+      </Form.Field>
     );
   };
 

--- a/src/lib/modules/Location/LocationDatePicker.js
+++ b/src/lib/modules/Location/LocationDatePicker.js
@@ -101,13 +101,14 @@ export class LocationDatePicker extends Component {
 }
 
 LocationDatePicker.propTypes = {
-  locationPid: PropTypes.string.isRequired,
-  handleDateChange: PropTypes.func.isRequired,
-  minDate: PropTypes.string.isRequired,
-  maxDate: PropTypes.string.isRequired,
   defaultValue: PropTypes.string,
+  handleDateChange: PropTypes.func.isRequired,
+  locationPid: PropTypes.string,
+  maxDate: PropTypes.string.isRequired,
+  minDate: PropTypes.string.isRequired,
 };
 
 LocationDatePicker.defaultProps = {
   defaultValue: '',
+  locationPid: null,
 };

--- a/src/semantic-ui/site/collections/form.overrides
+++ b/src/semantic-ui/site/collections/form.overrides
@@ -27,7 +27,6 @@ Form Overrides - REACT-INVENIO-APP-ILS
     position: absolute;
     right: -0.4em;
     top: -0.3em;
-    z-index: 9999;
 
     .button {
       box-shadow: none;


### PR DESCRIPTION
- upgrade Formik 2.1.6
- fix propTypes for Subform
- fix activeIndex for ObjectListField
- fix DeleteActionButton overlap with dropdown menus in forms

The delete button `x` of the url should be hidden behind the dropdown or the Role
<img width="497" alt="Screenshot 2020-10-01 at 5 05 26 PM" src="https://user-images.githubusercontent.com/230805/94827130-5f4c0880-0408-11eb-9025-c72747afaaa9.png">
