### PR TITLE
backoffice: enhance links

### DIFF
--- a/src/lib/api/ill/borrowingRequest.js
+++ b/src/lib/api/ill/borrowingRequest.js
@@ -69,6 +69,12 @@ const list = async query => {
   return response;
 };
 
+const count = async query => {
+  const response = await http.get(`${borrowingRequestUrl}?q=${query}`);
+  response.data = response.data.hits.total;
+  return response;
+};
+
 class QueryBuilder {
   constructor() {
     this.page = '';
@@ -150,6 +156,7 @@ export const borrowingRequestApi = {
   requestExtension: requestExtension,
   acceptExtension: acceptExtension,
   declineExtension: declineExtension,
+  count: count,
   query: queryBuilder,
   url: borrowingRequestUrl,
 };

--- a/src/lib/components/backoffice/RecordsBriefCard/RecordsBriefCard.js
+++ b/src/lib/components/backoffice/RecordsBriefCard/RecordsBriefCard.js
@@ -16,11 +16,13 @@ export default class RecordsBriefCard extends Component {
           <span data-test={stats}>{stats}</span> {text}
         </p>
         <Grid>
-          <Grid.Row>
-            <Grid.Column width={8}>{buttonLeft ? buttonLeft : ''}</Grid.Column>
-            <Grid.Column width={8}>
-              {buttonRight ? buttonRight : ''}
-            </Grid.Column>
+          <Grid.Row columns="equal">
+            {buttonLeft ? (
+              <Grid.Column key="left">{buttonLeft}</Grid.Column>
+            ) : null}
+            {buttonRight ? (
+              <Grid.Column key="right">{buttonRight}</Grid.Column>
+            ) : null}
           </Grid.Row>
         </Grid>
       </Segment>

--- a/src/lib/components/backoffice/RecordsBriefCard/__snapshots__/RecordsBriefCard.test.js.snap
+++ b/src/lib/components/backoffice/RecordsBriefCard/__snapshots__/RecordsBriefCard.test.js.snap
@@ -22,14 +22,9 @@ exports[`RecordsBriefCard tests should load the details component 1`] = `
     test test test
   </p>
   <Grid>
-    <GridRow>
-      <GridColumn
-        width={8}
-      />
-      <GridColumn
-        width={8}
-      />
-    </GridRow>
+    <GridRow
+      columns="equal"
+    />
   </Grid>
 </Segment>
 `;
@@ -99,15 +94,17 @@ exports[`RecordsBriefCard tests should render with buttons 1`] = `
         <div
           className="ui grid"
         >
-          <GridRow>
+          <GridRow
+            columns="equal"
+          >
             <div
-              className="row"
+              className="equal width row"
             >
               <GridColumn
-                width={8}
+                key="left"
               >
                 <div
-                  className="eight wide column"
+                  className="column"
                 >
                   <Button
                     as="button"
@@ -167,10 +164,10 @@ exports[`RecordsBriefCard tests should render with buttons 1`] = `
                 </div>
               </GridColumn>
               <GridColumn
-                width={8}
+                key="right"
               >
                 <div
-                  className="eight wide column"
+                  className="column"
                 >
                   <Button
                     as="button"
@@ -277,25 +274,12 @@ exports[`RecordsBriefCard tests should render without buttons 1`] = `
         <div
           className="ui grid"
         >
-          <GridRow>
+          <GridRow
+            columns="equal"
+          >
             <div
-              className="row"
-            >
-              <GridColumn
-                width={8}
-              >
-                <div
-                  className="eight wide column"
-                />
-              </GridColumn>
-              <GridColumn
-                width={8}
-              >
-                <div
-                  className="eight wide column"
-                />
-              </GridColumn>
-            </div>
+              className="equal width row"
+            />
           </GridRow>
         </div>
       </Grid>

--- a/src/lib/components/backoffice/Sidebar/AdminMenu.js
+++ b/src/lib/components/backoffice/Sidebar/AdminMenu.js
@@ -9,20 +9,24 @@ export default class AdminMenu extends Component {
       <Overridable id="AdminMenu.layout">
         <>
           <Divider horizontal>Admin menu</Divider>
-          <Menu text vertical className="bo-menu">
-            <Menu.Item
-              as="a"
-              href={`${invenioConfig.APP.INVENIO_UI_URL}/admin`}
-              target="_blank"
-            >
-              Admin panel
-            </Menu.Item>
-            <Menu.Item
-              as="a"
-              href={`${invenioConfig.APP.INVENIO_UI_URL}/admin/page`}
-              target="_blank"
-            >
-              Static pages
+          <Menu text vertical className="bo-menu bo-menu-footer">
+            <Menu.Item>
+              <Menu.Menu>
+                <Menu.Item
+                  as="a"
+                  href={`${invenioConfig.APP.INVENIO_UI_URL}/admin`}
+                  target="_blank"
+                >
+                  Admin panel
+                </Menu.Item>
+                <Menu.Item
+                  as="a"
+                  href={`${invenioConfig.APP.INVENIO_UI_URL}/admin/page`}
+                  target="_blank"
+                >
+                  Static pages
+                </Menu.Item>
+              </Menu.Menu>
             </Menu.Item>
           </Menu>
         </>

--- a/src/lib/components/backoffice/Sidebar/Sidebar.js
+++ b/src/lib/components/backoffice/Sidebar/Sidebar.js
@@ -23,6 +23,18 @@ import {
 import AdminMenu from './AdminMenu';
 
 class Sidebar extends Component {
+  logout = async () => {
+    const { logout, sendErrorNotification } = this.props;
+    try {
+      await logout();
+    } catch (e) {
+      sendErrorNotification(
+        'Logout',
+        'Something went wrong. Please try to logout again.'
+      );
+    }
+  };
+
   removeTrailingSlashes = path => path.replace(/\/+$/, '');
   render() {
     const { location, user } = this.props;
@@ -64,9 +76,19 @@ class Sidebar extends Component {
               </Header.Subheader>
             </Header.Content>
           </Header>
-          <Divider />
           <Overridable id="Sidebar.Menu">
             <>
+              <Menu text vertical className="bo-menu bo-menu-subheader">
+                <Menu.Item>
+                  <Menu.Menu>
+                    <Menu.Item onClick={this.logout}>Sign out</Menu.Item>
+                    <Menu.Item as={Link} to={FrontSiteRoutes.home}>
+                      Go to Frontsite
+                    </Menu.Item>
+                  </Menu.Menu>
+                </Menu.Item>
+              </Menu>
+              <Divider />
               <Menu text vertical className="bo-menu">
                 <Menu.Item>
                   <Menu.Header>Actions</Menu.Header>
@@ -223,12 +245,6 @@ class Sidebar extends Component {
                   </Menu.Menu>
                 </Menu.Item>
               </Menu>
-              <Divider horizontal>Other</Divider>
-              <Menu text vertical className="bo-menu">
-                <Menu.Item as={Link} to={FrontSiteRoutes.home}>
-                  Go to Home Page
-                </Menu.Item>
-              </Menu>
             </>
           </Overridable>
           <AuthenticationGuard
@@ -280,6 +296,8 @@ Sidebar.propTypes = {
   }),
   /* REDUX */
   user: PropTypes.object.isRequired,
+  logout: PropTypes.func.isRequired,
+  sendErrorNotification: PropTypes.func.isRequired,
 };
 
 Sidebar.defaultProps = {

--- a/src/lib/components/backoffice/Sidebar/index.js
+++ b/src/lib/components/backoffice/Sidebar/index.js
@@ -1,3 +1,5 @@
+import { logout } from '@authentication/state/actions';
+import { addNotification } from '@components/Notifications';
 import { connect } from 'react-redux';
 import SidebarComponent from './Sidebar';
 
@@ -5,4 +7,13 @@ const mapStateToProps = state => ({
   user: state.authenticationManagement.data,
 });
 
-export const Sidebar = connect(mapStateToProps, null)(SidebarComponent);
+const mapDispatchToProps = dispatch => ({
+  sendErrorNotification: (title, content) =>
+    dispatch(addNotification(title, content, 'error')),
+  logout: () => dispatch(logout()),
+});
+
+export const Sidebar = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(SidebarComponent);

--- a/src/lib/components/backoffice/buttons/SeeAllButton/SeeAllButton.js
+++ b/src/lib/components/backoffice/buttons/SeeAllButton/SeeAllButton.js
@@ -7,7 +7,7 @@ export default class SeeAllButton extends Component {
   render() {
     const { fluid, disabled, to } = this.props;
     return (
-      <Button as={Link} to={to} size="tiny" disabled={disabled} fluid={fluid}>
+      <Button as={Link} to={to} size="small" disabled={disabled} fluid={fluid}>
         See all
       </Button>
     );

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -71,6 +71,7 @@ export const RECORDS_CONFIG = {
   ACQ_ORDERS: {
     maxShowOrderLines: 3,
     orderedValidStatuses: ['PENDING', 'ORDERED', 'RECEIVED'],
+    orderedStatuses: ['ORDERED'],
     statuses: ACQ_ORDER_STATUSES,
     search: {
       filters: [

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
@@ -12,7 +12,7 @@ import _get from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Header, Icon } from 'semantic-ui-react';
+import { Header, Icon, Label } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
 
 export class DocumentHeader extends Component {
@@ -34,9 +34,14 @@ export class DocumentHeader extends Component {
         {toShortDate(DateTime.fromISO(data.created))}
         <br />
         <RestrictedAccessLabel isRestricted={data.metadata.restricted} />
-        <Link to={FrontSiteRoutes.documentDetailsFor(data.metadata.pid)}>
-          public view <Icon name="linkify" />
-        </Link>
+        <Label
+          as={Link}
+          to={FrontSiteRoutes.documentDetailsFor(data.metadata.pid)}
+          color="grey"
+        >
+          <Icon name="linkify" />
+          View in Frontsite
+        </Label>
       </>
     );
     return (

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentItems/__snapshots__/DocumentItems.test.js.snap
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentItems/__snapshots__/DocumentItems.test.js.snap
@@ -1566,7 +1566,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1587,7 +1587,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1670,7 +1670,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1691,7 +1691,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1774,7 +1774,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1795,7 +1795,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1878,7 +1878,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1899,7 +1899,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1982,7 +1982,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -2003,7 +2003,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -2075,7 +2075,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                                       false,
                                                       false,
                                                     ],
-                                                    "className": "ui tiny button",
+                                                    "className": "ui small button",
                                                     "disabled": undefined,
                                                     "onClick": [Function],
                                                     "role": "button",
@@ -2108,7 +2108,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                         }
                                         disabled={false}
                                         fluid={false}
-                                        size="tiny"
+                                        size="small"
                                         to="/backoffice/items?q=document_pid:111"
                                       >
                                         <Ref
@@ -2126,7 +2126,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                                             }
                                           >
                                             <Link
-                                              className="ui tiny button"
+                                              className="ui small button"
                                               onClick={[Function]}
                                               role="button"
                                               to="/backoffice/items?q=document_pid:111"

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPendingLoans/__snapshots__/DocumentPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPendingLoans/__snapshots__/DocumentPendingLoans.test.js.snap
@@ -1308,7 +1308,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1329,7 +1329,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1457,7 +1457,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1478,7 +1478,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1606,7 +1606,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1627,7 +1627,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1755,7 +1755,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1776,7 +1776,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1904,7 +1904,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -1925,7 +1925,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                         false,
                                                         false,
                                                       ],
-                                                      "className": "ui tiny button",
+                                                      "className": "ui small button",
                                                       "disabled": undefined,
                                                       "onClick": [Function],
                                                       "role": "button",
@@ -2030,7 +2030,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                                       false,
                                                       false,
                                                     ],
-                                                    "className": "ui tiny button",
+                                                    "className": "ui small button",
                                                     "disabled": undefined,
                                                     "onClick": [Function],
                                                     "role": "button",
@@ -2075,7 +2075,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                         }
                                         disabled={false}
                                         fluid={false}
-                                        size="tiny"
+                                        size="small"
                                         to="/backoffice/loans?q=(document_pid:111 AND state:(PENDING))"
                                       >
                                         <Ref
@@ -2093,7 +2093,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                                             }
                                           >
                                             <Link
-                                              className="ui tiny button"
+                                              className="ui small button"
                                               onClick={[Function]}
                                               role="button"
                                               to="/backoffice/loans?q=(document_pid:111 AND state:(PENDING))"

--- a/src/lib/pages/backoffice/Home/reducer.js
+++ b/src/lib/pages/backoffice/Home/reducer.js
@@ -1,5 +1,7 @@
 export { default as loansCardReducer } from './widgets/LoansCard/state/reducer';
 export { default as documentCardReducer } from './widgets/DocumentCard/state/reducer';
+export { default as acquisitionCardReducer } from './widgets/ACQRequestsCard/state/reducer';
+export { default as illCardReducer } from './widgets/ILLCard/state/reducer';
 export { default as overbookedDocumentsReducer } from './lists/OverbookedDocumentsList/state/reducer';
 export { default as overdueLoansReducer } from './lists/OverdueLoansList/state/reducer';
 export { default as pendingOverdueDocumentsReducer } from './lists/PendingOverdueDocumentsList/state/reducer';

--- a/src/lib/pages/backoffice/Home/widgets/ACQRequestsCard/ACQRequestsCard.js
+++ b/src/lib/pages/backoffice/Home/widgets/ACQRequestsCard/ACQRequestsCard.js
@@ -1,3 +1,6 @@
+import { orderApi } from '@api/acquisition';
+import { invenioConfig } from '@config';
+import { AcquisitionRoutes } from '@routes/backoffice/AcquisitionUrls';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Loader } from '@components/Loader';
@@ -9,20 +12,27 @@ import { SeeAllButton } from '@components/backoffice/buttons/SeeAllButton';
 export default class ACQRequestsCard extends Component {
   constructor(props) {
     super(props);
-
-    // TODO when acquisition module
-    this.seeAllUrl = '';
-    this.newAcqURL = '';
+    this.seeAllUrl = AcquisitionRoutes.ordersListWithQuery;
+    this.newAcqURL = AcquisitionRoutes.orderCreate;
   }
 
-  componentDidMount() {}
+  componentDidMount() {
+    const { fetchOngoingAcqRequests } = this.props;
+    fetchOngoingAcqRequests();
+  }
 
   seeAllButton = () => {
-    return <SeeAllButton fluid disabled to={this.seeAllUrl} />;
+    const path = this.seeAllUrl(
+      orderApi
+        .query()
+        .withState(`(${invenioConfig.ACQ_ORDERS.orderedStatuses.join(' OR ')})`)
+        .qs()
+    );
+    return <SeeAllButton fluid to={path} />;
   };
 
   newAcqButton = () => {
-    return <NewButton fluid disabled to={this.newAcqURL} />;
+    return <NewButton fluid to={this.newAcqURL} />;
   };
 
   renderCard = data => {
@@ -48,8 +58,8 @@ export default class ACQRequestsCard extends Component {
 }
 
 ACQRequestsCard.propTypes = {
-  // fetchOngoingAcqRequests: PropTypes.func.isRequired,
   /* redux */
+  fetchOngoingAcqRequests: PropTypes.func.isRequired,
   data: PropTypes.number.isRequired,
   isLoading: PropTypes.bool.isRequired,
   error: PropTypes.object,

--- a/src/lib/pages/backoffice/Home/widgets/ACQRequestsCard/index.js
+++ b/src/lib/pages/backoffice/Home/widgets/ACQRequestsCard/index.js
@@ -1,1 +1,19 @@
-export { default as ACQRequestsCard } from './ACQRequestsCard';
+import { connect } from 'react-redux';
+import { fetchOngoingAcqRequests } from './state/actions';
+import ACQRequestsCardComponent from './ACQRequestsCard';
+
+const mapStateToProps = state => ({
+  data: state.acquisitionCard.data,
+  error: state.acquisitionCard.error,
+  isLoading: state.acquisitionCard.isLoading,
+  hasError: state.acquisitionCard.hasError,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchOngoingAcqRequests: () => dispatch(fetchOngoingAcqRequests()),
+});
+
+export const ACQRequestsCard = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ACQRequestsCardComponent);

--- a/src/lib/pages/backoffice/Home/widgets/ACQRequestsCard/state/actions.js
+++ b/src/lib/pages/backoffice/Home/widgets/ACQRequestsCard/state/actions.js
@@ -1,0 +1,37 @@
+import { orderApi } from '@api/acquisition';
+import { sendErrorNotification } from '@components/Notifications';
+import { invenioConfig } from '@config';
+
+export const IS_LOADING = 'fetchOngoingAcqRequests/IS_LOADING';
+export const SUCCESS = 'fetchOngoingAcqRequests/SUCCESS';
+export const HAS_ERROR = 'fetchOngoingAcqRequests/HAS_ERROR';
+
+export const fetchOngoingAcqRequests = () => {
+  return async dispatch => {
+    dispatch({
+      type: IS_LOADING,
+    });
+
+    try {
+      const response = await orderApi.count(
+        orderApi
+          .query()
+          .withState(
+            `(${invenioConfig.ACQ_ORDERS.orderedStatuses.join(' OR ')})`
+          )
+          .qs()
+      );
+
+      dispatch({
+        type: SUCCESS,
+        payload: response.data,
+      });
+    } catch (error) {
+      dispatch({
+        type: HAS_ERROR,
+        payload: error,
+      });
+      dispatch(sendErrorNotification(error));
+    }
+  };
+};

--- a/src/lib/pages/backoffice/Home/widgets/ACQRequestsCard/state/reducer.js
+++ b/src/lib/pages/backoffice/Home/widgets/ACQRequestsCard/state/reducer.js
@@ -1,0 +1,32 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './actions';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: 0,
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/lib/pages/backoffice/Home/widgets/DocumentCard/DocumentCard.js
+++ b/src/lib/pages/backoffice/Home/widgets/DocumentCard/DocumentCard.js
@@ -28,11 +28,11 @@ export default class DocumentCard extends Component {
         .withPendingLoans()
         .qs()
     );
-    return <SeeAllButton fluid disabled to={path} />;
+    return <SeeAllButton fluid to={path} />;
   };
 
   newDocumentButton = () => {
-    return <NewButton fluid disabled to={this.newDocumentURL} />;
+    return <NewButton fluid to={this.newDocumentURL} />;
   };
 
   render() {

--- a/src/lib/pages/backoffice/Home/widgets/DocumentCard/__snapshots__/DocumentsCard.test.js.snap
+++ b/src/lib/pages/backoffice/Home/widgets/DocumentCard/__snapshots__/DocumentsCard.test.js.snap
@@ -10,7 +10,7 @@ exports[`DocumentsCard tests should load the details component 1`] = `
     <RecordsBriefCard
       buttonLeft={
         <NewButton
-          disabled={true}
+          disabled={false}
           fluid={true}
           text="New"
           to="/backoffice/documents/create"
@@ -18,7 +18,7 @@ exports[`DocumentsCard tests should load the details component 1`] = `
       }
       buttonRight={
         <SeeAllButton
-          disabled={true}
+          disabled={false}
           fluid={true}
           to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
         />
@@ -66,7 +66,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
           <RecordsBriefCard
             buttonLeft={
               <NewButton
-                disabled={true}
+                disabled={false}
                 fluid={true}
                 text="New"
                 to="/backoffice/documents/create"
@@ -74,7 +74,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
             }
             buttonRight={
               <SeeAllButton
-                disabled={true}
+                disabled={false}
                 fluid={true}
                 to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
               />
@@ -114,18 +114,20 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                   <div
                     className="ui grid"
                   >
-                    <GridRow>
+                    <GridRow
+                      columns="equal"
+                    >
                       <div
-                        className="row"
+                        className="equal width row"
                       >
                         <GridColumn
-                          width={8}
+                          key="left"
                         >
                           <div
-                            className="eight wide column"
+                            className="column"
                           >
                             <NewButton
-                              disabled={true}
+                              disabled={false}
                               fluid={true}
                               text="New"
                               to="/backoffice/documents/create"
@@ -152,11 +154,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -180,11 +182,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -202,11 +204,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "innerRef",
@@ -223,11 +225,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "innerRef",
@@ -272,11 +274,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -300,11 +302,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -322,11 +324,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "onClick",
@@ -343,11 +345,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "onClick",
@@ -392,11 +394,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -420,11 +422,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -442,11 +444,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "replace",
@@ -463,11 +465,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "replace",
@@ -512,11 +514,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -540,11 +542,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -562,11 +564,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "target",
@@ -583,11 +585,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "target",
@@ -632,11 +634,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -660,11 +662,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -682,11 +684,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "to",
@@ -703,11 +705,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "to",
@@ -753,11 +755,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               false,
                                               false,
                                             ],
-                                            "className": "ui small fluid icon positive disabled left labeled button",
+                                            "className": "ui small fluid icon positive left labeled button",
                                             "disabled": undefined,
                                             "onClick": [Function],
                                             "role": "button",
-                                            "tabIndex": -1,
+                                            "tabIndex": undefined,
                                             "text": "New",
                                             "to": "/backoffice/documents/create",
                                           },
@@ -771,11 +773,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               false,
                                               false,
                                             ],
-                                            "className": "ui tiny fluid disabled button",
+                                            "className": "ui small fluid button",
                                             "disabled": undefined,
                                             "onClick": [Function],
                                             "role": "button",
-                                            "tabIndex": -1,
+                                            "tabIndex": undefined,
                                             "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                           },
                                           [Function],
@@ -794,7 +796,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                     },
                                   }
                                 }
-                                disabled={true}
+                                disabled={false}
                                 fluid={true}
                                 icon={true}
                                 labelPosition="left"
@@ -818,10 +820,9 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                     }
                                   >
                                     <Link
-                                      className="ui small fluid icon positive disabled left labeled button"
+                                      className="ui small fluid icon positive left labeled button"
                                       onClick={[Function]}
                                       role="button"
-                                      tabIndex={-1}
                                       text="New"
                                       to="/backoffice/documents/create"
                                     />
@@ -832,13 +833,13 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                           </div>
                         </GridColumn>
                         <GridColumn
-                          width={8}
+                          key="right"
                         >
                           <div
-                            className="eight wide column"
+                            className="column"
                           >
                             <SeeAllButton
-                              disabled={true}
+                              disabled={false}
                               fluid={true}
                               to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
                             >
@@ -864,11 +865,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -892,11 +893,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -914,11 +915,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "innerRef",
@@ -935,11 +936,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "innerRef",
@@ -984,11 +985,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -1012,11 +1013,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -1034,11 +1035,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "onClick",
@@ -1055,11 +1056,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "onClick",
@@ -1104,11 +1105,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -1132,11 +1133,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -1154,11 +1155,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "replace",
@@ -1175,11 +1176,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "replace",
@@ -1224,11 +1225,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -1252,11 +1253,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -1274,11 +1275,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "target",
@@ -1295,11 +1296,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "target",
@@ -1344,11 +1345,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -1372,11 +1373,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
+                                              "className": "ui small fluid icon positive left labeled button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "text": "New",
                                               "to": "/backoffice/documents/create",
                                             },
@@ -1394,11 +1395,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "to",
@@ -1415,11 +1416,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                             },
                                             "to",
@@ -1465,11 +1466,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               false,
                                               false,
                                             ],
-                                            "className": "ui small fluid icon positive disabled left labeled button",
+                                            "className": "ui small fluid icon positive left labeled button",
                                             "disabled": undefined,
                                             "onClick": [Function],
                                             "role": "button",
-                                            "tabIndex": -1,
+                                            "tabIndex": undefined,
                                             "text": "New",
                                             "to": "/backoffice/documents/create",
                                           },
@@ -1483,11 +1484,11 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               false,
                                               false,
                                             ],
-                                            "className": "ui tiny fluid disabled button",
+                                            "className": "ui small fluid button",
                                             "disabled": undefined,
                                             "onClick": [Function],
                                             "role": "button",
-                                            "tabIndex": -1,
+                                            "tabIndex": undefined,
                                             "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
                                           },
                                           [Function],
@@ -1506,9 +1507,9 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                     },
                                   }
                                 }
-                                disabled={true}
+                                disabled={false}
                                 fluid={true}
-                                size="tiny"
+                                size="small"
                                 to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
                               >
                                 <Ref
@@ -1526,10 +1527,9 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                     }
                                   >
                                     <Link
-                                      className="ui tiny fluid disabled button"
+                                      className="ui small fluid button"
                                       onClick={[Function]}
                                       role="button"
-                                      tabIndex={-1}
                                       to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
                                     />
                                   </RefForward>

--- a/src/lib/pages/backoffice/Home/widgets/ILLCard/ILLCard.js
+++ b/src/lib/pages/backoffice/Home/widgets/ILLCard/ILLCard.js
@@ -1,3 +1,6 @@
+import { borrowingRequestApi } from '@api/ill';
+import { invenioConfig } from '@config';
+import { ILLRoutes } from '@routes/urls';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Loader } from '@components/Loader';
@@ -9,21 +12,31 @@ import { SeeAllButton } from '@components/backoffice/buttons/SeeAllButton';
 export default class ILLCard extends Component {
   constructor(props) {
     super(props);
-
-    // TODO when acquisition module
-    this.seeAllUrl = '';
-    this.newILLUrl = '';
+    this.seeAllUrl = ILLRoutes.borrowingRequestListWithQuery;
+    this.newILLUrl = ILLRoutes.borrowingRequestCreate;
   }
 
-  componentDidMount() {}
+  componentDidMount() {
+    const { fetchOngoingILLRequests } = this.props;
+    fetchOngoingILLRequests();
+  }
 
   seeAllButton = () => {
-    // TODO when #155 solved
-    return <SeeAllButton fluid disabled to={this.seeAllUrl} />;
+    const path = this.seeAllUrl(
+      borrowingRequestApi
+        .query()
+        .withState(
+          `(${invenioConfig.ILL_BORROWING_REQUESTS.requestedStatuses.join(
+            ' OR '
+          )})`
+        )
+        .qs()
+    );
+    return <SeeAllButton fluid to={path} />;
   };
 
   newAcqButton = () => {
-    return <NewButton fluid disabled to={this.newILLUrl} />;
+    return <NewButton fluid to={this.newILLUrl} />;
   };
 
   renderCard = data => {
@@ -49,13 +62,12 @@ export default class ILLCard extends Component {
 }
 
 ILLCard.propTypes = {
-  // fetchOngoingILLRequests: PropTypes.func.isRequired,
+  fetchOngoingILLRequests: PropTypes.func.isRequired,
   data: PropTypes.number.isRequired,
-  isLoading: PropTypes.bool,
+  isLoading: PropTypes.bool.isRequired,
   error: PropTypes.object,
 };
 
 ILLCard.defaultProps = {
-  isLoading: false,
   error: {},
 };

--- a/src/lib/pages/backoffice/Home/widgets/ILLCard/index.js
+++ b/src/lib/pages/backoffice/Home/widgets/ILLCard/index.js
@@ -1,1 +1,19 @@
-export { default as ILLCard } from './ILLCard';
+import { connect } from 'react-redux';
+import { fetchOngoingILLRequests } from './state/actions';
+import ILLCardComponent from './ILLCard';
+
+const mapStateToProps = state => ({
+  data: state.illCard.data,
+  error: state.illCard.error,
+  isLoading: state.illCard.isLoading,
+  hasError: state.illCard.hasError,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchOngoingILLRequests: () => dispatch(fetchOngoingILLRequests()),
+});
+
+export const ILLCard = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ILLCardComponent);

--- a/src/lib/pages/backoffice/Home/widgets/ILLCard/state/actions.js
+++ b/src/lib/pages/backoffice/Home/widgets/ILLCard/state/actions.js
@@ -1,0 +1,40 @@
+import { borrowingRequestApi } from '@api/ill';
+import { sendErrorNotification } from '@components/Notifications';
+import { invenioConfig } from '@config';
+
+export const IS_LOADING = 'fetchOngoingILLRequests/IS_LOADING';
+export const SUCCESS = 'fetchOngoingILLRequests/SUCCESS';
+export const HAS_ERROR = 'fetchOngoingILLRequests/HAS_ERROR';
+
+export const fetchOngoingILLRequests = () => {
+  return async dispatch => {
+    dispatch({
+      type: IS_LOADING,
+    });
+
+    try {
+      const response = await borrowingRequestApi.count(
+        borrowingRequestApi
+          .query()
+          .withState(
+            `(${invenioConfig.ILL_BORROWING_REQUESTS.requestedStatuses.join(
+              ' OR '
+            )})`
+          )
+          .qs()
+      );
+
+      dispatch({
+        type: SUCCESS,
+        payload: response.data,
+      });
+    } catch (error) {
+      console.log(error);
+      dispatch({
+        type: HAS_ERROR,
+        payload: error,
+      });
+      dispatch(sendErrorNotification(error));
+    }
+  };
+};

--- a/src/lib/pages/backoffice/Home/widgets/ILLCard/state/reducer.js
+++ b/src/lib/pages/backoffice/Home/widgets/ILLCard/state/reducer.js
@@ -1,0 +1,32 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './actions';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: 0,
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/lib/pages/backoffice/Home/widgets/LoansCard/LoansCard.js
+++ b/src/lib/pages/backoffice/Home/widgets/LoansCard/LoansCard.js
@@ -6,7 +6,6 @@ import { invenioConfig } from '@config';
 import { loanApi } from '@api/loans';
 import { RecordsBriefCard } from '@components/backoffice/RecordsBriefCard';
 import { BackOfficeRoutes } from '@routes/urls';
-import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { SeeAllButton } from '@components/backoffice/buttons/SeeAllButton';
 
 export default class LoansCard extends Component {
@@ -27,11 +26,7 @@ export default class LoansCard extends Component {
         .withState(invenioConfig.CIRCULATION.loanRequestStates)
         .qs()
     );
-    return <SeeAllButton fluid disabled to={path} />;
-  };
-
-  newLoanButton = () => {
-    return <NewButton fluid disabled to="" />;
+    return <SeeAllButton fluid to={path} />;
   };
 
   renderCard = data => {
@@ -40,7 +35,7 @@ export default class LoansCard extends Component {
         title="Loans"
         stats={data}
         text="new requests"
-        buttonLeft={this.newLoanButton()}
+        buttonLeft={null}
         buttonRight={this.seeAllButton()}
       />
     );

--- a/src/lib/pages/backoffice/Home/widgets/LoansCard/__snapshots__/LoansCard.test.js.snap
+++ b/src/lib/pages/backoffice/Home/widgets/LoansCard/__snapshots__/LoansCard.test.js.snap
@@ -8,17 +8,10 @@ exports[`LoansCard tests should load the details component 1`] = `
     error={Object {}}
   >
     <RecordsBriefCard
-      buttonLeft={
-        <NewButton
-          disabled={true}
-          fluid={true}
-          text="New"
-          to=""
-        />
-      }
+      buttonLeft={null}
       buttonRight={
         <SeeAllButton
-          disabled={true}
+          disabled={false}
           fluid={true}
           to="/backoffice/loans?q=(state:(PENDING))"
         />
@@ -64,17 +57,10 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
           error={Object {}}
         >
           <RecordsBriefCard
-            buttonLeft={
-              <NewButton
-                disabled={true}
-                fluid={true}
-                text="New"
-                to=""
-              />
-            }
+            buttonLeft={null}
             buttonRight={
               <SeeAllButton
-                disabled={true}
+                disabled={false}
                 fluid={true}
                 to="/backoffice/loans?q=(state:(PENDING))"
               />
@@ -114,731 +100,20 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                   <div
                     className="ui grid"
                   >
-                    <GridRow>
+                    <GridRow
+                      columns="equal"
+                    >
                       <div
-                        className="row"
+                        className="equal width row"
                       >
                         <GridColumn
-                          width={8}
+                          key="right"
                         >
                           <div
-                            className="eight wide column"
-                          >
-                            <NewButton
-                              disabled={true}
-                              fluid={true}
-                              text="New"
-                              to=""
-                            >
-                              <Button
-                                as={
-                                  Object {
-                                    "$$typeof": Symbol(react.forward_ref),
-                                    "displayName": "Link",
-                                    "propTypes": Object {
-                                      "innerRef": [MockFunction] {
-                                        "calls": Array [
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "innerRef",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "innerRef",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "innerRef",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "innerRef",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                        ],
-                                        "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                        ],
-                                      },
-                                      "onClick": [MockFunction] {
-                                        "calls": Array [
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "onClick",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "onClick",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "onClick",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "onClick",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                        ],
-                                        "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                        ],
-                                      },
-                                      "replace": [MockFunction] {
-                                        "calls": Array [
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "replace",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "replace",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "replace",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "replace",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                        ],
-                                        "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                        ],
-                                      },
-                                      "target": [MockFunction] {
-                                        "calls": Array [
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "target",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "target",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "target",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "target",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                        ],
-                                        "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                        ],
-                                      },
-                                      "to": [MockFunction] {
-                                        "calls": Array [
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "to",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "to",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "to",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                "See all",
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui tiny fluid disabled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "to": "/backoffice/loans?q=(state:(PENDING))",
-                                            },
-                                            "to",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                        ],
-                                        "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                        ],
-                                      },
-                                    },
-                                    "render": [MockFunction] {
-                                      "calls": Array [
-                                        Array [
-                                          Object {
-                                            "aria-pressed": undefined,
-                                            "children": Array [
-                                              Array [
-                                                <Icon
-                                                  as="i"
-                                                  name="plus"
-                                                />,
-                                                "New",
-                                              ],
-                                              false,
-                                              false,
-                                            ],
-                                            "className": "ui small fluid icon positive disabled left labeled button",
-                                            "disabled": undefined,
-                                            "onClick": [Function],
-                                            "role": "button",
-                                            "tabIndex": -1,
-                                            "text": "New",
-                                            "to": "",
-                                          },
-                                          [Function],
-                                        ],
-                                        Array [
-                                          Object {
-                                            "aria-pressed": undefined,
-                                            "children": Array [
-                                              "See all",
-                                              false,
-                                              false,
-                                            ],
-                                            "className": "ui tiny fluid disabled button",
-                                            "disabled": undefined,
-                                            "onClick": [Function],
-                                            "role": "button",
-                                            "tabIndex": -1,
-                                            "to": "/backoffice/loans?q=(state:(PENDING))",
-                                          },
-                                          [Function],
-                                        ],
-                                      ],
-                                      "results": Array [
-                                        Object {
-                                          "type": "return",
-                                          "value": undefined,
-                                        },
-                                        Object {
-                                          "type": "return",
-                                          "value": undefined,
-                                        },
-                                      ],
-                                    },
-                                  }
-                                }
-                                disabled={true}
-                                fluid={true}
-                                icon={true}
-                                labelPosition="left"
-                                positive={true}
-                                size="small"
-                                text="New"
-                                to=""
-                              >
-                                <Ref
-                                  innerRef={
-                                    Object {
-                                      "current": null,
-                                    }
-                                  }
-                                >
-                                  <RefForward
-                                    innerRef={
-                                      Object {
-                                        "current": null,
-                                      }
-                                    }
-                                  >
-                                    <Link
-                                      className="ui small fluid icon positive disabled left labeled button"
-                                      onClick={[Function]}
-                                      role="button"
-                                      tabIndex={-1}
-                                      text="New"
-                                      to=""
-                                    />
-                                  </RefForward>
-                                </Ref>
-                              </Button>
-                            </NewButton>
-                          </div>
-                        </GridColumn>
-                        <GridColumn
-                          width={8}
-                        >
-                          <div
-                            className="eight wide column"
+                            className="column"
                           >
                             <SeeAllButton
-                              disabled={true}
+                              disabled={false}
                               fluid={true}
                               to="/backoffice/loans?q=(state:(PENDING))"
                             >
@@ -854,71 +129,15 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                             Object {
                                               "aria-pressed": undefined,
                                               "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "innerRef",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "innerRef",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
                                                 "See all",
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "innerRef",
@@ -935,11 +154,11 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "innerRef",
@@ -950,14 +169,6 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                           ],
                                         ],
                                         "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
                                           Object {
                                             "type": "return",
                                             "value": undefined,
@@ -974,71 +185,15 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                             Object {
                                               "aria-pressed": undefined,
                                               "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "onClick",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "onClick",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
                                                 "See all",
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "onClick",
@@ -1055,11 +210,11 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "onClick",
@@ -1070,14 +225,6 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                           ],
                                         ],
                                         "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
                                           Object {
                                             "type": "return",
                                             "value": undefined,
@@ -1094,71 +241,15 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                             Object {
                                               "aria-pressed": undefined,
                                               "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "replace",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "replace",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
                                                 "See all",
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "replace",
@@ -1175,11 +266,11 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "replace",
@@ -1190,14 +281,6 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                           ],
                                         ],
                                         "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
                                           Object {
                                             "type": "return",
                                             "value": undefined,
@@ -1214,71 +297,15 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                             Object {
                                               "aria-pressed": undefined,
                                               "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "target",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "target",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
                                                 "See all",
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "target",
@@ -1295,11 +322,11 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "target",
@@ -1310,14 +337,6 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                           ],
                                         ],
                                         "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
                                           Object {
                                             "type": "return",
                                             "value": undefined,
@@ -1334,71 +353,15 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                             Object {
                                               "aria-pressed": undefined,
                                               "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "to",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
-                                                Array [
-                                                  <Icon
-                                                    as="i"
-                                                    name="plus"
-                                                  />,
-                                                  "New",
-                                                ],
-                                                false,
-                                                false,
-                                              ],
-                                              "className": "ui small fluid icon positive disabled left labeled button",
-                                              "disabled": undefined,
-                                              "onClick": [Function],
-                                              "role": "button",
-                                              "tabIndex": -1,
-                                              "text": "New",
-                                              "to": "",
-                                            },
-                                            "to",
-                                            "Link",
-                                            "prop",
-                                            null,
-                                            "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
-                                          ],
-                                          Array [
-                                            Object {
-                                              "aria-pressed": undefined,
-                                              "children": Array [
                                                 "See all",
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "to",
@@ -1415,11 +378,11 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                                 false,
                                                 false,
                                               ],
-                                              "className": "ui tiny fluid disabled button",
+                                              "className": "ui small fluid button",
                                               "disabled": undefined,
                                               "onClick": [Function],
                                               "role": "button",
-                                              "tabIndex": -1,
+                                              "tabIndex": undefined,
                                               "to": "/backoffice/loans?q=(state:(PENDING))",
                                             },
                                             "to",
@@ -1430,14 +393,6 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                           ],
                                         ],
                                         "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
-                                          Object {
-                                            "type": "return",
-                                            "value": undefined,
-                                          },
                                           Object {
                                             "type": "return",
                                             "value": undefined,
@@ -1455,39 +410,15 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                           Object {
                                             "aria-pressed": undefined,
                                             "children": Array [
-                                              Array [
-                                                <Icon
-                                                  as="i"
-                                                  name="plus"
-                                                />,
-                                                "New",
-                                              ],
-                                              false,
-                                              false,
-                                            ],
-                                            "className": "ui small fluid icon positive disabled left labeled button",
-                                            "disabled": undefined,
-                                            "onClick": [Function],
-                                            "role": "button",
-                                            "tabIndex": -1,
-                                            "text": "New",
-                                            "to": "",
-                                          },
-                                          [Function],
-                                        ],
-                                        Array [
-                                          Object {
-                                            "aria-pressed": undefined,
-                                            "children": Array [
                                               "See all",
                                               false,
                                               false,
                                             ],
-                                            "className": "ui tiny fluid disabled button",
+                                            "className": "ui small fluid button",
                                             "disabled": undefined,
                                             "onClick": [Function],
                                             "role": "button",
-                                            "tabIndex": -1,
+                                            "tabIndex": undefined,
                                             "to": "/backoffice/loans?q=(state:(PENDING))",
                                           },
                                           [Function],
@@ -1498,17 +429,13 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                           "type": "return",
                                           "value": undefined,
                                         },
-                                        Object {
-                                          "type": "return",
-                                          "value": undefined,
-                                        },
                                       ],
                                     },
                                   }
                                 }
-                                disabled={true}
+                                disabled={false}
                                 fluid={true}
-                                size="tiny"
+                                size="small"
                                 to="/backoffice/loans?q=(state:(PENDING))"
                               >
                                 <Ref
@@ -1526,10 +453,9 @@ exports[`LoansCard tests should render stats with 2 records 1`] = `
                                     }
                                   >
                                     <Link
-                                      className="ui tiny fluid disabled button"
+                                      className="ui small fluid button"
                                       onClick={[Function]}
                                       role="button"
-                                      tabIndex={-1}
                                       to="/backoffice/loans?q=(state:(PENDING))"
                                     />
                                   </RefForward>

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
@@ -2292,14 +2292,14 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                             }
                                             disabled={false}
                                             fluid={false}
-                                            size="tiny"
+                                            size="small"
                                             to="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(PENDING OR REQUESTED OR ON_LOAN))"
                                           >
                                             <Ref
                                               innerRef={
                                                 Object {
                                                   "current": <a
-                                                    class="ui tiny button"
+                                                    class="ui small button"
                                                     href="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(PENDING OR REQUESTED OR ON_LOAN))"
                                                     role="button"
                                                   >
@@ -2312,7 +2312,7 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                                 innerRef={
                                                   Object {
                                                     "current": <a
-                                                      class="ui tiny button"
+                                                      class="ui small button"
                                                       href="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(PENDING OR REQUESTED OR ON_LOAN))"
                                                       role="button"
                                                     >
@@ -2322,20 +2322,20 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                                 }
                                               >
                                                 <Link
-                                                  className="ui tiny button"
+                                                  className="ui small button"
                                                   onClick={[Function]}
                                                   role="button"
                                                   to="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(PENDING OR REQUESTED OR ON_LOAN))"
                                                 >
                                                   <LinkAnchor
-                                                    className="ui tiny button"
+                                                    className="ui small button"
                                                     href="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(PENDING OR REQUESTED OR ON_LOAN))"
                                                     navigate={[Function]}
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
                                                     <a
-                                                      className="ui tiny button"
+                                                      className="ui small button"
                                                       href="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(PENDING OR REQUESTED OR ON_LOAN))"
                                                       onClick={[Function]}
                                                       role="button"

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentLoans/__snapshots__/PatronCurrentLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentLoans/__snapshots__/PatronCurrentLoans.test.js.snap
@@ -1444,14 +1444,14 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                             }
                                             disabled={false}
                                             fluid={false}
-                                            size="tiny"
+                                            size="small"
                                             to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
                                           >
                                             <Ref
                                               innerRef={
                                                 Object {
                                                   "current": <a
-                                                    class="ui tiny button"
+                                                    class="ui small button"
                                                     href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
                                                     role="button"
                                                   >
@@ -1464,7 +1464,7 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                                 innerRef={
                                                   Object {
                                                     "current": <a
-                                                      class="ui tiny button"
+                                                      class="ui small button"
                                                       href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
                                                       role="button"
                                                     >
@@ -1474,20 +1474,20 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                                 }
                                               >
                                                 <Link
-                                                  className="ui tiny button"
+                                                  className="ui small button"
                                                   onClick={[Function]}
                                                   role="button"
                                                   to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
                                                 >
                                                   <LinkAnchor
-                                                    className="ui tiny button"
+                                                    className="ui small button"
                                                     href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
                                                     navigate={[Function]}
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
                                                     <a
-                                                      className="ui tiny button"
+                                                      className="ui small button"
                                                       href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
                                                       onClick={[Function]}
                                                       role="button"

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronDocumentRequests/__snapshots__/PatronDocumentRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronDocumentRequests/__snapshots__/PatronDocumentRequests.test.js.snap
@@ -1406,14 +1406,14 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                                             }
                                             disabled={false}
                                             fluid={false}
-                                            size="tiny"
+                                            size="small"
                                             to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
                                           >
                                             <Ref
                                               innerRef={
                                                 Object {
                                                   "current": <a
-                                                    class="ui tiny button"
+                                                    class="ui small button"
                                                     href="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
                                                     role="button"
                                                   >
@@ -1426,7 +1426,7 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                                                 innerRef={
                                                   Object {
                                                     "current": <a
-                                                      class="ui tiny button"
+                                                      class="ui small button"
                                                       href="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
                                                       role="button"
                                                     >
@@ -1436,20 +1436,20 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                                                 }
                                               >
                                                 <Link
-                                                  className="ui tiny button"
+                                                  className="ui small button"
                                                   onClick={[Function]}
                                                   role="button"
                                                   to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
                                                 >
                                                   <LinkAnchor
-                                                    className="ui tiny button"
+                                                    className="ui small button"
                                                     href="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
                                                     navigate={[Function]}
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
                                                     <a
-                                                      className="ui tiny button"
+                                                      className="ui small button"
                                                       href="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
                                                       onClick={[Function]}
                                                       role="button"

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
@@ -2072,14 +2072,14 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                                             }
                                             disabled={false}
                                             fluid={false}
-                                            size="tiny"
+                                            size="small"
                                             to="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(CANCELLED OR RETURNED))"
                                           >
                                             <Ref
                                               innerRef={
                                                 Object {
                                                   "current": <a
-                                                    class="ui tiny button"
+                                                    class="ui small button"
                                                     href="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(CANCELLED OR RETURNED))"
                                                     role="button"
                                                   >
@@ -2092,7 +2092,7 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                                                 innerRef={
                                                   Object {
                                                     "current": <a
-                                                      class="ui tiny button"
+                                                      class="ui small button"
                                                       href="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(CANCELLED OR RETURNED))"
                                                       role="button"
                                                     >
@@ -2102,20 +2102,20 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                                                 }
                                               >
                                                 <Link
-                                                  className="ui tiny button"
+                                                  className="ui small button"
                                                   onClick={[Function]}
                                                   role="button"
                                                   to="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(CANCELLED OR RETURNED))"
                                                 >
                                                   <LinkAnchor
-                                                    className="ui tiny button"
+                                                    className="ui small button"
                                                     href="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(CANCELLED OR RETURNED))"
                                                     navigate={[Function]}
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
                                                     <a
-                                                      className="ui tiny button"
+                                                      className="ui small button"
                                                       href="/backoffice/ill/borrowing-requests?q=(patron_pid:2 AND status:(CANCELLED OR RETURNED))"
                                                       onClick={[Function]}
                                                       role="button"

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
@@ -1767,14 +1767,14 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                                             }
                                             disabled={false}
                                             fluid={false}
-                                            size="tiny"
+                                            size="small"
                                             to="/backoffice/loans?q=(patron_pid:2 AND state:(PENDING))"
                                           >
                                             <Ref
                                               innerRef={
                                                 Object {
                                                   "current": <a
-                                                    class="ui tiny button"
+                                                    class="ui small button"
                                                     href="/backoffice/loans?q=(patron_pid:2 AND state:(PENDING))"
                                                     role="button"
                                                   >
@@ -1787,7 +1787,7 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                                                 innerRef={
                                                   Object {
                                                     "current": <a
-                                                      class="ui tiny button"
+                                                      class="ui small button"
                                                       href="/backoffice/loans?q=(patron_pid:2 AND state:(PENDING))"
                                                       role="button"
                                                     >
@@ -1797,20 +1797,20 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                                                 }
                                               >
                                                 <Link
-                                                  className="ui tiny button"
+                                                  className="ui small button"
                                                   onClick={[Function]}
                                                   role="button"
                                                   to="/backoffice/loans?q=(patron_pid:2 AND state:(PENDING))"
                                                 >
                                                   <LinkAnchor
-                                                    className="ui tiny button"
+                                                    className="ui small button"
                                                     href="/backoffice/loans?q=(patron_pid:2 AND state:(PENDING))"
                                                     navigate={[Function]}
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
                                                     <a
-                                                      className="ui tiny button"
+                                                      className="ui small button"
                                                       href="/backoffice/loans?q=(patron_pid:2 AND state:(PENDING))"
                                                       onClick={[Function]}
                                                       role="button"

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesHeader.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesHeader.js
@@ -11,7 +11,7 @@ import _get from 'lodash/get';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Header, Icon } from 'semantic-ui-react';
+import { Header, Icon, Label } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
 
 export class SeriesHeader extends Component {
@@ -32,9 +32,14 @@ export class SeriesHeader extends Component {
         <label className="muted">Created on</label>{' '}
         {toShortDate(DateTime.fromISO(data.created))}
         <br />
-        <Link to={FrontSiteRoutes.seriesDetailsFor(data.metadata.pid)}>
-          public view <Icon name="linkify" />
-        </Link>
+        <Label
+          as={Link}
+          to={FrontSiteRoutes.seriesDetailsFor(data.metadata.pid)}
+          color="grey"
+        >
+          <Icon name="linkify" />
+          View in Frontsite
+        </Label>
       </>
     );
     return (

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Overridable from 'react-overridable';
 import { Link } from 'react-router-dom';
-import { Container, Grid, Icon, Responsive } from 'semantic-ui-react';
+import { Container, Grid, Icon, Label, Responsive } from 'semantic-ui-react';
 import { DocumentItems } from './DocumentItems';
 import { DocumentMetadata } from './DocumentMetadata';
 import DocumentPanel from './DocumentPanel/DocumentPanel';
@@ -55,13 +55,16 @@ const DocumentDetailsLayout = ({ error, isLoading, documentDetails }) => {
                 <AuthenticationGuard
                   silent
                   authorizedComponent={() => (
-                    <Link
+                    <Label
+                      as={Link}
                       to={BackOfficeRoutes.documentDetailsFor(
                         documentDetails.metadata.pid
                       )}
+                      color="grey"
                     >
-                      open in backoffice <Icon name="cogs" />
-                    </Link>
+                      <Icon name="cogs" />
+                      Open in Backoffice
+                    </Label>
                   )}
                   roles={['admin', 'librarian']}
                   loginComponent={() => null}

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Overridable from 'react-overridable';
 import { Link } from 'react-router-dom';
-import { Container, Grid, Icon, Responsive } from 'semantic-ui-react';
+import { Container, Grid, Icon, Label, Responsive } from 'semantic-ui-react';
 import { SeriesMetadata } from './SeriesMetadata';
 import SeriesPanel from './SeriesPanel/SeriesPanel';
 import { NotFound } from '@components/HttpErrors';
@@ -43,16 +43,19 @@ const SeriesDetailsLayout = ({ error, isLoading, series }) => {
                   <AuthenticationGuard
                     silent
                     authorizedComponent={() => (
-                      <Link
+                      <Label
+                        as={Link}
                         to={BackOfficeRoutes.seriesDetailsFor(
                           series.metadata.pid
                         )}
+                        color="grey"
                       >
-                        open in backoffice <Icon name="cogs" />
-                      </Link>
+                        <Icon name="cogs" />
+                        Open in Backoffice
+                      </Label>
                     )}
                     roles={['admin', 'librarian']}
-                    loginComponent={() => <></>}
+                    loginComponent={() => null}
                   />
                 )}
               </Grid.Column>

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -27,8 +27,10 @@ import { documentRequestDetailsReducer } from '@pages/backoffice/DocumentRequest
 import { eitemDetailsFileReducer } from '@pages/backoffice/EItem/EItemDetails/File/reducer';
 import { eitemDetailsReducer } from '@pages/backoffice/EItem/EItemDetails/reducer';
 import {
+  acquisitionCardReducer,
   documentCardReducer,
   idleLoansReducer,
+  illCardReducer,
   loansCardReducer,
   overbookedDocumentsReducer,
   overdueLoansReducer,
@@ -97,6 +99,8 @@ const rootReducer = combineReducers({
   /* backoffice */
   loansCard: loansCardReducer,
   documentCard: documentCardReducer,
+  acquisitionCard: acquisitionCardReducer,
+  illCard: illCardReducer,
   overbookedDocuments: overbookedDocumentsReducer,
   overdueLoans: overdueLoansReducer,
   pendingOverdueDocuments: pendingOverdueDocumentsReducer,

--- a/src/semantic-ui/site/collections/menu.overrides
+++ b/src/semantic-ui/site/collections/menu.overrides
@@ -135,6 +135,20 @@ Menu Overrides - REACT-INVENIO-APP-ILS
           font-size: 1em;
         }
       }
+
+      &.bo-menu-subheader {
+        margin-top: 0;
+        margin-bottom: 1.2em;
+
+        .item {
+          margin: 0;
+          padding: 0.5em 0;
+        }
+      }
+
+      &.bo-menu-footer {
+        margin-top: -1.2em;
+      }
     }
   }
 

--- a/src/semantic-ui/site/elements/header.overrides
+++ b/src/semantic-ui/site/elements/header.overrides
@@ -89,7 +89,7 @@ Header Overrides - REACT-INVENIO-APP-ILS
     }
     &.bo-menu-header {
       margin-top: 1em;
-      margin-bottom: 2em;
+      margin-bottom: 0em;
 
       .icon {
         font-size: 2em;


### PR DESCRIPTION
* sidebar: move homepage to the top, add logout (closes #175), fix footer styling
* make literature backoffice links more visible, changed the displayed text
* completed the overview cards
* changed the "See all" button size to match "New"
* closes #86

![Screenshot from 2020-10-12 11-40-23](https://user-images.githubusercontent.com/9027075/95731477-dcd10d80-0c7f-11eb-9ee3-a1499659af89.png)

![Screenshot from 2020-10-12 10-16-05](https://user-images.githubusercontent.com/9027075/95731456-d6429600-0c7f-11eb-9495-4261a44334b1.png)

![Screenshot from 2020-10-12 10-21-01](https://user-images.githubusercontent.com/9027075/95731468-d8a4f000-0c7f-11eb-8a8b-8a4b31f1251b.png)

![Screenshot from 2020-10-12 11-40-35](https://user-images.githubusercontent.com/9027075/95731486-dfcbfe00-0c7f-11eb-9014-685a9f845f22.png)
