### PR TITLE
pagination: hide last page item

### DIFF
--- a/src/lib/components/Pagination/Pagination.js
+++ b/src/lib/components/Pagination/Pagination.js
@@ -12,7 +12,6 @@ class Pagination extends Component {
       currentSize = invenioConfig.APP.DEFAULT_RESULTS_SIZE,
       onPageChange,
       loading,
-      simple,
       firstItem,
       lastItem,
       totalPages: _,
@@ -32,8 +31,8 @@ class Pagination extends Component {
           <Paginator
             activePage={currentPage}
             totalPages={totalDisplayedPages}
-            firstItem={simple ? null : firstItem}
-            lastItem={simple ? null : lastItem}
+            firstItem={null}
+            lastItem={null}
             onPageChange={(event, { activePage }) => onPageChange(activePage)}
             {...extraParams}
           />
@@ -50,13 +49,8 @@ Pagination.propTypes = {
   totalResults: PropTypes.number.isRequired,
   onPageChange: PropTypes.func.isRequired,
   loading: PropTypes.bool,
-  simple: PropTypes.bool,
   firstItem: PropTypes.any,
   lastItem: PropTypes.any,
-};
-
-Pagination.defaultProps = {
-  simple: false,
 };
 
 export default Overridable.component('Pagination', Pagination);

--- a/src/lib/modules/Relations/backoffice/components/ExistingRelations.js
+++ b/src/lib/modules/Relations/backoffice/components/ExistingRelations.js
@@ -37,7 +37,6 @@ export class ExistingRelations extends Component {
             currentSize={showMaxRows}
             totalResults={rows.length}
             onPageChange={this.onPageChange}
-            simple
           />
         }
       />

--- a/src/lib/pages/frontsite/PatronProfile/LoansList.js
+++ b/src/lib/pages/frontsite/PatronProfile/LoansList.js
@@ -30,7 +30,6 @@ export default class LoansList extends Component {
             loading={isLoading}
             onPageChange={onPageChange}
             totalResults={loans.total}
-            simple
           />
         </Container>
       </>

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentDocumentRequests/PatronCurrentDocumentRequests.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentDocumentRequests/PatronCurrentDocumentRequests.js
@@ -286,7 +286,6 @@ class PatronCurrentDocumentRequests extends Component {
                     loading={isLoading}
                     onPageChange={this.onPageChange}
                     totalResults={documentRequests.total}
-                    simple
                   />
                 </Container>
               )}

--- a/src/lib/pages/frontsite/PatronProfile/PatronPastDocumentRequests/PatronPastDocumentRequests.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronPastDocumentRequests/PatronPastDocumentRequests.js
@@ -52,7 +52,6 @@ class PatronPastDocumentRequests extends Component {
         loading={isLoading}
         totalResults={documentRequests.total}
         onPageChange={this.onPageChange}
-        simple
       />
     );
   };
@@ -124,7 +123,6 @@ class PatronPastDocumentRequests extends Component {
                     loading={isLoading}
                     onPageChange={this.onPageChange}
                     totalResults={documentRequests.total}
-                    simple
                   />
                 </Container>
               )}

--- a/src/semantic-ui/site/globals/site.overrides
+++ b/src/semantic-ui/site/globals/site.overrides
@@ -137,6 +137,11 @@ a {
   justify-content: center;
 }
 
+.ui.pagination [type=ellipsisItem]:nth-last-child(3) + [type=pageItem] {
+  /* Workaround to hide the last page item button */
+  display: none !important;
+}
+
 /* FRONTSITE */
 
 @media only screen and (max-width: @largestMobileScreen) {


### PR DESCRIPTION
Tiny PR that aims to revise pagination. It does not make sense to display a button to go to the last page, firstly because in production the last page may not correspond to the last data entry but rather the last match within the allowed window (currently set at 10k).
Semantic-UI does not provide a way to avoid displaying a button for the last page, we can only control the side buttons; thus as suggested by @kprzerwa if we want to avoid rewriting the entire component the easiest solution is to fix it using CSS.

* First modification is to disable the <kbd><<</kbd> and <kbd>>></kbd> buttons, directly in the overriden component (which was conveniently tweaked to be the global pagination component, in a recent PR)
* Second one is to use a CSS selector that searches for a <kbd>…</kbd> at position 3 starting from the right hand side, and hides the next sibling (which turns out to be the last page)

Preview of the new look (for a result set that fits in 11 displayable pages):

![Capture d’écran de 2020-10-27 13-46-16](https://user-images.githubusercontent.com/9027075/97305106-f4ea8480-185c-11eb-8845-4624d55759dc.png)
![Capture d’écran de 2020-10-27 13-46-03](https://user-images.githubusercontent.com/9027075/97305100-f320c100-185c-11eb-970b-993826e94f3d.png)
![Capture d’écran de 2020-10-27 13-45-41](https://user-images.githubusercontent.com/9027075/97305094-f156fd80-185c-11eb-87c8-1521bf7404a0.png)
![Capture d’écran de 2020-10-27 14-04-05](https://user-images.githubusercontent.com/9027075/97305415-57438500-185d-11eb-8d5d-5f205d79d374.png)
