### PR TITLE
Major fixes

### DIFF
--- a/src/lib/api/ill/borrowingRequest.js
+++ b/src/lib/api/ill/borrowingRequest.js
@@ -1,16 +1,19 @@
 import { apiConfig, http } from '@api/base';
 import { prepareSumQuery } from '@api/utils';
 import { sessionManager } from '@authentication/services/SessionManager';
+import { borrowingRequestSerializer as serializer } from './serializers';
 
 const borrowingRequestUrl = '/ill/borrowing-requests/';
 
 const get = async pid => {
   const response = await http.get(`${borrowingRequestUrl}${pid}`);
+  response.data = serializer.fromJSON(response.data);
   return response;
 };
 
 const create = async data => {
   const resp = await http.post(`${borrowingRequestUrl}`, data);
+  resp.data = serializer.fromJSON(resp.data);
   return resp;
 };
 
@@ -19,6 +22,7 @@ const update = async (borrowingRequestPid, data) => {
     `${borrowingRequestUrl}${borrowingRequestPid}`,
     data
   );
+  resp.data = serializer.fromJSON(resp.data);
   return resp;
 };
 
@@ -66,6 +70,9 @@ const declineExtension = async borrowingRequestPid => {
 const list = async query => {
   const response = await http.get(`${borrowingRequestUrl}?q=${query}`);
   response.data.total = response.data.hits.total;
+  response.data.hits = response.data.hits.hits.map(hit =>
+    serializer.fromJSON(hit)
+  );
   return response;
 };
 

--- a/src/lib/api/ill/serializers.js
+++ b/src/lib/api/ill/serializers.js
@@ -6,6 +6,16 @@ const LibrarySerializers = {
   },
 };
 
+const BorrowingRequestSerializers = {
+  responseSerializer: function(hit) {
+    return recordResponseSerializer(hit);
+  },
+};
+
 export const librarySerializer = {
   fromJSON: LibrarySerializers.responseSerializer,
+};
+
+export const borrowingRequestSerializer = {
+  fromJSON: BorrowingRequestSerializers.responseSerializer,
 };

--- a/src/lib/components/DatePicker/DatePicker.js
+++ b/src/lib/components/DatePicker/DatePicker.js
@@ -56,6 +56,7 @@ class DatePicker extends Component {
       disable,
       disabledInput,
       loading,
+      required,
     } = this.props;
     const { selectedDate } = this.state;
     // Remove this code when this issue is solved -> https://github.com/arfedulov/semantic-ui-calendar-react/issues/202
@@ -86,6 +87,7 @@ class DatePicker extends Component {
         data-test={selectedDate}
         dateFormat="YYYY-MM-DD"
         animation="none"
+        required={required}
       />
     );
   }
@@ -107,6 +109,7 @@ DatePicker.propTypes = {
   disabledInput: PropTypes.bool,
   loading: PropTypes.bool,
   locationPid: PropTypes.string,
+  required: PropTypes.bool,
 };
 
 DatePicker.defaultProps = {
@@ -124,6 +127,7 @@ DatePicker.defaultProps = {
   fetchData: null,
   loading: false,
   locationPid: '',
+  required: false,
 };
 
 export default Overridable.component('DatePicker', DatePicker);

--- a/src/lib/components/Pagination/Pagination.js
+++ b/src/lib/components/Pagination/Pagination.js
@@ -19,7 +19,7 @@ class Pagination extends Component {
       ...extraParams
     } = this.props;
     // Maximum number of pages allowed (backend window limitation)
-    const maximumWindowPages = Math.ceil(
+    const maximumWindowPages = Math.floor(
       invenioConfig.APP.MAX_RESULTS_WINDOW / currentSize
     );
     // Theoretical number of pages for this search result

--- a/src/lib/components/backoffice/buttons/ScrollingMenu/ScrollingMenu.js
+++ b/src/lib/components/backoffice/buttons/ScrollingMenu/ScrollingMenu.js
@@ -1,11 +1,16 @@
 import React, { Component } from 'react';
+import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import { Menu } from 'semantic-ui-react';
 
 export default class ScrollingMenuItem extends Component {
   constructor(props) {
     super(props);
-    this.state = { activeItem: props.children[0].props.elementId };
+    this.state = {
+      activeItem: props.children
+        .map(child => child.props.elementId)
+        .find(id => !_isEmpty(id)),
+    };
   }
 
   setActiveLink = elementId => {

--- a/src/lib/forms/core/BaseForm/BaseForm.js
+++ b/src/lib/forms/core/BaseForm/BaseForm.js
@@ -98,6 +98,8 @@ export class BaseForm extends Component {
           initialValues={initialValues}
           onSubmit={onSubmit || this.onSubmit}
           validationSchema={validationSchema}
+          validateOnChange={false}
+          validateOnBlur={false}
         >
           {({ isSubmitting, handleSubmit, submitForm, values }) => (
             <Form

--- a/src/lib/forms/core/DateTimeFields/DateInputField.js
+++ b/src/lib/forms/core/DateTimeFields/DateInputField.js
@@ -32,6 +32,7 @@ export class DateInputField extends React.Component {
           id={fieldPath}
           name={fieldPath}
           placeholder={placeholder}
+          required={required}
           error={props.error}
           defaultValue={props.value}
           handleBlur={props.form.handleBlur}

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderEditor/OrderForm/OrderForm.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderEditor/OrderForm/OrderForm.js
@@ -12,6 +12,7 @@ import { Grid, Header, Segment } from 'semantic-ui-react';
 import { OrderInfo } from './OrderInfo';
 import { OrderLines } from './OrderLines';
 import { Payment } from './Payment';
+import * as Yup from 'yup';
 
 const orderSubmitSerializer = values => {
   const submitValues = { ...values };
@@ -37,6 +38,35 @@ const orderSubmitSerializer = values => {
 
   return submitValues;
 };
+
+const OrderSchema = Yup.object().shape({
+  vendor: Yup.object().shape({
+    pid: Yup.string().required(),
+  }),
+  status: Yup.string().required(),
+  order_date: Yup.date().required(),
+  expected_delivery_date: Yup.date(),
+  received_date: Yup.date(),
+  funds: Yup.array().of(Yup.string().required()),
+  payment: Yup.object().shape({
+    mode: Yup.string().required(),
+  }),
+  order_lines: Yup.array().of(
+    Yup.object().shape({
+      document: Yup.object().shape({
+        pid: Yup.string().required(),
+      }),
+      medium: Yup.string().required(),
+      unit_price: Yup.object().shape({
+        value: Yup.number().required(),
+      }),
+      total_price: Yup.object().shape({
+        value: Yup.number().required(),
+      }),
+      recipient: Yup.string().required(),
+    })
+  ),
+});
 
 export class OrderForm extends Component {
   get buttons() {
@@ -95,6 +125,7 @@ export class OrderForm extends Component {
         title={title}
         pid={pid}
         submitSerializer={orderSubmitSerializer}
+        validationSchema={OrderSchema}
         buttons={this.buttons}
       >
         <Grid columns="equal">

--- a/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/DocumentForm.js
+++ b/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/DocumentForm.js
@@ -20,15 +20,9 @@ import { DocumentCurationCatalog } from './DocumentCurationCatalog';
 import { DocumentLicensesCopyright } from './DocumentLicensesCopyright';
 import { DocumentPublishing } from './DocumentPublishing';
 import documentSubmitSerializer from './documentSubmitSerializer';
-
 import * as Yup from 'yup';
 
 const DocumentSchema = Yup.object().shape({
-  affiliations: Yup.array().of(
-    Yup.object().shape({
-      value: Yup.string().required(),
-    })
-  ),
   document_type: Yup.string().required(),
   identifiers: Yup.array().of(
     Yup.object().shape({

--- a/src/lib/pages/backoffice/EItem/EItemForms/EItemEditor/EItemForm/EItemForm.js
+++ b/src/lib/pages/backoffice/EItem/EItemForms/EItemEditor/EItemForm/EItemForm.js
@@ -32,7 +32,7 @@ const EItemSchema = Yup.object().shape({
   urls: Yup.array().of(
     Yup.object().shape({
       value: Yup.string()
-        .url('not a cvali d url')
+        .url('not a valid url')
         .required(),
     })
   ),

--- a/src/lib/pages/backoffice/Item/ItemForms/ItemEditor/ItemForm/ItemForm.js
+++ b/src/lib/pages/backoffice/Item/ItemForms/ItemEditor/ItemForm/ItemForm.js
@@ -27,6 +27,23 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Header, Segment } from 'semantic-ui-react';
 import itemSubmitSerializer from './itemSubmitSerializer';
+import * as Yup from 'yup';
+
+const ItemSchema = Yup.object().shape({
+  barcode: Yup.string().required(),
+  document: Yup.object().shape({
+    pid: Yup.string().required(),
+  }),
+  medium: Yup.string().required(),
+  internal_location: Yup.object().shape({
+    pid: Yup.string().required(),
+  }),
+  status: Yup.string().required(),
+  circulation_restriction: Yup.string().required(),
+  isbn: Yup.object().shape({
+    value: Yup.string().required(),
+  }),
+});
 
 export class ItemForm extends Component {
   constructor(props) {
@@ -98,6 +115,7 @@ export class ItemForm extends Component {
         title={title}
         pid={pid}
         submitSerializer={itemSubmitSerializer}
+        validationSchema={ItemSchema}
       >
         <Segment>
           <Header dividing>Basic Metadata</Header>

--- a/src/lib/pages/frontsite/PatronProfile/PatronPendingLoans/PatronPendingLoans.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronPendingLoans/PatronPendingLoans.js
@@ -86,8 +86,10 @@ class ButtonCancelRequest extends Component {
       this.setState({ isLoading: false });
       onSuccess(`Your loan request for ${documentTitle} has been cancelled.`);
     } catch (error) {
-      this.setState({ isLoading: false });
-      this.showError(error.response.data.message);
+      if (error !== 'UNMOUNTED') {
+        this.setState({ isLoading: false });
+        this.showError(error.response.data.message);
+      }
     }
   };
 


### PR DESCRIPTION
* serialize borrowing request responses (closes CERNDocumentServer/cds-ils#189)
* fix patron scrolling menu initial value
* improve yup validation (addresses #243)
  * propagate html required property to date picker input
  * schema errors (and more generally all errors) are displayed only after submission, instead of after value change
  * schemas for orders, items
* revert pagination pages calculation
* fix patron cancel loan page change bug (closes #225)