### PR TITLE
CheckoutSearch: get results for email without quotes

### DIFF
--- a/src/lib/api/patrons/patron.js
+++ b/src/lib/api/patrons/patron.js
@@ -33,7 +33,7 @@ class QueryBuilder {
     this.patronQuery = [];
   }
 
-  withEmail(email, wildcard = false) {
+  withEmail(email) {
     if (!email) {
       throw TypeError('Email argument missing');
     }

--- a/src/lib/api/patrons/patron.js
+++ b/src/lib/api/patrons/patron.js
@@ -37,7 +37,7 @@ class QueryBuilder {
     if (!email) {
       throw TypeError('Email argument missing');
     }
-    this.patronQuery.push(`email:${email}${wildcard ? '*' : ''}`);
+    this.patronQuery.push(`email:${email}`);
     return this;
   }
 

--- a/src/lib/api/patrons/patron.test.js
+++ b/src/lib/api/patrons/patron.test.js
@@ -33,7 +33,7 @@ describe('Patron query builder tests', () => {
       .query()
       .withEmail('test', true)
       .qs();
-    expect(query).toEqual('(email:test*)');
+    expect(query).toEqual('(email:test)');
   });
 
   it('should build query string with configured custom fields', () => {
@@ -56,7 +56,7 @@ describe('Patron query builder tests', () => {
       .withCustomField(term)
       .qs();
     expect(query).toEqual(
-      `(name:${term}* OR email:${term}* OR ${invenioConfig.PATRONS.customFields.mockField.field}:${term})`
+      `(name:${term}* OR email:${term} OR ${invenioConfig.PATRONS.customFields.mockField.field}:${term})`
     );
   });
 

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/actions.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/actions.js
@@ -33,7 +33,7 @@ const searchPatrons = async (dispatch, term) => {
     patronApi
       .query()
       .withPid(term, true)
-      .withEmail(term, true)
+      .withEmail(term)
       .withName(term, true)
       .withCustomField(term)
       .qs(),


### PR DESCRIPTION
When searching by an email in the checkout page before there were no results at all when you didn't wrap the email in quotes. Now it shows results without quotes.
Closes partially CERNDocumentServer/cds-ils#214