### PR TITLE
fixes duplication error

### DIFF
--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentCirculation/DocumentCirculation.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentCirculation/DocumentCirculation.js
@@ -28,10 +28,8 @@ class DocumentCirculation extends Component {
   };
 
   renderLoanRequestForm = () => {
-    const {
-      documentDetails,
-      loansInfo: { last_loan: lastLoan },
-    } = this.props;
+    const { documentDetails, loansInfo } = this.props;
+    const lastLoan = loansInfo ? loansInfo.last_loan : null;
     return <LoanRequestForm document={documentDetails} lastLoan={lastLoan} />;
   };
 


### PR DESCRIPTION
This PR pretends to solve this error: `UI error when duplicating literature details tab on frontsite`, but take into account that is not reproducible locally, but is happening on dev and sandbox environments. 
Error on sandbox/dev:
![image](https://user-images.githubusercontent.com/15194802/97731609-a562bd80-1ad5-11eb-9071-0774fd2cdc62.png)
