### PR TITLE
fix price field

### DIFF
--- a/src/lib/forms/core/BaseForm/RecordSerializer.js
+++ b/src/lib/forms/core/BaseForm/RecordSerializer.js
@@ -22,6 +22,9 @@ export const removeEmptyValues = obj => {
       }
     } else if (val && _isObject(val)) {
       removeEmptyValues(val);
+      if (Object.entries(val).every(([k, v]) => v === undefined)) {
+        obj[key] = undefined;
+      }
     } else if (val === '') obj[key] = undefined;
   });
 };

--- a/src/lib/forms/core/BaseForm/RecordSerializer.test.js
+++ b/src/lib/forms/core/BaseForm/RecordSerializer.test.js
@@ -14,7 +14,7 @@ describe('removeEmptyValues', () => {
 
     const expectedObject = {
       authors: [{ name: 'Joe', surname: undefined }],
-      contributors: [{ identifiers: undefined }],
+      contributors: [undefined],
       roles: undefined,
       version: 0,
       cool: false,
@@ -96,7 +96,7 @@ describe('removeEmptyValues', () => {
       pid: 'c1dg5-6aj21',
       publication_year: '123',
       restricted: false,
-      stock: { mediums: undefined },
+      stock: undefined,
       title: 'Title',
       urls: [
         { value: 'http://localhost:3000/backoffice/documents/create' },


### PR DESCRIPTION
* closes #155

The following changes and simplifications were made to the price field in order to finally make it work correctly:
* the serializer recursively clears the nested objects with empty values
  * for instance `{ a: { b: '' } }` will become `{}`
  * this also fixes other issues with accordions that were touched but eventually left unfilled and collapsed
* in case of a fixed currency, the feature of displaying a label was discarded in favor of the dropdown
  * instead of displaying all currencies the dropdown only shows `defaultCurrency` 
* the currency dropdown always contains an empty value <kbd>-</kbd> and defaults to that
* semantic-UI has bogus error popups for grouped inputs; we now make sure the field is at least highlighted red on any error

As an illustration, the following price field is correctly filled:
![](https://user-images.githubusercontent.com/9027075/97413545-33d31580-1903-11eb-9d98-5d2ba80a42f1.png)
These two are considered non-empty - and incorrect (respectively, the value field is nonempty and the currency dropdown is nonempty):
![](https://user-images.githubusercontent.com/9027075/97411441-924ac480-1900-11eb-89d9-0586d296b868.png)
While this one is considered empty (and treated as such):
![](https://user-images.githubusercontent.com/9027075/97411615-cc1bcb00-1900-11eb-9973-da58b874e8e7.png)
