### PR TITLE
global: change sort config

### DIFF
--- a/src/lib/api/documentRequests/documentRequest.js
+++ b/src/lib/api/documentRequests/documentRequest.js
@@ -1,8 +1,8 @@
-import { http, apiConfig } from '@api/base';
-import { serializer } from './serializer';
+import { apiConfig, http } from '@api/base';
 import { prepareSumQuery } from '@api/utils';
 import _isEmpty from 'lodash/isEmpty';
 import { generatePath } from 'react-router-dom';
+import { serializer } from './serializer';
 
 const documentRequestURL = '/document-requests/';
 const apiPaths = {
@@ -115,7 +115,7 @@ class QueryBuilder {
   }
 
   sortByNewest() {
-    this.sortBy = `&sort=-mostrecent`;
+    this.sortBy = `&sort=-created`;
     return this;
   }
 

--- a/src/lib/api/documents/document.js
+++ b/src/lib/api/documents/document.js
@@ -79,7 +79,9 @@ class QueryBuilder {
   }
 
   withAvailableItems() {
-    this.availableItemsQuery.push('circulation.has_items_for_loan:>0');
+    this.availableItemsQuery.push(
+      'circulation.available_items_for_loan_count:>0'
+    );
     return this;
   }
 
@@ -132,7 +134,7 @@ class QueryBuilder {
 
   pendingOverdue() {
     const query = [
-      'circulation.has_items_for_loan:0',
+      'circulation.available_items_for_loan_count:0',
       'circulation.pending_loans:>0',
       'circulation.overdue_loans:>0',
       'items.total:>0',

--- a/src/lib/api/documents/document.test.js
+++ b/src/lib/api/documents/document.test.js
@@ -30,7 +30,7 @@ describe('Document query builder tests', () => {
       .query()
       .withAvailableItems()
       .qs();
-    expect(query).toEqual('circulation.has_items_for_loan:>0');
+    expect(query).toEqual('circulation.available_items_for_loan_count:>0');
   });
 
   it('should build the query string for documents with items available for loan and pending loans stats', () => {
@@ -40,7 +40,7 @@ describe('Document query builder tests', () => {
       .withPendingLoans()
       .qs();
     expect(query).toEqual(
-      'circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0'
+      'circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0'
     );
   });
 

--- a/src/lib/api/loans/loan.js
+++ b/src/lib/api/loans/loan.js
@@ -230,7 +230,7 @@ class QueryBuilder {
   }
 
   sortByNewest() {
-    this.sortBy = `&sort=-mostrecent`;
+    this.sortBy = `&sort=-created`;
     return this;
   }
 

--- a/src/lib/components/backoffice/ExportSearchResults/ExportSearchResults.js
+++ b/src/lib/components/backoffice/ExportSearchResults/ExportSearchResults.js
@@ -1,12 +1,12 @@
-import React, { Component } from 'react';
+import { invenioConfig } from '@config';
 import PropTypes from 'prop-types';
 import Qs from 'qs';
-import { Button, Popup, Dropdown, Menu, Icon } from 'semantic-ui-react';
+import React, { Component } from 'react';
 import {
   InvenioRequestSerializer,
   withState as withSearchState,
 } from 'react-searchkit';
-import { invenioConfig } from '@config';
+import { Button, Dropdown, Icon, Menu, Popup } from 'semantic-ui-react';
 
 /** Simple component rendering a small dialog to choose format of results to export. */
 class ExportDialog extends Component {
@@ -68,7 +68,7 @@ class ExportDialog extends Component {
         </div>
         <br />
         <div>
-          <span>Only the first {max} results will be exported.</span>
+          <span>Export is limited to the first {max} results.</span>
         </div>
         <br />
         <div style={{ textAlign: 'center' }}>

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -117,8 +117,8 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'mostrecent',
-          sortOrder: 'asc',
+          sortBy: 'created',
+          sortOrder: 'desc',
           text: 'Recently added',
         },
         {
@@ -129,27 +129,15 @@ export const RECORDS_CONFIG = {
         },
         {
           order: 3,
-          sortBy: 'grand_total',
-          sortOrder: 'desc',
-          text: `Total (${DEFAULT_CURRENCY})`,
-        },
-        {
-          order: 4,
-          sortBy: 'received_date',
-          sortOrder: 'desc',
-          text: 'Received date',
-        },
-        {
-          order: 5,
           sortBy: 'expected_delivery_date',
           sortOrder: 'desc',
           text: 'Expected delivery date',
         },
         {
-          order: 6,
-          sortBy: 'bestmatch',
-          sortOrder: 'asc',
-          text: 'Best match',
+          order: 4,
+          sortBy: 'grand_total',
+          sortOrder: 'desc',
+          text: `Total (${DEFAULT_CURRENCY})`,
         },
       ],
       defaultPage: 1,
@@ -165,7 +153,7 @@ export const RECORDS_CONFIG = {
           order: 1,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
         {
           order: 2,
@@ -246,7 +234,7 @@ export const RECORDS_CONFIG = {
         },
         {
           title: 'Availability',
-          field: 'circulation.has_items_for_loan',
+          field: 'circulation.available_items_for_loan_count',
           aggName: 'availability',
         },
         {
@@ -274,39 +262,39 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'mostrecent',
-          sortOrder: 'asc',
+          sortBy: 'created',
+          sortOrder: 'desc',
           text: 'Recently added',
         },
         {
           order: 2,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
         {
           order: 3,
-          sortBy: 'available_items',
-          sortOrder: 'asc',
+          sortBy: 'available_copies',
+          sortOrder: 'desc',
           text: 'Available copies',
         },
         {
           order: 4,
           sortBy: 'mostloaned',
-          sortOrder: 'asc',
+          sortOrder: 'desc',
           text: 'Most loaned',
         },
         {
           order: 5,
           sortBy: 'publication_year',
           sortOrder: 'desc',
-          text: 'Publication year [oldest]',
+          text: 'Publication year [newest]',
         },
         {
           order: 6,
           sortBy: 'publication_year',
           sortOrder: 'asc',
-          text: 'Publication year [newest]',
+          text: 'Publication year [oldest]',
         },
         {
           order: 7,
@@ -352,15 +340,15 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'mostrecent',
-          sortOrder: 'asc',
+          sortBy: 'created',
+          sortOrder: 'desc',
           text: 'Recently added',
         },
         {
           order: 2,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
       ],
       defaultPage: 1,
@@ -385,15 +373,15 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'mostrecent',
-          sortOrder: 'asc',
+          sortBy: 'created',
+          sortOrder: 'desc',
           text: 'Recently added',
         },
         {
           order: 2,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
         {
           order: 3,
@@ -449,8 +437,8 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'mostrecent',
-          sortOrder: 'asc',
+          sortBy: 'created',
+          sortOrder: 'desc',
           text: 'Recently added',
         },
         {
@@ -461,27 +449,15 @@ export const RECORDS_CONFIG = {
         },
         {
           order: 3,
-          sortBy: 'received_date',
-          sortOrder: 'desc',
-          text: 'Received date',
-        },
-        {
-          order: 4,
           sortBy: 'expected_delivery_date',
           sortOrder: 'desc',
           text: 'Expected delivery date',
         },
         {
-          order: 5,
-          sortBy: 'loan_end_date',
+          order: 4,
+          sortBy: 'due_date',
           sortOrder: 'desc',
-          text: 'Loan end date',
-        },
-        {
-          order: 6,
-          sortBy: 'bestmatch',
-          sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Due date',
         },
       ],
       defaultPage: 1,
@@ -497,7 +473,7 @@ export const RECORDS_CONFIG = {
           order: 1,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
         {
           order: 2,
@@ -578,15 +554,15 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'mostrecent',
-          sortOrder: 'asc',
+          sortBy: 'created',
+          sortOrder: 'desc',
           text: 'Recently added',
         },
         {
           order: 2,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
         {
           order: 3,
@@ -622,7 +598,7 @@ export const RECORDS_CONFIG = {
         },
         {
           title: 'Availability',
-          field: 'circulation.has_items_for_loan',
+          field: 'circulation.available_items_for_loan_count',
           aggName: 'availability',
         },
         {
@@ -650,39 +626,39 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'mostrecent',
-          sortOrder: 'asc',
+          sortBy: 'created',
+          sortOrder: 'desc',
           text: 'Recently added',
         },
         {
           order: 2,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
         {
           order: 3,
-          sortBy: 'available_items',
-          sortOrder: 'asc',
+          sortBy: 'available_copies',
+          sortOrder: 'desc',
           text: 'Available copies',
         },
         {
           order: 4,
           sortBy: 'mostloaned',
-          sortOrder: 'asc',
+          sortOrder: 'desc',
           text: 'Most loaned',
         },
         {
           order: 5,
           sortBy: 'publication_year',
-          sortOrder: 'asc',
-          text: 'Publication year [oldest] ',
+          sortOrder: 'desc',
+          text: 'Publication year [newest]',
         },
         {
           order: 6,
           sortBy: 'publication_year',
-          sortOrder: 'desc',
-          text: 'Publication year [newest]',
+          sortOrder: 'asc',
+          text: 'Publication year [oldest] ',
         },
         {
           order: 7,
@@ -724,33 +700,33 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'expire_date',
-          sortOrder: 'desc',
-          text: 'Expiration date',
+          sortBy: 'request_expire_date',
+          sortOrder: 'asc',
+          text: 'Request expiration date',
         },
         {
           order: 2,
           sortBy: 'request_start_date',
-          sortOrder: 'desc',
+          sortOrder: 'asc',
           text: 'Request start date',
         },
         {
           order: 3,
           sortBy: 'end_date',
-          sortOrder: 'desc',
+          sortOrder: 'asc',
           text: 'Loan end date',
         },
         {
           order: 4,
           sortBy: 'start_date',
-          sortOrder: 'desc',
+          sortOrder: 'asc',
           text: 'Loan start date',
         },
         {
           order: 5,
           sortBy: 'extensions',
-          sortOrder: 'asc',
-          text: 'Extension count',
+          sortOrder: 'desc',
+          text: 'Extensions count',
         },
       ],
       defaultPage: 1,
@@ -785,15 +761,15 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
-          sortBy: 'mostrecent',
-          sortOrder: 'asc',
+          sortBy: 'created',
+          sortOrder: 'desc',
           text: 'Recently added',
         },
         {
           order: 2,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
         {
           order: 3,
@@ -822,7 +798,7 @@ export const RECORDS_CONFIG = {
           order: 1,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
-          text: 'Best match',
+          text: 'Most relevant',
         },
       ],
       defaultPage: 1,

--- a/src/lib/modules/Document/DocumentCard/DocumentCard.js
+++ b/src/lib/modules/Document/DocumentCard/DocumentCard.js
@@ -74,9 +74,8 @@ class DocumentCard extends Component {
             </Card.Meta>
           </Card.Content>
           <Card.Content extra>
-            {_get(metadata, 'circulation.has_items_for_loan') > 0 && (
-              <Label>On shelf</Label>
-            )}
+            {_get(metadata, 'circulation.available_items_for_loan_count') >
+              0 && <Label>On shelf</Label>}
             {metadata.eitems.total > 0 && <Label>E-book</Label>}
           </Card.Content>
         </Card>

--- a/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.js
+++ b/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.js
@@ -1,7 +1,7 @@
 import DocumentAuthors from '@modules/Document/DocumentAuthors';
 import DocumentLanguages from '@modules/Document/DocumentLanguages';
-import LiteratureTags from '@modules/Literature/LiteratureTags';
 import LiteratureCover from '@modules/Literature/LiteratureCover';
+import LiteratureTags from '@modules/Literature/LiteratureTags';
 import { FrontSiteRoutes } from '@routes/urls';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
@@ -20,11 +20,12 @@ export default class DocumentListEntry extends Component {
   renderCirculationInfo = meta => {
     if (
       meta.circulation &&
-      (meta.circulation.has_items_for_loan > 0 || meta.eitems.total > 0)
+      (meta.circulation.available_items_for_loan_count > 0 ||
+        meta.eitems.total > 0)
     ) {
       return (
         <List className="document-availability-wrapper">
-          {meta.circulation.has_items_for_loan > 0 ? (
+          {meta.circulation.available_items_for_loan_count > 0 ? (
             <List.Item>
               <List.Icon color="green" name="check" />
               <List.Content>Available for loan</List.Content>

--- a/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.test.js
+++ b/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.test.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import DocumentListEntry from './DocumentListEntry';
 import * as testData from '@testData/documents.json';
 import { shallow } from 'enzyme';
+import React from 'react';
+import DocumentListEntry from './DocumentListEntry';
 
 it('should render correctly', () => {
   const data = {
@@ -10,7 +10,7 @@ it('should render correctly', () => {
       pid: '13',
       eitems: { hits: [], total: 0 },
       circulation: {
-        has_items_for_loan: 0,
+        available_items_for_loan_count: 0,
       },
     },
   };

--- a/src/lib/modules/Document/backoffice/DocumentList/DocumentCirculation.js
+++ b/src/lib/modules/Document/backoffice/DocumentList/DocumentCirculation.js
@@ -1,6 +1,6 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Icon, List } from 'semantic-ui-react';
-import PropTypes from 'prop-types';
 
 export default class DocumentCirculation extends Component {
   renderOverbookIcon = isOverbooked => {
@@ -18,13 +18,13 @@ export default class DocumentCirculation extends Component {
           <List.Content floated="right">
             <strong>{document.metadata.items.total}</strong>
           </List.Content>
-          <List.Content>total items</List.Content>
+          <List.Content>total physical copies</List.Content>
         </List.Item>
         <List.Item>
           <List.Content floated="right">
-            <strong>{circulation.has_items_for_loan}</strong>
+            <strong>{circulation.available_items_for_loan_count}</strong>
           </List.Content>
-          <List.Content>available items</List.Content>
+          <List.Content>available copies for loan</List.Content>
         </List.Item>
         <List.Item>
           <List.Content floated="right">
@@ -36,7 +36,7 @@ export default class DocumentCirculation extends Component {
           <List.Content floated="right">
             <strong>{circulation.pending_loans}</strong>
           </List.Content>
-          <List.Content>pending loans</List.Content>
+          <List.Content>loan requests</List.Content>
         </List.Item>
         <List.Item>
           <List.Content floated="right">

--- a/src/lib/modules/Document/backoffice/DocumentList/DocumentCirculation.test.js
+++ b/src/lib/modules/Document/backoffice/DocumentList/DocumentCirculation.test.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import { shallow } from 'enzyme';
-import DocumentCirculation from './DocumentCirculation';
 import * as testData from '@testData/documents.json';
+import { shallow } from 'enzyme';
+import React from 'react';
+import DocumentCirculation from './DocumentCirculation';
 
 describe('DocumentCirculation tests', () => {
   let component;
@@ -15,7 +15,7 @@ describe('DocumentCirculation tests', () => {
     metadata: {
       ...testData[0],
       items: { total: 2 },
-      circulation: { has_items_for_loan: 2 },
+      circulation: { available_items_for_loan_count: 2 },
     },
   };
 

--- a/src/lib/modules/Document/backoffice/DocumentList/__snapshots__/DocumentCirculation.test.js.snap
+++ b/src/lib/modules/Document/backoffice/DocumentList/__snapshots__/DocumentCirculation.test.js.snap
@@ -14,7 +14,7 @@ exports[`DocumentCirculation tests should load the DocumentCirculation component
       </strong>
     </ListContent>
     <ListContent>
-      total items
+      total physical copies
     </ListContent>
   </ListItem>
   <ListItem>
@@ -26,7 +26,7 @@ exports[`DocumentCirculation tests should load the DocumentCirculation component
       </strong>
     </ListContent>
     <ListContent>
-      available items
+      available copies for loan
     </ListContent>
   </ListItem>
   <ListItem>
@@ -46,7 +46,7 @@ exports[`DocumentCirculation tests should load the DocumentCirculation component
       <strong />
     </ListContent>
     <ListContent>
-      pending loans
+      loan requests
     </ListContent>
   </ListItem>
   <ListItem>

--- a/src/lib/modules/Patron/PatronCurrentLoans/actions.test.js
+++ b/src/lib/modules/Patron/PatronCurrentLoans/actions.test.js
@@ -46,7 +46,7 @@ describe('Patron current loans tests', () => {
 
       store.dispatch(actions.fetchPatronCurrentLoans(2)).then(() => {
         expect(mockFetchPatronCurrentLoans).toHaveBeenCalledWith(
-          '(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent&size=15&page=1'
+          '(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created&size=15&page=1'
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);
@@ -64,7 +64,7 @@ describe('Patron current loans tests', () => {
 
       store.dispatch(actions.fetchPatronCurrentLoans(2)).then(() => {
         expect(mockFetchPatronCurrentLoans).toHaveBeenCalledWith(
-          '(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent&size=15&page=1'
+          '(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created&size=15&page=1'
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -82,7 +82,7 @@ describe('Patron current loans tests', () => {
 
       store.dispatch(actions.fetchPatronCurrentLoans(2)).then(() => {
         expect(mockFetchPatronCurrentLoans).toHaveBeenCalledWith(
-          '(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent&size=15&page=1'
+          '(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created&size=15&page=1'
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -99,7 +99,7 @@ describe('Patron current loans tests', () => {
 
       store.dispatch(actions.fetchPatronCurrentLoans(2)).then(e => {
         expect(mockFetchPatronCurrentLoans).toHaveBeenCalledWith(
-          '(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent&size=15&page=1'
+          '(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created&size=15&page=1'
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);

--- a/src/lib/modules/Patron/PatronDocumentRequests/actions.test.js
+++ b/src/lib/modules/Patron/PatronDocumentRequests/actions.test.js
@@ -1,8 +1,8 @@
+import { documentRequestApi } from '@api/documentRequests';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as actions from './actions';
 import { initialState } from './reducer';
-import { documentRequestApi } from '@api/documentRequests';
 
 jest.mock('@config');
 
@@ -46,7 +46,7 @@ describe('Patron document requests tests', () => {
 
       store.dispatch(actions.fetchPatronDocumentRequests(2)).then(() => {
         expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-          '(patron_pid:2)&sort=-mostrecent&page=1'
+          '(patron_pid:2)&sort=-created&page=1'
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);
@@ -64,7 +64,7 @@ describe('Patron document requests tests', () => {
 
       store.dispatch(actions.fetchPatronDocumentRequests(2)).then(() => {
         expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-          '(patron_pid:2)&sort=-mostrecent&page=1'
+          '(patron_pid:2)&sort=-created&page=1'
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -82,7 +82,7 @@ describe('Patron document requests tests', () => {
 
       store.dispatch(actions.fetchPatronDocumentRequests(2)).then(() => {
         expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-          '(patron_pid:2)&sort=-mostrecent&page=1'
+          '(patron_pid:2)&sort=-created&page=1'
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -99,7 +99,7 @@ describe('Patron document requests tests', () => {
 
       store.dispatch(actions.fetchPatronDocumentRequests(2)).then(e => {
         expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-          '(patron_pid:2)&sort=-mostrecent&page=1'
+          '(patron_pid:2)&sort=-created&page=1'
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);

--- a/src/lib/modules/Patron/PatronPastLoans/actions.test.js
+++ b/src/lib/modules/Patron/PatronPastLoans/actions.test.js
@@ -42,7 +42,7 @@ describe('Patron past loans tests', () => {
     };
     await store.dispatch(actions.fetchPatronPastLoans(2));
     expect(mockFetchPatronPasttLoans).toHaveBeenCalledWith(
-      '(patron_pid:2 AND state:(ITEM_RETURNED OR CANCELLED))&sort=-mostrecent&size=15&page=1'
+      '(patron_pid:2 AND state:(ITEM_RETURNED OR CANCELLED))&sort=-created&size=15&page=1'
     );
     expect(store.getActions()[0]).toEqual(expectedAction);
   });
@@ -55,7 +55,7 @@ describe('Patron past loans tests', () => {
     };
     await store.dispatch(actions.fetchPatronPastLoans(2));
     expect(mockFetchPatronPasttLoans).toHaveBeenCalledWith(
-      '(patron_pid:2 AND state:(ITEM_RETURNED OR CANCELLED))&sort=-mostrecent&size=15&page=1'
+      '(patron_pid:2 AND state:(ITEM_RETURNED OR CANCELLED))&sort=-created&size=15&page=1'
     );
     expect(store.getActions()[1]).toEqual(expectedAction);
   });
@@ -68,7 +68,7 @@ describe('Patron past loans tests', () => {
     };
     await store.dispatch(actions.fetchPatronPastLoans(2));
     expect(mockFetchPatronPasttLoans).toHaveBeenCalledWith(
-      '(patron_pid:2 AND state:(ITEM_RETURNED OR CANCELLED))&sort=-mostrecent&size=15&page=1'
+      '(patron_pid:2 AND state:(ITEM_RETURNED OR CANCELLED))&sort=-created&size=15&page=1'
     );
     expect(store.getActions()[1]).toEqual(expectedAction);
   });
@@ -80,7 +80,7 @@ describe('Patron past loans tests', () => {
     };
     await store.dispatch(actions.fetchPatronPastLoans(2));
     expect(mockFetchPatronPasttLoans).toHaveBeenCalledWith(
-      '(patron_pid:2 AND state:(ITEM_RETURNED OR CANCELLED))&sort=-mostrecent&size=15&page=1'
+      '(patron_pid:2 AND state:(ITEM_RETURNED OR CANCELLED))&sort=-created&size=15&page=1'
     );
     expect(store.getActions()[0]).toEqual(expectedAction);
   });

--- a/src/lib/modules/Patron/PatronPendingLoans/actions.test.js
+++ b/src/lib/modules/Patron/PatronPendingLoans/actions.test.js
@@ -45,7 +45,7 @@ describe('Patron loans tests', () => {
 
       store.dispatch(actions.fetchPatronPendingLoans(2)).then(() => {
         expect(mockFetchUserLoan).toHaveBeenCalledWith(
-          '(patron_pid:2 AND state:(PENDING))&sort=-mostrecent&size=15&page=1'
+          '(patron_pid:2 AND state:(PENDING))&sort=-created&size=15&page=1'
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);
@@ -63,7 +63,7 @@ describe('Patron loans tests', () => {
 
       store.dispatch(actions.fetchPatronPendingLoans(2)).then(() => {
         expect(mockFetchUserLoan).toHaveBeenCalledWith(
-          '(patron_pid:2 AND state:(PENDING))&sort=-mostrecent&size=15&page=1'
+          '(patron_pid:2 AND state:(PENDING))&sort=-created&size=15&page=1'
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -81,7 +81,7 @@ describe('Patron loans tests', () => {
 
       store.dispatch(actions.fetchPatronPendingLoans(2)).then(() => {
         expect(mockFetchUserLoan).toHaveBeenCalledWith(
-          '(patron_pid:2 AND state:(PENDING))&sort=-mostrecent&size=15&page=1'
+          '(patron_pid:2 AND state:(PENDING))&sort=-created&size=15&page=1'
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);

--- a/src/lib/modules/Series/SeriesLiteratureSearch/__snapshots__/SeriesLiteratureSearch.test.js.snap
+++ b/src/lib/modules/Series/SeriesLiteratureSearch/__snapshots__/SeriesLiteratureSearch.test.js.snap
@@ -51,8 +51,8 @@ exports[`SeriesLiteratureSearch tests should load the SeriesLiteratureSearch com
           "layout": "grid",
           "page": 1,
           "size": 15,
-          "sortBy": "mostrecent",
-          "sortOrder": "asc",
+          "sortBy": "created",
+          "sortOrder": "desc",
         }
       }
       searchApi={

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentSummary/DocumentSummary.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentSummary/DocumentSummary.js
@@ -64,7 +64,7 @@ export default class DocumentSummary extends Component {
           onClick={() => this.scrollTo(anchors.attachedItemsRef)}
         >
           <Statistic.Value>
-            {document.metadata.circulation.has_items_for_loan}
+            {document.metadata.circulation.available_items_for_loan_count}
           </Statistic.Value>
           <Statistic.Label>Items available for loan</Statistic.Label>
         </Statistic>

--- a/src/lib/pages/backoffice/Home/lists/PendingOverdueDocumentsList/__snapshots__/PendingOverdueDocumentsList.test.js.snap
+++ b/src/lib/pages/backoffice/Home/lists/PendingOverdueDocumentsList/__snapshots__/PendingOverdueDocumentsList.test.js.snap
@@ -43,7 +43,7 @@ exports[`PendingOverdueDocumentsList tests should load the details component 1`]
         <SeeAllButton
           disabled={false}
           fluid={false}
-          to="/backoffice/documents?q=circulation.has_items_for_loan:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0"
+          to="/backoffice/documents?q=circulation.available_items_for_loan_count:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0"
         />
       }
       showAllResults={false}
@@ -229,7 +229,7 @@ exports[`PendingOverdueDocumentsList tests should render documents 1`] = `
               <SeeAllButton
                 disabled={false}
                 fluid={false}
-                to="/backoffice/documents?q=circulation.has_items_for_loan:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0"
+                to="/backoffice/documents?q=circulation.available_items_for_loan_count:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0"
               />
             }
             showAllResults={false}
@@ -2098,7 +2098,7 @@ exports[`PendingOverdueDocumentsList tests should render documents 1`] = `
                     <SeeAllButton
                       disabled={false}
                       fluid={false}
-                      to="/backoffice/documents?q=circulation.has_items_for_loan:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0"
+                      to="/backoffice/documents?q=circulation.available_items_for_loan_count:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0"
                     />
                   }
                   showAllResults={false}
@@ -2176,7 +2176,7 @@ exports[`PendingOverdueDocumentsList tests should render show a message with no 
               <SeeAllButton
                 disabled={false}
                 fluid={false}
-                to="/backoffice/documents?q=circulation.has_items_for_loan:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0"
+                to="/backoffice/documents?q=circulation.available_items_for_loan_count:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0"
               />
             }
             showAllResults={false}

--- a/src/lib/pages/backoffice/Home/lists/PendingOverdueDocumentsList/state/actions.test.js
+++ b/src/lib/pages/backoffice/Home/lists/PendingOverdueDocumentsList/state/actions.test.js
@@ -1,8 +1,8 @@
+import { documentApi } from '@api/documents';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as actions from './actions';
 import { initialState } from './reducer';
-import { documentApi } from '@api/documents';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -23,7 +23,7 @@ const mockResponse = {
 };
 
 const param =
-  'circulation.has_items_for_loan:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0';
+  'circulation.available_items_for_loan_count:0%20AND%20circulation.pending_loans:%3E0%20AND%20circulation.overdue_loans:%3E0%20AND%20items.total:%3E0';
 
 const mockLoanList = jest.fn();
 documentApi.list = mockLoanList;

--- a/src/lib/pages/backoffice/Home/widgets/DocumentCard/__snapshots__/DocumentsCard.test.js.snap
+++ b/src/lib/pages/backoffice/Home/widgets/DocumentCard/__snapshots__/DocumentsCard.test.js.snap
@@ -20,7 +20,7 @@ exports[`DocumentsCard tests should load the details component 1`] = `
         <SeeAllButton
           disabled={false}
           fluid={true}
-          to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
+          to="/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0"
         />
       }
       stats={0}
@@ -76,7 +76,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
               <SeeAllButton
                 disabled={false}
                 fluid={true}
-                to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
+                to="/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0"
               />
             }
             stats={2}
@@ -209,7 +209,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "innerRef",
                                             "Link",
@@ -230,7 +230,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "innerRef",
                                             "Link",
@@ -329,7 +329,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "onClick",
                                             "Link",
@@ -350,7 +350,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "onClick",
                                             "Link",
@@ -449,7 +449,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "replace",
                                             "Link",
@@ -470,7 +470,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "replace",
                                             "Link",
@@ -569,7 +569,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "target",
                                             "Link",
@@ -590,7 +590,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "target",
                                             "Link",
@@ -689,7 +689,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "to",
                                             "Link",
@@ -710,7 +710,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "to",
                                             "Link",
@@ -778,7 +778,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                             "onClick": [Function],
                                             "role": "button",
                                             "tabIndex": undefined,
-                                            "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                            "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                           },
                                           [Function],
                                         ],
@@ -841,7 +841,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                             <SeeAllButton
                               disabled={false}
                               fluid={true}
-                              to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
+                              to="/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0"
                             >
                               <Button
                                 as={
@@ -920,7 +920,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "innerRef",
                                             "Link",
@@ -941,7 +941,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "innerRef",
                                             "Link",
@@ -1040,7 +1040,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "onClick",
                                             "Link",
@@ -1061,7 +1061,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "onClick",
                                             "Link",
@@ -1160,7 +1160,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "replace",
                                             "Link",
@@ -1181,7 +1181,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "replace",
                                             "Link",
@@ -1280,7 +1280,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "target",
                                             "Link",
@@ -1301,7 +1301,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "target",
                                             "Link",
@@ -1400,7 +1400,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "to",
                                             "Link",
@@ -1421,7 +1421,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                               "onClick": [Function],
                                               "role": "button",
                                               "tabIndex": undefined,
-                                              "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                              "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                             },
                                             "to",
                                             "Link",
@@ -1489,7 +1489,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                             "onClick": [Function],
                                             "role": "button",
                                             "tabIndex": undefined,
-                                            "to": "/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0",
+                                            "to": "/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0",
                                           },
                                           [Function],
                                         ],
@@ -1510,7 +1510,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                 disabled={false}
                                 fluid={true}
                                 size="small"
-                                to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
+                                to="/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0"
                               >
                                 <Ref
                                   innerRef={
@@ -1530,7 +1530,7 @@ exports[`DocumentsCard tests should render stats with 2 records 1`] = `
                                       className="ui small fluid button"
                                       onClick={[Function]}
                                       role="button"
-                                      to="/backoffice/documents?q=circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0"
+                                      to="/backoffice/documents?q=circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0"
                                     />
                                   </RefForward>
                                 </Ref>

--- a/src/lib/pages/backoffice/Home/widgets/DocumentCard/state/actions.test.js
+++ b/src/lib/pages/backoffice/Home/widgets/DocumentCard/state/actions.test.js
@@ -1,8 +1,8 @@
+import { documentApi } from '@api/documents';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as actions from './actions';
 import { initialState } from './reducer';
-import { documentApi } from '@api/documents';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -43,7 +43,7 @@ describe('Documents with items on shelf tests', () => {
 
     store.dispatch(actions.fetchRequestedWithAvailableItems()).then(() => {
       expect(mockDocumentsCount).toHaveBeenCalledWith(
-        'circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0'
+        'circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0'
       );
       const actions = store.getActions();
       expect(actions[0]).toEqual(expectedAction);
@@ -61,7 +61,7 @@ describe('Documents with items on shelf tests', () => {
 
     store.dispatch(actions.fetchRequestedWithAvailableItems()).then(() => {
       expect(mockDocumentsCount).toHaveBeenCalledWith(
-        'circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0'
+        'circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0'
       );
       const actions = store.getActions();
       expect(actions[1]).toEqual(expectedAction);
@@ -79,7 +79,7 @@ describe('Documents with items on shelf tests', () => {
 
     store.dispatch(actions.fetchRequestedWithAvailableItems()).then(() => {
       expect(mockDocumentsCount).toHaveBeenCalledWith(
-        'circulation.has_items_for_loan:>0 AND circulation.pending_loans:>0'
+        'circulation.available_items_for_loan_count:>0 AND circulation.pending_loans:>0'
       );
       const actions = store.getActions();
       expect(actions[1]).toEqual(expectedAction);

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentLoans/__snapshots__/PatronCurrentLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentLoans/__snapshots__/PatronCurrentLoans.test.js.snap
@@ -44,7 +44,7 @@ exports[`PatronCurrentLoans tests should load the details component 1`] = `
         <SeeAllButton
           disabled={false}
           fluid={false}
-          to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+          to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
         />
       }
       showAllResults={false}
@@ -258,7 +258,7 @@ exports[`PatronCurrentLoans tests should render patron loans 1`] = `
                   <SeeAllButton
                     disabled={false}
                     fluid={false}
-                    to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                    to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                   />
                 }
                 showAllResults={false}
@@ -702,7 +702,7 @@ exports[`PatronCurrentLoans tests should render patron loans 1`] = `
                         <SeeAllButton
                           disabled={false}
                           fluid={false}
-                          to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                          to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                         />
                       }
                       showAllResults={false}
@@ -803,7 +803,7 @@ exports[`PatronCurrentLoans tests should render show a message with no user loan
               <SeeAllButton
                 disabled={false}
                 fluid={false}
-                to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
               />
             }
             showAllResults={false}
@@ -1047,7 +1047,7 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                   <SeeAllButton
                     disabled={false}
                     fluid={false}
-                    to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                    to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                   />
                 }
                 showAllResults={false}
@@ -1368,7 +1368,7 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                         <SeeAllButton
                           disabled={false}
                           fluid={false}
-                          to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                          to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                         />
                       }
                       showAllResults={false}
@@ -1425,7 +1425,7 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                         <SeeAllButton
                                           disabled={false}
                                           fluid={false}
-                                          to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                                          to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                                         >
                                           <Button
                                             as={
@@ -1445,14 +1445,14 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                             disabled={false}
                                             fluid={false}
                                             size="small"
-                                            to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                                            to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                                           >
                                             <Ref
                                               innerRef={
                                                 Object {
                                                   "current": <a
                                                     class="ui small button"
-                                                    href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                                                    href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                                                     role="button"
                                                   >
                                                     See all
@@ -1465,7 +1465,7 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                                   Object {
                                                     "current": <a
                                                       class="ui small button"
-                                                      href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                                                      href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                                                       role="button"
                                                     >
                                                       See all
@@ -1477,18 +1477,18 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                                   className="ui small button"
                                                   onClick={[Function]}
                                                   role="button"
-                                                  to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                                                  to="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                                                 >
                                                   <LinkAnchor
                                                     className="ui small button"
-                                                    href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                                                    href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                                                     navigate={[Function]}
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
                                                     <a
                                                       className="ui small button"
-                                                      href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-mostrecent"
+                                                      href="/backoffice/loans?q=(patron_pid:2 AND state:(ITEM_AT_DESK OR ITEM_ON_LOAN OR ITEM_IN_TRANSIT_FOR_PICKUP OR ITEM_IN_TRANSIT_TO_HOUSE))&sort=-created"
                                                       onClick={[Function]}
                                                       role="button"
                                                     >

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronDocumentRequests/__snapshots__/PatronDocumentRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronDocumentRequests/__snapshots__/PatronDocumentRequests.test.js.snap
@@ -43,7 +43,7 @@ exports[`PatronDocumentRequests tests should load the details component 1`] = `
         <SeeAllButton
           disabled={false}
           fluid={false}
-          to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+          to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
         />
       }
       showAllResults={false}
@@ -235,7 +235,7 @@ exports[`PatronDocumentRequests tests should render patron document requests 1`]
                   <SeeAllButton
                     disabled={false}
                     fluid={false}
-                    to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                    to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                   />
                 }
                 showAllResults={false}
@@ -666,7 +666,7 @@ exports[`PatronDocumentRequests tests should render patron document requests 1`]
                         <SeeAllButton
                           disabled={false}
                           fluid={false}
-                          to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                          to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                         />
                       }
                       showAllResults={false}
@@ -790,7 +790,7 @@ exports[`PatronDocumentRequests tests should render show a message with no user 
                   <SeeAllButton
                     disabled={false}
                     fluid={false}
-                    to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                    to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                   />
                 }
                 showAllResults={false}
@@ -1015,7 +1015,7 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                   <SeeAllButton
                     disabled={false}
                     fluid={false}
-                    to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                    to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                   />
                 }
                 showAllResults={false}
@@ -1330,7 +1330,7 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                         <SeeAllButton
                           disabled={false}
                           fluid={false}
-                          to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                          to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                         />
                       }
                       showAllResults={false}
@@ -1387,7 +1387,7 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                                         <SeeAllButton
                                           disabled={false}
                                           fluid={false}
-                                          to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                                          to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                                         >
                                           <Button
                                             as={
@@ -1407,14 +1407,14 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                                             disabled={false}
                                             fluid={false}
                                             size="small"
-                                            to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                                            to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                                           >
                                             <Ref
                                               innerRef={
                                                 Object {
                                                   "current": <a
                                                     class="ui small button"
-                                                    href="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                                                    href="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                                                     role="button"
                                                   >
                                                     See all
@@ -1427,7 +1427,7 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                                                   Object {
                                                     "current": <a
                                                       class="ui small button"
-                                                      href="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                                                      href="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                                                       role="button"
                                                     >
                                                       See all
@@ -1439,18 +1439,18 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                                                   className="ui small button"
                                                   onClick={[Function]}
                                                   role="button"
-                                                  to="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                                                  to="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                                                 >
                                                   <LinkAnchor
                                                     className="ui small button"
-                                                    href="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                                                    href="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                                                     navigate={[Function]}
                                                     onClick={[Function]}
                                                     role="button"
                                                   >
                                                     <a
                                                       className="ui small button"
-                                                      href="/backoffice/document-requests?q=(patron_pid:2)&sort=-mostrecent"
+                                                      href="/backoffice/document-requests?q=(patron_pid:2)&sort=-created"
                                                       onClick={[Function]}
                                                       role="button"
                                                     >

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentCirculation/LoanAvailability.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentCirculation/LoanAvailability.js
@@ -6,7 +6,7 @@ import { List, Popup } from 'semantic-ui-react';
 export class LoanAvailability extends Component {
   render() {
     const { circulation } = this.props;
-    if (circulation.has_items_for_loan > 0) {
+    if (circulation.available_items_for_loan_count > 0) {
       return (
         <List.Item>
           <Popup
@@ -15,7 +15,7 @@ export class LoanAvailability extends Component {
           />
           <List.Content
             className={
-              circulation.has_items_for_loan > 0
+              circulation.available_items_for_loan_count > 0
                 ? 'text-success'
                 : 'text-danger'
             }

--- a/src/lib/pages/frontsite/Home/Headline/Headline.js
+++ b/src/lib/pages/frontsite/Home/Headline/Headline.js
@@ -51,7 +51,7 @@ const HeadlineLayout = props => {
                     className="headline-quick-access"
                     as={Link}
                     to={FrontSiteRoutes.documentsListWithQuery(
-                      '&sort=mostrecent&order=desc'
+                      '&sort=created&order=desc'
                     )}
                     primary
                   >
@@ -71,7 +71,7 @@ const HeadlineLayout = props => {
                     className="headline-quick-access"
                     as={Link}
                     to={FrontSiteRoutes.documentsListWithQuery(
-                      '&f=doctype%3ABOOK&f=medium%3AELECTRONIC_VERSION&sort=mostrecent&order=desc'
+                      '&f=doctype%3ABOOK&f=medium%3AELECTRONIC_VERSION&sort=created&order=desc'
                     )}
                     primary
                   >

--- a/src/lib/pages/frontsite/Home/Sections/SectionsWrapper.js
+++ b/src/lib/pages/frontsite/Home/Sections/SectionsWrapper.js
@@ -24,11 +24,11 @@ export default class SectionsWrapper extends Component {
               fetchDataQuery={documentApi
                 .query()
                 .withDocumentType('BOOK')
-                .sortBy('mostrecent')
+                .sortBy('-created')
                 .withSize(size)
                 .qs()}
               viewAllUrl={FrontSiteRoutes.documentsListWithQuery(
-                '&sort=mostrecent&order=desc'
+                '&sort=created&order=desc'
               )}
             />
           </Container>
@@ -59,11 +59,11 @@ export default class SectionsWrapper extends Component {
               .query()
               .withDocumentType('BOOK')
               .withEitems()
-              .sortBy('-mostrecent')
+              .sortBy('-created')
               .withSize(size)
               .qs()}
             viewAllUrl={FrontSiteRoutes.documentsListWithQuery(
-              '&f=doctype%3ABOOK&f=medium%3AELECTRONIC_VERSION&sort=mostrecent&order=desc'
+              '&f=doctype%3ABOOK&f=medium%3AELECTRONIC_VERSION&sort=created&order=desc'
             )}
           />
         </Container>

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentDocumentRequests/state/actions.test.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentDocumentRequests/state/actions.test.js
@@ -46,7 +46,7 @@ describe('Patron document requests tests', () => {
 
       await store.dispatch(actions.fetchPatronDocumentRequests(2));
       expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-        '(patron_pid:2 AND state:PENDING)&sort=-mostrecent&size=15&page=1'
+        '(patron_pid:2 AND state:PENDING)&sort=-created&size=15&page=1'
       );
       expect(store.getActions()[0]).toEqual(expectedAction);
     });
@@ -61,7 +61,7 @@ describe('Patron document requests tests', () => {
 
       await store.dispatch(actions.fetchPatronDocumentRequests(2));
       expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-        '(patron_pid:2 AND state:PENDING)&sort=-mostrecent&size=15&page=1'
+        '(patron_pid:2 AND state:PENDING)&sort=-created&size=15&page=1'
       );
       expect(store.getActions()[1]).toEqual(expectedAction);
     });
@@ -76,7 +76,7 @@ describe('Patron document requests tests', () => {
 
       await store.dispatch(actions.fetchPatronDocumentRequests(2));
       expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-        '(patron_pid:2 AND state:PENDING)&sort=-mostrecent&size=15&page=1'
+        '(patron_pid:2 AND state:PENDING)&sort=-created&size=15&page=1'
       );
       expect(store.getActions()[1]).toEqual(expectedAction);
     });
@@ -90,7 +90,7 @@ describe('Patron document requests tests', () => {
 
       await store.dispatch(actions.fetchPatronDocumentRequests(2));
       expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-        '(patron_pid:2 AND state:PENDING)&sort=-mostrecent&size=15&page=1'
+        '(patron_pid:2 AND state:PENDING)&sort=-created&size=15&page=1'
       );
       expect(store.getActions()[0]).toEqual(expectedAction);
     });

--- a/src/lib/pages/frontsite/PatronProfile/PatronPastDocumentRequests/state/actions.test.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronPastDocumentRequests/state/actions.test.js
@@ -46,7 +46,7 @@ describe('Patron document requests tests', () => {
 
       await store.dispatch(actions.fetchPatronPastDocumentRequests(2));
       expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-        '(patron_pid:2 AND state:(ACCEPTED OR REJECTED))&sort=-mostrecent&size=15&page=1'
+        '(patron_pid:2 AND state:(ACCEPTED OR REJECTED))&sort=-created&size=15&page=1'
       );
       expect(store.getActions()[0]).toEqual(expectedAction);
     });
@@ -61,7 +61,7 @@ describe('Patron document requests tests', () => {
 
       await store.dispatch(actions.fetchPatronPastDocumentRequests(2));
       expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-        '(patron_pid:2 AND state:(ACCEPTED OR REJECTED))&sort=-mostrecent&size=15&page=1'
+        '(patron_pid:2 AND state:(ACCEPTED OR REJECTED))&sort=-created&size=15&page=1'
       );
       expect(store.getActions()[1]).toEqual(expectedAction);
     });
@@ -76,7 +76,7 @@ describe('Patron document requests tests', () => {
 
       await store.dispatch(actions.fetchPatronPastDocumentRequests(2));
       expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-        '(patron_pid:2 AND state:(ACCEPTED OR REJECTED))&sort=-mostrecent&size=15&page=1'
+        '(patron_pid:2 AND state:(ACCEPTED OR REJECTED))&sort=-created&size=15&page=1'
       );
       expect(store.getActions()[1]).toEqual(expectedAction);
     });
@@ -90,7 +90,7 @@ describe('Patron document requests tests', () => {
 
       await store.dispatch(actions.fetchPatronPastDocumentRequests(2));
       expect(mockFetchPatronDocumentRequests).toHaveBeenCalledWith(
-        '(patron_pid:2 AND state:(ACCEPTED OR REJECTED))&sort=-mostrecent&size=15&page=1'
+        '(patron_pid:2 AND state:(ACCEPTED OR REJECTED))&sort=-created&size=15&page=1'
       );
       expect(store.getActions()[0]).toEqual(expectedAction);
     });


### PR DESCRIPTION
For reviewers: there are some sort by that ideally would require to add both ASC and DESC (e.g. loan end date), but we need also to keep the text relatively short. What about using icons?

Ideas with emojis (it does not looks super nice...):
<img width="286" alt="sort_by_emojys" src="https://user-images.githubusercontent.com/2089455/96500395-12ad5d80-124f-11eb-9d1e-7712c7d46575.png">
