### PR TITLE
search: improve searchbar

### DIFF
--- a/src/lib/components/SearchBar/SearchBarILS.js
+++ b/src/lib/components/SearchBar/SearchBarILS.js
@@ -33,6 +33,7 @@ export class SearchBarILS extends Component {
       onKeyPressHandler: parentKeyPressHandler,
       onSearchHandler,
       onPasteHandler,
+      onChangeHandler,
       placeholder,
       ...rest
     } = this.props;
@@ -45,6 +46,7 @@ export class SearchBarILS extends Component {
         }}
         onChange={(event, { value }) => {
           this.setState({ currentValue: value });
+          onChangeHandler && onChangeHandler(value);
         }}
         onKeyPress={parentKeyPressHandler || this.onKeyPressHandler}
         onPaste={onPasteHandler || this.onPasteHandler}
@@ -65,6 +67,7 @@ SearchBarILS.propTypes = {
   onKeyPressHandler: PropTypes.func,
   onPasteHandler: PropTypes.func,
   onSearchHandler: PropTypes.func.isRequired,
+  onChangeHandler: PropTypes.func,
   placeholder: PropTypes.string,
   className: PropTypes.string,
 };
@@ -72,6 +75,7 @@ SearchBarILS.propTypes = {
 SearchBarILS.defaultProps = {
   onKeyPressHandler: null,
   onPasteHandler: null,
+  onChangeHandler: null,
   placeholder: '',
   className: '',
 };

--- a/src/lib/components/SearchBar/__snapshots__/SearchBarILS.test.js.snap
+++ b/src/lib/components/SearchBar/__snapshots__/SearchBarILS.test.js.snap
@@ -3,6 +3,7 @@
 exports[`SearchBar tests should match snapshot 1`] = `
 <SearchBarILS
   className=""
+  onChangeHandler={null}
   onKeyPressHandler={null}
   onPasteHandler={null}
   onSearchHandler={[Function]}

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
@@ -188,6 +188,7 @@ class DocumentDetails extends Component {
           <Container fluid className="literature-search-container">
             <Container>
               <SearchBarILS
+                onPasteHandler={() => {}}
                 onSearchHandler={this.onSearchClick}
                 placeholder={invenioConfig.APP.HOME_SEARCH_BAR_PLACEHOLDER}
                 className="fs-headline"

--- a/src/lib/pages/frontsite/Home/Headline/HomeSearchBar.js
+++ b/src/lib/pages/frontsite/Home/Headline/HomeSearchBar.js
@@ -13,6 +13,7 @@ export class HomeSearchBar extends Component {
   render() {
     return (
       <SearchBarILS
+        onPasteHandler={() => {}}
         onSearchHandler={this.onSearchExecute}
         placeholder={invenioConfig.APP.HOME_SEARCH_BAR_PLACEHOLDER}
         className="fs-headline"

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
@@ -152,6 +152,7 @@ class SeriesDetails extends React.Component {
           >
             <Container>
               <SearchBarILS
+                onPasteHandler={() => {}}
                 onSearchHandler={this.onSearchClick}
                 placeholder={invenioConfig.APP.HOME_SEARCH_BAR_PLACEHOLDER}
                 className="fs-headline"


### PR DESCRIPTION
* implement loan checkout workflow with barcode reader (closes #235)
* disable search on paste on frontsite (closes #264)

Loan checkout behavior that this PR implements:
* if the librarian scans an item and all the conditions are met for this item to be loaned, then the item is shown in the search results and a checkout action is automatically triggered (as opposed to searching for an item and then clicking on the button)
* the same happens when a barcode is manually typed and submitted (= clicking on the search button or hitting enter)
* an information message indicates the existence of this behavior when it is applicable
* when typing, the search results are updated accordingly (filtered, since no request is performed). That is, all the items having a barcode starting with the query will be shown

![Capture d’écran de 2020-11-06 09-35-54](https://user-images.githubusercontent.com/9027075/98344984-50163700-2014-11eb-8bcb-f78e76687d50.png)
