### PR TITLE
backoffice: update location form opening hours

### DIFF
--- a/src/lib/pages/backoffice/Location/LocationForms/LocationEditor/components/LocationForm/Closures/Closures.js
+++ b/src/lib/pages/backoffice/Location/LocationForms/LocationEditor/components/LocationForm/Closures/Closures.js
@@ -1,22 +1,33 @@
 import React, { Component } from 'react';
-import { Segment, Grid, Header, Message } from 'semantic-ui-react';
+import {
+  Segment,
+  Grid,
+  Header,
+  Message,
+  Button,
+  Icon,
+} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
 import { BooleanField } from '@forms/core/BooleanField';
 import { HourField } from './HourField';
 import { ExceptionsField } from './ExceptionsField';
-import { Field } from 'formik';
+import { Field, getIn } from 'formik';
 
-export default class Closures extends Component {
-  renderError = fieldPath => {
-    return (
-      <Field
-        name="error-message"
-        component={({ form: { errors } }) =>
-          fieldPath in errors && (
-            <Message negative content={errors[fieldPath]} />
-          )
-        }
-      />
-    );
+class Weekday extends Component {
+  state = {
+    singlePeriod: null,
+  };
+
+  handleAddPeriod = (props, fieldPath) => {
+    this.setState({ singlePeriod: false });
+  };
+
+  handleRemovePeriod = (props, fieldPath) => {
+    const {
+      form: { setFieldValue },
+    } = props;
+    setFieldValue(`${fieldPath}.1`, null);
+    this.setState({ singlePeriod: true });
   };
 
   renderHourField = (fieldPath, index, placeholder) => {
@@ -44,12 +55,23 @@ export default class Closures extends Component {
     );
   };
 
-  renderWeekday = (pathPrefix, weekday, arrayPath) => {
-    const fieldPathIsOpen = `${pathPrefix}.${arrayPath}.is_open`;
-    const fieldPath = `${pathPrefix}.${arrayPath}.times`;
+  renderField = props => {
+    const { pathPrefix, weekday, arrayPath, errorRenderer } = this.props;
+    const {
+      form: { values },
+    } = props;
+    const { singlePeriod: singlePeriodState } = this.state;
+    const groupPath = `${pathPrefix}.${arrayPath}`;
+    const fieldPathIsOpen = `${groupPath}.is_open`;
+    const fieldPath = `${groupPath}.times`;
+    const disabled = !getIn(values, fieldPathIsOpen, null);
+    const singlePeriod =
+      singlePeriodState !== null
+        ? singlePeriodState
+        : getIn(values, fieldPath, []).length !== 2;
     return (
       <Grid.Row key={arrayPath}>
-        <Grid.Column width={16}>{this.renderError(fieldPath)}</Grid.Column>
+        <Grid.Column width={16}>{errorRenderer(fieldPath)}</Grid.Column>
         <Grid.Column width={3}>
           <BooleanField
             rightLabel={weekday}
@@ -58,9 +80,61 @@ export default class Closures extends Component {
           />
         </Grid.Column>
         {this.renderHoursPeriod(arrayPath, fieldPath, 0)}
-        <Grid.Column width={1} />
-        {this.renderHoursPeriod(arrayPath, fieldPath, 1)}
+        {singlePeriod ? (
+          <Grid.Column width={1}>
+            <Button
+              secondary
+              basic
+              onClick={this.handleAddPeriod}
+              disabled={disabled}
+            >
+              <Icon name="add" fitted />
+            </Button>
+          </Grid.Column>
+        ) : (
+          <>
+            <Grid.Column width={1} />
+            {this.renderHoursPeriod(arrayPath, fieldPath, 1)}
+            <Grid.Column width={1}>
+              <Button
+                secondary
+                basic
+                onClick={() => this.handleRemovePeriod(props, fieldPath)}
+                disabled={disabled}
+              >
+                <Icon name="delete" fitted />
+              </Button>
+            </Grid.Column>
+          </>
+        )}
       </Grid.Row>
+    );
+  };
+
+  render() {
+    const { weekday } = this.props;
+    return <Field name={weekday} component={this.renderField} />;
+  }
+}
+
+Weekday.propTypes = {
+  pathPrefix: PropTypes.string.isRequired,
+  weekday: PropTypes.string.isRequired,
+  arrayPath: PropTypes.number.isRequired,
+  errorRenderer: PropTypes.func.isRequired,
+};
+
+export default class Closures extends Component {
+  renderError = fieldPath => {
+    return (
+      <Field
+        name="error-message"
+        component={({ form: { errors } }) =>
+          fieldPath in errors && (
+            <Message negative content={errors[fieldPath]} />
+          )
+        }
+      />
     );
   };
 
@@ -81,9 +155,15 @@ export default class Closures extends Component {
           <Header as="h4">Opening hours</Header>
           {this.renderError(weekdaysFieldPath)}
           <Grid columns={6}>
-            {weekdays.map((weekday, i) =>
-              this.renderWeekday(weekdaysFieldPath, weekday, i)
-            )}
+            {weekdays.map((weekday, i) => (
+              <Weekday
+                key={weekday}
+                pathPrefix={weekdaysFieldPath}
+                weekday={weekday}
+                arrayPath={i}
+                errorRenderer={this.renderError}
+              />
+            ))}
           </Grid>
         </Segment>
         <Segment>

--- a/src/lib/pages/backoffice/Location/LocationForms/LocationEditor/components/LocationForm/Closures/HourField.js
+++ b/src/lib/pages/backoffice/Location/LocationForms/LocationEditor/components/LocationForm/Closures/HourField.js
@@ -31,6 +31,7 @@ export class HourField extends Component {
       parentFieldPath,
       index,
       dependantValue,
+      required,
     } = this.props;
     const {
       form: { values, errors },
@@ -57,6 +58,7 @@ export class HourField extends Component {
           onChange={(value, name) => {
             this.handleChange(props, value, name);
           }}
+          required={required}
         />
       </Form.Field>
     );
@@ -78,6 +80,7 @@ HourField.propTypes = {
   inline: PropTypes.bool,
   optimized: PropTypes.bool,
   width: PropTypes.number,
+  required: PropTypes.bool,
 };
 
 HourField.defaultProps = {
@@ -88,4 +91,5 @@ HourField.defaultProps = {
   optimized: false,
   width: 16,
   placeholder: '',
+  required: false,
 };

--- a/src/lib/pages/backoffice/Location/LocationForms/LocationEditor/components/LocationForm/LocationForm.js
+++ b/src/lib/pages/backoffice/Location/LocationForms/LocationEditor/components/LocationForm/LocationForm.js
@@ -86,6 +86,8 @@ export class LocationForm extends Component {
     data['opening_weekdays'].forEach(element => {
       if (!element['is_open']) {
         delete element['times'];
+      } else if (element['times']) {
+        element['times'] = element['times'].filter(e => e);
       }
     });
     if (data['opening_exceptions'] === undefined) {


### PR DESCRIPTION
* closes inveniosoftware/invenio-app-ils#980, assuming inveniosoftware/invenio-app-ils#981 is already merged (but AFAIK no blocking dependency)

For the sake of simplicity, the two period fields are always there. The user may leave a pair of inputs empty, and it will be filtered out. The consequence is that if the period is defined in the second pair, it will be moved to the first (as illustrated below).

(before submission)
![](https://user-images.githubusercontent.com/9027075/98351575-2b728d00-201d-11eb-82ff-56c9a8c3bfb2.png)
(after submission, when editing again)
![](https://user-images.githubusercontent.com/9027075/98351576-2c0b2380-201d-11eb-9dd2-6dba3bb79517.png)
