### PR TITLE
Relations: disable add relation button, remove empty edition from frontsite document card

### DIFF
--- a/src/lib/modules/Document/DocumentCard/DocumentCard.js
+++ b/src/lib/modules/Document/DocumentCard/DocumentCard.js
@@ -69,7 +69,7 @@ class DocumentCard extends Component {
                     {toShortDate(_get(metadata, 'imprints[0].date'))} <br />{' '}
                   </>
                 ) : null}
-                Edition {metadata.edition}
+                {metadata.edition && <>Edition {metadata.edition}</>}
               </div>
             </Card.Meta>
           </Card.Content>

--- a/src/lib/modules/Document/DocumentInfo.js
+++ b/src/lib/modules/Document/DocumentInfo.js
@@ -55,10 +55,13 @@ export class DocumentInfo extends Component {
                 />
               </Table.Cell>
             </Table.Row>
-            <Table.Row>
-              <Table.Cell>Edition</Table.Cell>
-              <Table.Cell>{metadata.edition}</Table.Cell>
-            </Table.Row>
+            {metadata.edition && (
+              <Table.Row>
+                <Table.Cell>Edition</Table.Cell>
+                <Table.Cell>{metadata.edition}</Table.Cell>
+              </Table.Row>
+            )}
+
             {this.renderLanguages()}
             {this.renderKeywords()}
           </Table.Body>

--- a/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.js
+++ b/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.js
@@ -127,18 +127,24 @@ export default class DocumentListEntry extends Component {
               {this.renderImprintInfo()}
               <Grid.Column width={4}>
                 <List>
-                  <List.Item>
-                    <List.Content>
-                      <span>Edition: </span>
-                      {this.metadata.edition}
-                    </List.Content>
-                  </List.Item>
-                  <List.Item>
-                    <List.Content>
-                      <span>Languages: </span>
-                      <DocumentLanguages languages={this.metadata.languages} />
-                    </List.Content>
-                  </List.Item>
+                  {this.metadata.edition && (
+                    <List.Item>
+                      <List.Content>
+                        <span>Edition: </span>
+                        {this.metadata.edition}
+                      </List.Content>
+                    </List.Item>
+                  )}
+                  {this.metadata.languages && (
+                    <List.Item>
+                      <List.Content>
+                        <span>Languages: </span>
+                        <DocumentLanguages
+                          languages={this.metadata.languages}
+                        />
+                      </List.Content>
+                    </List.Item>
+                  )}
                 </List>
               </Grid.Column>
             </Grid>

--- a/src/lib/modules/Relations/backoffice/RelationEdition/RelationEditionModal/RelationEditionModal.js
+++ b/src/lib/modules/Relations/backoffice/RelationEdition/RelationEditionModal/RelationEditionModal.js
@@ -67,6 +67,8 @@ export default class RelationEditionModal extends Component {
     return (
       <RelationModal
         triggerButtonContent="Attach editions"
+        disabled={!recordDetails.metadata.edition}
+        disabledContent="Please specify an edition for this record before adding an edition relation."
         modalHeader="Attach editions"
         isLoading={isLoading}
         relationType={relationType}

--- a/src/lib/modules/Relations/backoffice/components/RelationModal/RelationModal.js
+++ b/src/lib/modules/Relations/backoffice/components/RelationModal/RelationModal.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Icon, Modal } from 'semantic-ui-react';
+import { Button, Icon, Modal, Popup } from 'semantic-ui-react';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 
@@ -51,6 +51,7 @@ export default class RelationModal extends Component {
       children,
       disabled,
       triggerButtonContent,
+      disabledContent,
       modalHeader,
       isLoading: externalLoading,
       selections,
@@ -69,17 +70,25 @@ export default class RelationModal extends Component {
         size="large"
         closeIcon
         trigger={
-          <Button
-            disabled={disabled}
-            className="edit-related"
-            icon
-            labelPosition="left"
-            positive
-            onClick={this.toggle}
-          >
-            <Icon name="add" />
-            {triggerButtonContent}
-          </Button>
+          <>
+            <Button
+              disabled={disabled}
+              className="edit-related"
+              icon
+              labelPosition="left"
+              positive
+              onClick={this.toggle}
+            >
+              <Icon name="add" />
+              {triggerButtonContent}
+            </Button>
+            {disabled && disabledContent && (
+              <Popup
+                content={disabledContent}
+                trigger={<Icon size="large" name="info circle" color="grey" />}
+              />
+            )}
+          </>
         }
         open={visible}
         centered
@@ -109,6 +118,7 @@ export default class RelationModal extends Component {
 RelationModal.propTypes = {
   disabled: PropTypes.bool,
   triggerButtonContent: PropTypes.string.isRequired,
+  disabledContent: PropTypes.string,
   modalHeader: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     .isRequired,
   isLoading: PropTypes.bool,
@@ -126,4 +136,5 @@ RelationModal.defaultProps = {
   extraRelationField: {},
   disabled: false,
   isLoading: false,
+  disabledContent: null,
 };

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentRelations/RelationLanguages/RelationLanguagesModal/RelationLanguagesModal.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentRelations/RelationLanguages/RelationLanguagesModal/RelationLanguagesModal.js
@@ -47,6 +47,8 @@ export default class RelationLanguagesModal extends Component {
     return (
       <RelationModal
         triggerButtonContent="Add language relations"
+        disabled={!documentDetails.metadata.languages}
+        disabledContent="Please specify a language for this record before adding a language relation."
         modalHeader={
           <>
             Attach translations <Icon size="large" name="language" />

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesRelations/RelationLanguages/RelationLanguagesModal/RelationLanguagesModal.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesRelations/RelationLanguages/RelationLanguagesModal/RelationLanguagesModal.js
@@ -53,6 +53,8 @@ export default class RelationLanguagesModal extends Component {
     return (
       <RelationModal
         triggerButtonContent="Add language relations"
+        disabled={!seriesDetails.metadata.languages}
+        disabledContent="Please specify a language for this record before adding a language relation."
         modalHeader={
           <>
             Attach translations <Icon size="large" name="language" />


### PR DESCRIPTION
When a document/series doesn't have the edition or languages field filled the button to attach a new relation is disabled until the respective field is filled. Also if the edition of a document/series is empty, it is not longer displayed in the frontsite search page documents card.

![Screenshot 2020-11-05 at 13 59 17](https://user-images.githubusercontent.com/33685068/98244404-ada47800-1f6f-11eb-97e2-6270f245eadf.png)

