### PR TITLE
Cypress: add more frontsite tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "baseUrl": "https://127.0.0.1:3000"
+  "baseUrl": "https://127.0.0.1:3000",
+  "backendBaseUrl": "https://127.0.0.1:5000"
 }

--- a/cypress/integration/frontsite/footer.test.spec.js
+++ b/cypress/integration/frontsite/footer.test.spec.js
@@ -1,0 +1,19 @@
+describe('frontsite footer', () => {
+  it('should have a link to the library schedule', () => {
+    cy.visit('/');
+    cy.contains('Opening hours').click();
+    cy.contains('h2', 'Opening hours');
+  });
+
+  it('should have a link to the about page', () => {
+    cy.visit('/');
+    cy.contains('About').click();
+    cy.contains('h1', 'About');
+  });
+
+  it('should have a link to the contact page', () => {
+    cy.visit('/');
+    cy.contains('Contact').click();
+    cy.contains('h1', 'Contact');
+  });
+});

--- a/cypress/integration/frontsite/homepage.test.spec.js
+++ b/cypress/integration/frontsite/homepage.test.spec.js
@@ -18,19 +18,49 @@ describe('frontsite homepage', () => {
     cy.url().should('contain', 'ipsum');
   });
 
-  it('should be able to find the recent literature', () => {
+  it('should be able to find recent books', () => {
     cy.visit('/');
 
     cy.contains('Recent books').click();
 
     cy.url().should('contain', Cypress.config().baseUrl + '/search');
+    cy.url().should('include', 'sort=created');
+    cy.url().should('include', 'order=desc');
   });
 
-  it('should have a link to the library schedule', () => {
+  it('should be able to find most loaned books', () => {
     cy.visit('/');
 
-    cy.contains('Opening hours').click();
+    cy.contains('Most loaned books').click();
 
-    cy.contains('h2', 'Opening hours');
+    cy.url().should('contain', Cypress.config().baseUrl + '/search');
+    cy.url().should('include', 'sort=mostloaned');
+    cy.url().should('include', 'order=desc');
+  });
+
+  it('should be able to find new ebooks', () => {
+    cy.visit('/');
+
+    cy.contains('New e-books').click();
+
+    cy.url().should('contain', Cypress.config().baseUrl + '/search');
+    cy.url().should('include', 'sort=created');
+    cy.url().should('include', 'order=desc');
+    cy.url().should('include', 'doctype%3ABOOK');
+    cy.url().should('include', 'medium%3AELECTRONIC_VERSION');
+  });
+
+  it('should be able to click on first VIEW ALL', () => {
+    cy.visit('/');
+    cy.contains('VIEW ALL').click();
+    cy.url().should('contain', Cypress.config().baseUrl + '/search');
+  });
+
+  it('should be able to go to details of book', () => {
+    cy.visit('/');
+    cy.get('.fs-book-card')
+      .eq(0)
+      .click();
+    cy.url().should('contain', Cypress.config().baseUrl + '/literature');
   });
 });

--- a/cypress/integration/frontsite/homepage.test.spec.js
+++ b/cypress/integration/frontsite/homepage.test.spec.js
@@ -1,4 +1,26 @@
 describe('frontsite homepage', () => {
+  const searchRoute = Cypress.config().baseUrl + '/search';
+  const mostRecentBooksAssertion = () => {
+    cy.url()
+      .should('contain', searchRoute)
+      .and('include', 'sort=created')
+      .and('include', 'order=desc');
+  };
+  const mostLoanedBooksAssertion = () => {
+    cy.url()
+      .should('contain', searchRoute)
+      .and('include', 'sort=mostloaned')
+      .and('include', 'order=desc');
+  };
+  const mostRecentEBooksAssertion = () => {
+    cy.url()
+      .should('contain', searchRoute)
+      .and('include', 'sort=created')
+      .and('include', 'order=desc')
+      .and('include', 'doctype%3ABOOK')
+      .and('include', 'medium%3AELECTRONIC_VERSION');
+  };
+
   it('should be able to search from a query', () => {
     cy.visit('/');
 
@@ -7,7 +29,7 @@ describe('frontsite homepage', () => {
       .type('{enter}');
 
     cy.url()
-      .should('contain', Cypress.config().baseUrl + '/search')
+      .should('contain', searchRoute)
       .should('contain', 'lorem');
 
     cy.focused()
@@ -22,44 +44,51 @@ describe('frontsite homepage', () => {
     cy.visit('/');
 
     cy.contains('Recent books').click();
-
-    cy.url().should('contain', Cypress.config().baseUrl + '/search');
-    cy.url().should('include', 'sort=created');
-    cy.url().should('include', 'order=desc');
+    mostRecentBooksAssertion();
   });
 
   it('should be able to find most loaned books', () => {
     cy.visit('/');
 
     cy.contains('Most loaned books').click();
-
-    cy.url().should('contain', Cypress.config().baseUrl + '/search');
-    cy.url().should('include', 'sort=mostloaned');
-    cy.url().should('include', 'order=desc');
+    mostLoanedBooksAssertion();
   });
 
   it('should be able to find new ebooks', () => {
     cy.visit('/');
 
     cy.contains('New e-books').click();
-
-    cy.url().should('contain', Cypress.config().baseUrl + '/search');
-    cy.url().should('include', 'sort=created');
-    cy.url().should('include', 'order=desc');
-    cy.url().should('include', 'doctype%3ABOOK');
-    cy.url().should('include', 'medium%3AELECTRONIC_VERSION');
+    mostRecentEBooksAssertion();
   });
 
-  it('should be able to click on first VIEW ALL', () => {
+  it('should be able to click on VIEW ALL buttons', () => {
+    const clickViewAllLink = title => {
+      cy.get('.ui.header.section-header.highlight')
+        .contains(title)
+        .siblings('.sub.header')
+        .within(() => {
+          cy.get('a').click();
+        });
+    };
     cy.visit('/');
-    cy.contains('VIEW ALL').click();
-    cy.url().should('contain', Cypress.config().baseUrl + '/search');
+
+    clickViewAllLink('Most Recent Books');
+    mostRecentBooksAssertion();
+    cy.go('back');
+
+    clickViewAllLink('Most Loaned Books');
+    mostLoanedBooksAssertion();
+    cy.go('back');
+
+    clickViewAllLink('Most Recent E-Books');
+    mostRecentEBooksAssertion();
   });
 
-  it('should be able to go to details of book', () => {
+  it('should be able to go to details of a book', () => {
     cy.visit('/');
+
     cy.get('.fs-book-card')
-      .eq(0)
+      .first()
       .click();
     cy.url().should('contain', Cypress.config().baseUrl + '/literature');
   });

--- a/cypress/integration/frontsite/literatureDetails.test.spec.js
+++ b/cypress/integration/frontsite/literatureDetails.test.spec.js
@@ -1,12 +1,29 @@
 //https://127.0.0.1:3000/search?f=doctype%3ABOOK
 
 describe('frontsite literature details', () => {
-  const goToSearchDocument = () => {
-    // Books + available for loan
+  const goToAvailableBookDetails = () => {
     cy.visit(
       '/search?f=doctype%3ABOOK&f=availability%3Aavailable%20for%20loan'
     );
+    cy.get('.fs-book-card')
+      .first()
+      .click();
   };
+
+  const goToEBookDetails = () => {
+    cy.visit('/search?f=medium%3AELECTRONIC_VERSION');
+    cy.get('.fs-book-card')
+      .first()
+      .click();
+  };
+
+  it('should require login to request loan and access files', () => {
+    goToAvailableBookDetails();
+    cy.contains('Sign in to loan');
+    goToEBookDetails();
+    cy.contains('Sign in to loan');
+    cy.contains('Please login to see restricted files.');
+  });
 
   it('can view document details and request loan if available', () => {
     cy.server();
@@ -14,28 +31,17 @@ describe('frontsite literature details', () => {
     cy.route('GET', '/api/me/loans?document_pid=*').as('loan');
     cy.route('GET', '/api/document-requests/*').as('requests');
 
-    goToSearchDocument();
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
 
-    cy.get('.fs-book-card')
-      .first()
-      .click();
-
-    cy.url().should('contain', Cypress.config().baseUrl + '/literature/');
-
-    cy.wait('@loan').should(xhr => expect(xhr.status).to.eq(401));
-
-    cy.contains('Sign in to loan').click();
-
-    cy.get('input#email').type('patron1@test.ch');
-    cy.get('input#password').type('123456');
-    cy.contains('button.primary', 'Sign in').click();
-
+    goToAvailableBookDetails();
     cy.url().should('contain', Cypress.config().baseUrl + '/literature/');
 
     cy.contains('Yannic Vilma').click();
     cy.contains('Your loans').click();
     cy.wait('@requests');
-    cy.get(':nth-child(2).statistic > .value').then($stat1 => {
+
+    const loanRequestCountSelector = ':nth-child(2).statistic > .value';
+    cy.get(loanRequestCountSelector).then($stat1 => {
       let expectedNextCount = parseInt($stat1.text());
 
       cy.go('back');
@@ -46,21 +52,24 @@ describe('frontsite literature details', () => {
           is_requested: isRequested,
         } = xhr.response.body;
         expect(hasActiveLoan).to.be.false;
-        if (isRequested) {
+
+        if (!isRequested) {
           cy.contains('Have it delivered to my office').click();
 
           cy.get('input[name=selectedDate]').click();
 
           cy.wait('@location').wait(1000); // Cannot avoid this delay
-          cy.get('td:not(.disabled) > span.suicr-content-item')
+          const dayFromDatePicker =
+            'td:not(.disabled) > span.suicr-content-item';
+          cy.get(dayFromDatePicker)
             .first()
             .type('{enter}');
 
           cy.contains('button.primary', 'Request').click();
-          cy.contains('div.positive.message', 'Request created');
 
-          cy.wait(1000); // ES delay
+          cy.wait(5000); // ES delay
 
+          cy.contains('.header', 'Request created');
           cy.reload();
 
           expectedNextCount++;
@@ -71,7 +80,7 @@ describe('frontsite literature details', () => {
 
       cy.go('forward');
       cy.wait('@requests');
-      cy.get(':nth-child(2).statistic > .value').then($stat2 => {
+      cy.get(loanRequestCountSelector).then($stat2 => {
         const nextCount = parseInt($stat2.text());
         expect(nextCount).to.eq(expectedNextCount);
       });
@@ -79,26 +88,16 @@ describe('frontsite literature details', () => {
   });
 
   it('librarian can view document in backoffice', () => {
-    cy.visit('/login');
-    cy.get('input#email').type('librarian@test.ch');
-    cy.get('input#password').type('123456');
-    cy.contains('button.primary', 'Sign in').click();
+    cy.login({ email: 'librarian@test.ch', password: '123456' });
 
-    goToSearchDocument();
-
-    cy.get('.fs-book-card')
-      .first()
-      .click();
-
+    goToAvailableBookDetails();
     cy.contains('Open in Backoffice').click();
-
     cy.url().should(
       'contain',
       Cypress.config().baseUrl + '/backoffice/documents/'
     );
 
     cy.contains('View in Frontsite').click();
-
     cy.url().should('contain', Cypress.config().baseUrl + '/literature/');
   });
 });

--- a/cypress/integration/frontsite/literatureRequest.test.spec.js
+++ b/cypress/integration/frontsite/literatureRequest.test.spec.js
@@ -1,0 +1,30 @@
+describe('literature request form', () => {
+  it('should redirect to login if not logged in', () => {
+    cy.shouldRedirectToLogin('/request');
+  });
+
+  it('should display form when logged in', () => {
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
+    cy.visit('/request');
+    cy.url().should('eq', Cypress.config().baseUrl + '/request');
+    cy.contains('h1', 'Request new literature');
+  });
+
+  it('should submit form', () => {
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
+    cy.visit('/request');
+
+    cy.get('input#title').type('A new book');
+    cy.get('div#medium').click();
+    cy.get('span')
+      .contains('Paper')
+      .click();
+    cy.get('div#request_type').click();
+    cy.get('span')
+      .contains('Loan')
+      .click();
+    cy.get('button[name=submit]').click();
+
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+  });
+});

--- a/cypress/integration/frontsite/navbar.test.spec.js
+++ b/cypress/integration/frontsite/navbar.test.spec.js
@@ -1,47 +1,27 @@
 describe('navbar links', () => {
-  Cypress.Cookies.defaults({
-    preserve: 'csrftoken',
-  });
-  //   it('should be able to go to login page', () => {
-  //     cy.visit('/');
-  //     cy.contains('Sign in').click();
-  //     cy.url().should('include', '/login');
-  //   });
-
-  it('should be able to go to profile page when user logged in', () => {
+  it('should be able to go to login page', () => {
     cy.visit('/');
-    cy.server();
-
-    cy.request('https://127.0.0.1:5000/login')
-      .its('headers')
-      .then(headers => {
-        const csrf = headers['set_cookie'];
-
-        cy.request({
-          method: 'POST',
-          url: 'https://127.0.0.1:5000/api/login',
-          failOnStatusCode: false,
-          // auth: {
-          //   username: 'user@user',
-          //   password: 'user123',
-          // },
-          headers: {
-            Origin: 'https://127.0.0.1:3000',
-            Referer: 'https://127.0.0.1:3000/',
-            HTTP_X_CSRFTOKEN: csrf,
-          },
-          body: {
-            email: 'patron1@test.ch',
-            password: '123456',
-            _submitButton: 'submit',
-          },
-        });
-      });
+    cy.contains('Sign in').click();
+    cy.url().should('include', '/login');
   });
 
-  //   it('should be able to go to login page', () => {
-  //     cy.visit('/');
-  //     cy.contains('Sign in').click();
-  //     cy.url().should('include', '/login');
-  //   });
+  it('should be able to go to profile when patron is logged in', () => {
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
+
+    cy.visit('/');
+    cy.contains('Yannic Vilma').click();
+    cy.contains('Your loans').click();
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+    cy.contains('h2', 'Your activity');
+  });
+
+  it('should be able to go to backoffice when librarian is logged in', () => {
+    cy.login({ email: 'librarian@test.ch', password: '123456' });
+
+    cy.visit('/');
+    cy.contains('Hector Nabu').click();
+    cy.contains('Your loans').click();
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+    cy.contains('h2', 'Your activity');
+  });
 });

--- a/cypress/integration/frontsite/navbar.test.spec.js
+++ b/cypress/integration/frontsite/navbar.test.spec.js
@@ -1,0 +1,47 @@
+describe('navbar links', () => {
+  Cypress.Cookies.defaults({
+    preserve: 'csrftoken',
+  });
+  //   it('should be able to go to login page', () => {
+  //     cy.visit('/');
+  //     cy.contains('Sign in').click();
+  //     cy.url().should('include', '/login');
+  //   });
+
+  it('should be able to go to profile page when user logged in', () => {
+    cy.visit('/');
+    cy.server();
+
+    cy.request('https://127.0.0.1:5000/login')
+      .its('headers')
+      .then(headers => {
+        const csrf = headers['set_cookie'];
+
+        cy.request({
+          method: 'POST',
+          url: 'https://127.0.0.1:5000/api/login',
+          failOnStatusCode: false,
+          // auth: {
+          //   username: 'user@user',
+          //   password: 'user123',
+          // },
+          headers: {
+            Origin: 'https://127.0.0.1:3000',
+            Referer: 'https://127.0.0.1:3000/',
+            HTTP_X_CSRFTOKEN: csrf,
+          },
+          body: {
+            email: 'patron1@test.ch',
+            password: '123456',
+            _submitButton: 'submit',
+          },
+        });
+      });
+  });
+
+  //   it('should be able to go to login page', () => {
+  //     cy.visit('/');
+  //     cy.contains('Sign in').click();
+  //     cy.url().should('include', '/login');
+  //   });
+});

--- a/cypress/integration/frontsite/profile.test.spec.js
+++ b/cypress/integration/frontsite/profile.test.spec.js
@@ -1,0 +1,79 @@
+describe('frontsite profile', () => {
+  it('should redirect to login if not logged in', () => {
+    cy.shouldRedirectToLogin('/profile');
+  });
+
+  it('should go to current tab if logged in', () => {
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
+    cy.visit('/profile');
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+    cy.get('a').should('contain', 'Current');
+    cy.get('a')
+      .contains('Current')
+      .should('have.class', 'active');
+    cy.contains('h2', 'Your current loans');
+  });
+
+  it('should change tab when tab is clicked', () => {
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
+    cy.visit('/profile');
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+    cy.get('a').should('contain', 'History');
+    cy.get('a')
+      .contains('History')
+      .click();
+    cy.contains('h2', 'Your past loans');
+  });
+
+  it('should cancel loan request', () => {
+    cy.login({ email: 'patron2@test.ch', password: '123456' });
+    cy.visit('/profile');
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+
+    const loanRequestDiv = '.ui.divided.items';
+
+    if (cy.get(loanRequestDiv).contains('Cancel request')) {
+      cy.get(loanRequestDiv).within(() => {
+        cy.contains('.button', 'Cancel request').click();
+      });
+      cy.contains('Are you sure you want to cancel your loan request?');
+      cy.contains('Yes, I am sure').click();
+    }
+  });
+
+  it('should cancel document request', () => {
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
+    cy.visit('/profile');
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+
+    if (cy.get('table').contains('Cancel request')) {
+      cy.get('table').within(() => {
+        cy.contains('.button', 'Cancel request').click();
+      });
+      cy.contains('Are you sure you want to cancel your request?');
+      cy.contains('Yes, I am sure').click();
+    }
+  });
+
+  it('should request extension for loan', () => {
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
+    cy.visit('/profile');
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+
+    cy.get('button')
+      .contains('Request extension')
+      .should('not.be.disabled')
+      .click();
+  });
+
+  it('should go to details page when clicking a document', () => {
+    cy.login({ email: 'patron1@test.ch', password: '123456' });
+    cy.visit('/profile');
+    cy.url().should('eq', Cypress.config().baseUrl + '/profile');
+
+    cy.get('.document-title')
+      .eq(0)
+      .click();
+    cy.url().should('contain', Cypress.config().baseUrl + '/literature');
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,31 @@
+Cypress.Commands.add('login', user => {
+  cy.server();
+
+  let cookie;
+
+  cy.getCookie('csrftoken')
+    .should('exist')
+    .then(c => {
+      cookie = c;
+
+      cy.request({
+        method: 'POST',
+        url: Cypress.config().backendBaseUrl + '/api/login',
+        headers: {
+          Origin: Cypress.config().baseUrl,
+          Referer: Cypress.config().baseUrl,
+          HTTP_X_CSRFTOKEN: cookie.value,
+        },
+        body: {
+          email: user.email,
+          password: user.password,
+          _submitButton: 'submit',
+        },
+      });
+    });
+});
+
+Cypress.Commands.add('shouldRedirectToLogin', route => {
+  cy.visit(route);
+  cy.url().should('contain', '/login');
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,1 +1,5 @@
 import './commands';
+
+Cypress.Cookies.defaults({
+  preserve: 'csrftoken',
+});


### PR DESCRIPTION
Added tests for frontsite. 

About this [comment](https://github.com/inveniosoftware/react-invenio-app-ils/pull/240#discussion_r506142014) I thought wrapping the selectors in variables is easier e.g. `const header = '.ui.header'` instead of using ids. 

Removed some status checks e.g. `cy.wait('@loan').should(xhr => expect(xhr.status).to.eq(401));` since we should be testing the ui and not the backend. 

Added custom command to login by making a backend request instead of using the ui ([comment](https://github.com/inveniosoftware/react-invenio-app-ils/pull/240#discussion_r506170328)).