### PR TITLE
global: add params to emails and improve button

### DIFF
--- a/src/lib/components/EmailLink/EmailLink.js
+++ b/src/lib/components/EmailLink/EmailLink.js
@@ -13,12 +13,12 @@ export const EmailLink = ({
   ...buttonUIProps
 }) => {
   const params = [];
-  if (bcc) params.push(`bcc=${bcc}`);
-  if (body) params.push(`body=${body}`);
-  if (cc) params.push(`cc=${cc}`);
-  if (subject) params.push(`subject=${subject}`);
+  if (bcc) params.push(`bcc=${encodeURIComponent(bcc)}`);
+  if (body) params.push(`body=${encodeURIComponent(body)}`);
+  if (cc) params.push(`cc=${encodeURIComponent(cc)}`);
+  if (subject) params.push(`subject=${encodeURIComponent(subject)}`);
 
-  const url = params.length > 0 ? email + '?' : email;
+  const url = params.length > 0 ? email + '?' + params : email;
 
   return asButton ? (
     <Button as="a" href={`mailto:${url}`} {...buttonUIProps}>

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -38,6 +38,8 @@ export const APP_CONFIG = {
     { name: 'contact', route: '/contact', apiURL: '2' },
   ],
   supportEmail: 'info@inveniosoftware.org',
+  emailSubjectPrefix: 'InvenioILS',
+  emailFooter: 'Kind regards,\nInvenioILS',
   environments: [
     {
       name: 'development',

--- a/src/lib/pages/backoffice/Acquisition/Vendor/VendorDetails/VendorInformation.js
+++ b/src/lib/pages/backoffice/Acquisition/Vendor/VendorDetails/VendorInformation.js
@@ -4,17 +4,21 @@ import { EmailLink } from '@components/EmailLink';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Grid } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export class VendorInformation extends React.Component {
   render() {
     const { vendor } = this.props;
+
+    const emailBody = `${vendor.name}, \n\n\n ${invenioConfig.APP.emailFooter}`;
+
     const leftTable = [
       { name: 'Name', value: vendor.name },
       {
         name: 'Email',
         value: (
           <span>
-            <EmailLink email={vendor.email} />{' '}
+            <EmailLink email={vendor.email} body={emailBody} />{' '}
             <CopyButton text={vendor.email} />
           </span>
         ),

--- a/src/lib/pages/backoffice/ILL/Library/LibraryDetails/LibraryInformation.js
+++ b/src/lib/pages/backoffice/ILL/Library/LibraryDetails/LibraryInformation.js
@@ -4,17 +4,21 @@ import { EmailLink } from '@components/EmailLink';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Grid } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export class LibraryInformation extends React.Component {
   render() {
     const { library } = this.props;
+
+    const emailBody = `${library.name}, \n\n\n ${invenioConfig.APP.emailFooter}`;
+
     const leftTable = [
       { name: 'Name', value: library.name },
       {
         name: 'Email',
         value: (
           <span>
-            <EmailLink email={library.email} />{' '}
+            <EmailLink email={library.email} body={emailBody} />{' '}
             <CopyButton text={library.email} />
           </span>
         ),

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemCirculation/ItemCirculation.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemCirculation/ItemCirculation.js
@@ -23,7 +23,10 @@ import {
 
 class ItemStatusMessageOnLoan extends Component {
   render() {
-    const { circulation } = this.props;
+    const { circulation, title } = this.props;
+
+    const emailBody = `${circulation.patron.name}, \n\n "${title}" \n\n\n${invenioConfig.APP.emailFooter}`;
+    const emailSubject = `${invenioConfig.APP.emailSubjectPrefix} - "${title}"`;
 
     const patron = [
       {
@@ -39,12 +42,17 @@ class ItemStatusMessageOnLoan extends Component {
             </Link>{' '}
             <EmailLink
               email={circulation.patron.email}
+              body={emailBody}
+              subject={emailSubject}
               asButton
-              size="mini"
-              basic
+              icon
+              size="small"
+              compact
               labelPosition="left"
               className="ml-10"
-            />
+            >
+              Send email
+            </EmailLink>
           </>
         ),
       },
@@ -87,6 +95,7 @@ class ItemStatusMessageOnLoan extends Component {
 
 ItemStatusMessageOnLoan.propTypes = {
   circulation: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 class ItemStatusMessageNotOnLoan extends Component {
@@ -151,7 +160,10 @@ export default class ItemCirculation extends Component {
 
     const circulationState = _get(metadata, 'circulation.state');
     const cmpItemStatusMessage = this.hasActiveLoan(circulationState) ? (
-      <ItemStatusMessageOnLoan circulation={metadata.circulation} />
+      <ItemStatusMessageOnLoan
+        circulation={metadata.circulation}
+        title={metadata.document.title}
+      />
     ) : (
       <ItemStatusMessageNotOnLoan status={metadata.status} />
     );

--- a/src/lib/pages/backoffice/Location/LocationDetails/LocationInformation.js
+++ b/src/lib/pages/backoffice/Location/LocationDetails/LocationInformation.js
@@ -4,17 +4,21 @@ import { EmailLink } from '@components/EmailLink';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Grid } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export class LocationInformation extends React.Component {
   render() {
     const { location } = this.props;
+
+    const emailBody = `${location.name}, \n\n\n ${invenioConfig.APP.emailFooter}`;
+
     const leftTable = [
       { name: 'Name', value: location.name },
       {
         name: 'Email',
         value: (
           <span>
-            <EmailLink email={location.email} />{' '}
+            <EmailLink email={location.email} body={emailBody} />{' '}
             <CopyButton text={location.email} />
           </span>
         ),

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronHeader/PatronHeader.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronHeader/PatronHeader.js
@@ -3,7 +3,9 @@ import { DetailsHeader } from '@components/backoffice/DetailsHeader';
 import { PatronIcon } from '@components/backoffice/icons';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { EmailLink } from '@components/EmailLink';
 import { Header } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export default class PatronHeader extends Component {
   render() {
@@ -16,11 +18,16 @@ export default class PatronHeader extends Component {
       </>
     );
 
+    const emailBody = `${data.metadata.name}, \n\n\n${invenioConfig.APP.emailFooter}`;
+
     return (
       <DetailsHeader
         title={
           <>
-            <Header.Subheader>{data.metadata.email}</Header.Subheader>
+            <Header.Subheader>
+              <EmailLink email={data.metadata.email} body={emailBody} />{' '}
+              <CopyButton text={data.metadata.email} />
+            </Header.Subheader>
             {data.metadata.name}
           </>
         }

--- a/src/lib/pages/backoffice/Patron/PatronSearch/PatronResultsList.js
+++ b/src/lib/pages/backoffice/Patron/PatronSearch/PatronResultsList.js
@@ -5,6 +5,7 @@ import { BackOfficeRoutes } from '@routes/backoffice/backofficeUrls';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import React from 'react';
+import { invenioConfig } from '@config';
 
 const ViewDetails = ({ row }) => {
   // NOTE: patrons have id in their metadata not pid.
@@ -25,9 +26,11 @@ ViewDetails.propTypes = {
 };
 
 const MailTo = ({ row }) => {
+  const emailBody = `${row.metadata.name}, \n\n\n${invenioConfig.APP.emailFooter}`;
+
   return (
     <>
-      <EmailLink email={row.metadata.email} />{' '}
+      <EmailLink email={row.metadata.email} body={emailBody} />{' '}
       <CopyButton text={row.metadata.email} />
     </>
   );


### PR DESCRIPTION
Closes #82

Display only names (patron, vendor, library etc.) and signature in mails because librarians might use another language for their emails.

Email button:
![Selection_031](https://user-images.githubusercontent.com/33685068/95837922-77455580-0d41-11eb-9020-2c6320f8321e.png)
