### PR TITLE
backoffice: refactors extra fields of the documents

### DIFF
--- a/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/DocumentAdditionalInfo.js
+++ b/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/DocumentAdditionalInfo.js
@@ -5,9 +5,15 @@ import {
   AlternativeIdentifiers,
   AlternativeTitles,
 } from './components';
+import Overridable from 'react-overridable';
+import { MetadataExtensions } from './components';
+import PropTypes from 'prop-types';
+import _isEmpty from 'lodash/isEmpty';
+import { invenioConfig } from '@config';
 
 export class DocumentAdditionalInfo extends Component {
   render() {
+    const { extensions } = this.props;
     return (
       <Grid columns="equal">
         <Grid.Row>
@@ -33,7 +39,30 @@ export class DocumentAdditionalInfo extends Component {
             </Segment>
           </Grid.Column>
         </Grid.Row>
+        {!_isEmpty(extensions) &&
+          !_isEmpty(invenioConfig.DOCUMENTS.extensions.fields) && (
+            <Grid.Row>
+              <Grid.Column>
+                <Segment>
+                  <Overridable
+                    id="DocumentForm.Extensions"
+                    extensions={extensions}
+                  >
+                    <MetadataExtensions extensions={extensions} />
+                  </Overridable>
+                </Segment>
+              </Grid.Column>
+            </Grid.Row>
+          )}
       </Grid>
     );
   }
 }
+
+DocumentAdditionalInfo.propTypes = {
+  extensions: PropTypes.object,
+};
+
+DocumentAdditionalInfo.defaultProps = {
+  extensions: null,
+};

--- a/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/DocumentForm.js
+++ b/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/DocumentForm.js
@@ -1,18 +1,14 @@
 import { documentRequestApi } from '@api/documentRequests';
 import { documentApi } from '@api/documents';
 import { Loader } from '@components/Loader';
-import { invenioConfig } from '@config';
 import { BaseForm } from '@forms/core/BaseForm';
 import { goTo } from '@history';
 import { BackOfficeRoutes } from '@routes/urls';
 import { getIn } from 'formik';
 import _get from 'lodash/get';
-import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Overridable from 'react-overridable';
 import { Header, Segment } from 'semantic-ui-react';
-import { MetadataExtensions } from './components';
 import { DocumentAdditionalInfo } from './DocumentAdditionalInfo';
 import { DocumentBasicMetadata } from './DocumentBasicMetadata';
 import { DocumentContent } from './DocumentContent';
@@ -193,16 +189,9 @@ export class DocumentForm extends Component {
         </Header>
         <Segment attached>
           <Loader>
-            <DocumentAdditionalInfo />
+            <DocumentAdditionalInfo extensions={extensions} />
           </Loader>
         </Segment>
-
-        {!_isEmpty(extensions) &&
-          !_isEmpty(invenioConfig.DOCUMENTS.extensions.fields) && (
-            <Overridable id="DocumentForm.Extensions" extensions={extensions}>
-              <MetadataExtensions extensions={extensions} />
-            </Overridable>
-          )}
       </BaseForm>
     );
   }

--- a/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/components/MetadataExtensions.js
+++ b/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/components/MetadataExtensions.js
@@ -3,12 +3,14 @@ import { AccordionField } from '@forms/core/AccordionField';
 import { BooleanField } from '@forms/core/BooleanField';
 import { DateInputField } from '@forms/core/DateTimeFields/DateInputField';
 import { StringField } from '@forms/core/StringField';
+import { VocabularyField } from '@forms/core/VocabularyField';
 import _forOwn from 'lodash/forOwn';
 import _get from 'lodash/get';
 import _keys from 'lodash/keys';
 import _merge from 'lodash/merge';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { GroupField } from '@forms/core/GroupField';
 
 const getFormComponent = fieldType => {
   switch (fieldType) {
@@ -25,41 +27,106 @@ const getFormComponent = fieldType => {
   }
 };
 
+/**
+ * Sort the components by line
+ * @param {components.<Object>} a
+ * @param {components.<Object>} b
+ */
+const sortByLine = (a, b) => {
+  if (a.line < b.line) {
+    return -1;
+  }
+  if (a.line > b.line) {
+    return 1;
+  }
+  return 0;
+};
+
+const createComponents = extensions => {
+  let components = [];
+  _forOwn(extensions, (value, key) => {
+    const componentType = invenioConfig.DOCUMENTS.extensions.fields[key].type;
+    const line = invenioConfig.DOCUMENTS.extensions.fields[key].line;
+    const label = invenioConfig.DOCUMENTS.extensions.fields[key].label;
+    if (componentType === 'vocabulary') {
+      components.push({
+        component: (
+          <VocabularyField
+            type={invenioConfig.DOCUMENTS.extensions.fields[key].vocabularyType}
+            fieldPath={`extensions.${key}`}
+            label={label}
+            multiple
+            placeholder={`Select ${label} ...`}
+          />
+        ),
+        line: line,
+      });
+    } else {
+      const Component = getFormComponent(componentType);
+      components.push({
+        component: (
+          <Component
+            fieldPath={`extensions.${key}`}
+            key={key}
+            label={label}
+            optimized
+            toggle={componentType === 'boolean' ? true : undefined}
+            required={_get(
+              invenioConfig,
+              `extensions.document.fields.${key}.isRequired`,
+              false
+            )}
+          />
+        ),
+        line: line,
+      });
+    }
+  });
+  return components;
+};
+
+const addToOrderedComponents = (orderedComponents, lineComponents) => {
+  orderedComponents.push(
+    <GroupField widths="equal">
+      {lineComponents.map(element => element)}
+    </GroupField>
+  );
+};
+
 export const MetadataExtensions = ({ extensions }) => {
   const { label, fields } = invenioConfig.DOCUMENTS.extensions;
   const configDefaults = {};
   _keys(fields).map(key => (configDefaults[key] = fields[key]['default']));
   const allExtensions = _merge(configDefaults, extensions);
 
-  let components = [];
-  _forOwn(allExtensions, (value, key) => {
-    const componentType = invenioConfig.DOCUMENTS.extensions.fields[key].type;
-    const Component = getFormComponent(componentType);
+  let orderedComponents = [];
+  let lineComponents = [];
+  let oldLine = 1;
 
-    components.push(
-      <Component
-        fieldPath={`extensions.${key}`}
-        key={key}
-        label={_get(
-          invenioConfig,
-          `extensions.document.fields.${key}.label`,
-          key
-        )}
-        optimized
-        required={_get(
-          invenioConfig,
-          `extensions.document.fields.${key}.isRequired`,
-          false
-        )}
-      />
-    );
+  const components = createComponents(allExtensions);
+  // Sort the components by line, to be able to loop through all the components by line
+  components.sort(sortByLine);
+  components.forEach(element => {
+    if (element.line === oldLine) {
+      lineComponents.push(element.component);
+    } else {
+      if (lineComponents) {
+        addToOrderedComponents(orderedComponents, lineComponents);
+        lineComponents = [element.component];
+        oldLine = element.line;
+      }
+    }
   });
+  if (lineComponents) {
+    addToOrderedComponents(orderedComponents, lineComponents);
+    lineComponents = [];
+  }
 
   return (
     <AccordionField
       label={label}
       fieldPath="extensions"
-      content={<>{components.map(cmp => cmp)}</>}
+      content={<>{orderedComponents.map(cmp => cmp)}</>}
     />
   );
 };


### PR DESCRIPTION
* Adds vocabularies to accelerator, experiments and
  standard_reviews

Updates the `MetadataExtension` to be able to support vocabularies and organize the extra fields in lines. Also moves these fields inside the `Additional information` section.
Related to https://github.com/CERNDocumentServer/cds-ils/pull/205
![image](https://user-images.githubusercontent.com/15194802/97457790-5fbdbd80-193a-11eb-9b11-7d656882aaa4.png)
