### PR TITLE
RSK: integrates latest changes

### DIFF
--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -126,18 +126,24 @@ export const RECORDS_CONFIG = {
         },
         {
           order: 2,
+          sortBy: 'bestmatch',
+          sortOrder: 'asc',
+          text: 'Most relevant',
+        },
+        {
+          order: 3,
           sortBy: 'order_date',
           sortOrder: 'desc',
           text: 'Order date',
         },
         {
-          order: 3,
+          order: 4,
           sortBy: 'expected_delivery_date',
           sortOrder: 'desc',
           text: 'Expected delivery date',
         },
         {
-          order: 4,
+          order: 5,
           sortBy: 'grand_total',
           sortOrder: 'desc',
           text: `Total (${DEFAULT_CURRENCY})`,
@@ -154,18 +160,24 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
+          sortBy: 'created',
+          sortOrder: 'desc',
+          text: 'Recently added',
+        },
+        {
+          order: 2,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
           text: 'Most relevant',
         },
         {
-          order: 2,
+          order: 3,
           sortBy: 'name',
           sortOrder: 'asc',
           text: 'Name [A-Z]',
         },
         {
-          order: 2,
+          order: 4,
           sortBy: 'name',
           sortOrder: 'desc',
           text: 'Name [Z-A]',
@@ -446,18 +458,24 @@ export const RECORDS_CONFIG = {
         },
         {
           order: 2,
+          sortBy: 'bestmatch',
+          sortOrder: 'asc',
+          text: 'Most relevant',
+        },
+        {
+          order: 3,
           sortBy: 'request_date',
           sortOrder: 'desc',
           text: 'Request date',
         },
         {
-          order: 3,
+          order: 4,
           sortBy: 'expected_delivery_date',
           sortOrder: 'desc',
           text: 'Expected delivery date',
         },
         {
-          order: 4,
+          order: 5,
           sortBy: 'due_date',
           sortOrder: 'desc',
           text: 'Due date',
@@ -474,18 +492,24 @@ export const RECORDS_CONFIG = {
       sort: [
         {
           order: 1,
+          sortBy: 'created',
+          sortOrder: 'desc',
+          text: 'Recently added',
+        },
+        {
+          order: 2,
           sortBy: 'bestmatch',
           sortOrder: 'asc',
           text: 'Most relevant',
         },
         {
-          order: 2,
+          order: 3,
           sortBy: 'name',
           sortOrder: 'asc',
           text: 'Name [A-Z]',
         },
         {
-          order: 2,
+          order: 4,
           sortBy: 'name',
           sortOrder: 'desc',
           text: 'Name [Z-A]',
@@ -730,6 +754,18 @@ export const RECORDS_CONFIG = {
           sortBy: 'extensions',
           sortOrder: 'desc',
           text: 'Extensions count',
+        },
+        {
+          order: 6,
+          sortBy: 'created',
+          sortOrder: 'desc',
+          text: 'Recently added',
+        },
+        {
+          order: 7,
+          sortBy: 'bestmatch',
+          sortOrder: 'asc',
+          text: 'Most relevant',
         },
       ],
       defaultPage: 1,

--- a/src/lib/config/index.js
+++ b/src/lib/config/index.js
@@ -2,6 +2,7 @@ import _find from 'lodash/find';
 import _get from 'lodash/get';
 import _map from 'lodash/map';
 import _merge from 'lodash/merge';
+import _isEmpty from 'lodash/isEmpty';
 import { APP_CONFIG, RECORDS_CONFIG } from './defaultConfig';
 
 class Config {
@@ -44,6 +45,13 @@ export const getSearchConfig = (modelName, extraOptions = {}) => {
   return _merge(result, extraOptions);
 };
 
+const findBySortTypeOrReturnFirst = (searchConfig, sortType) => {
+  const getCreatedSort = searchConfig.SORT_BY.find(
+    elem => elem.sortBy === sortType
+  );
+  return !_isEmpty(getCreatedSort) ? getCreatedSort : searchConfig.SORT_BY[0];
+};
+
 export const setReactSearchKitInitialQueryState = modelName => {
   const searchConfig = getSearchConfig(modelName);
   let initialState = {};
@@ -57,11 +65,22 @@ export const setReactSearchKitInitialQueryState = modelName => {
     initialState['size'] = searchConfig.DEFAULT_SIZE;
   }
   if (searchConfig.SORT_BY) {
-    const defaultSort = searchConfig.SORT_BY[0];
+    const defaultSort = findBySortTypeOrReturnFirst(searchConfig, 'bestmatch');
     initialState['sortBy'] = defaultSort.sortBy;
     initialState['sortOrder'] = defaultSort.sortOrder;
   }
   return initialState;
+};
+
+export const setReactSearchKitDefaultSortingOnEmptyQueryString = modelName => {
+  const searchConfig = getSearchConfig(modelName);
+  let sortObject = {};
+  if (searchConfig.SORT_BY) {
+    const defaultSort = findBySortTypeOrReturnFirst(searchConfig, 'created');
+    sortObject['sortBy'] = defaultSort.sortBy;
+    sortObject['sortOrder'] = defaultSort.sortOrder;
+  }
+  return sortObject;
 };
 
 export function getDisplayVal(configField, value) {

--- a/src/lib/modules/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
+++ b/src/lib/modules/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
@@ -1,5 +1,9 @@
 import { literatureApi } from '@api/literature';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import { LiteratureSearchOverridesMap } from '@modules/Literature/LiteratureSearchOverrides';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
@@ -42,7 +46,9 @@ export class SeriesLiteratureSearch extends React.Component {
     });
 
     const initialState = setReactSearchKitInitialQueryState('LITERATURE');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'LITERATURE'
+    );
     return (
       <>
         <Divider horizontal>
@@ -59,6 +65,7 @@ export class SeriesLiteratureSearch extends React.Component {
             history={history}
             urlHandlerApi={{ enabled: false }}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container className="series-details-search-container">

--- a/src/lib/modules/Series/SeriesLiteratureSearch/__snapshots__/SeriesLiteratureSearch.test.js.snap
+++ b/src/lib/modules/Series/SeriesLiteratureSearch/__snapshots__/SeriesLiteratureSearch.test.js.snap
@@ -26,6 +26,12 @@ exports[`SeriesLiteratureSearch tests should load the SeriesLiteratureSearch com
     }
   >
     <Overridable(ReactSearchKit)
+      defaultSortingOnEmptyQueryString={
+        Object {
+          "sortBy": "created",
+          "sortOrder": "desc",
+        }
+      }
       history={
         Object {
           "action": "POP",
@@ -51,8 +57,8 @@ exports[`SeriesLiteratureSearch tests should load the SeriesLiteratureSearch com
           "layout": "grid",
           "page": 1,
           "size": 15,
-          "sortBy": "created",
-          "sortOrder": "desc",
+          "sortBy": "bestmatch",
+          "sortOrder": "asc",
         }
       }
       searchApi={

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderSearch/OrderSearch.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderSearch/OrderSearch.js
@@ -2,7 +2,11 @@ import { orderApi } from '@api/acquisition';
 import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
@@ -67,7 +71,9 @@ export class OrderSearch extends Component {
     ];
 
     const initialState = setReactSearchKitInitialQueryState('ACQ_ORDERS');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'ACQ_ORDERS'
+    );
     return (
       <>
         <Header as="h2">Purchase Orders</Header>
@@ -80,6 +86,7 @@ export class OrderSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/Acquisition/Vendor/VendorSearch/VendorSearch.js
+++ b/src/lib/pages/backoffice/Acquisition/Vendor/VendorSearch/VendorSearch.js
@@ -2,7 +2,11 @@ import { vendorApi } from '@api/acquisition';
 import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
 import { SearchControlsOverridesMap } from '@modules/SearchControls/SearchControlsOverrides';
@@ -50,7 +54,9 @@ export class VendorSearch extends Component {
     ];
 
     const initialState = setReactSearchKitInitialQueryState('ACQ_VENDORS');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'ACQ_VENDORS'
+    );
     return (
       <>
         <Header as="h2">Vendors</Header>
@@ -63,6 +69,7 @@ export class VendorSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/Document/DocumentSearch/DocumentSearch.js
+++ b/src/lib/pages/backoffice/Document/DocumentSearch/DocumentSearch.js
@@ -2,7 +2,11 @@ import { documentApi } from '@api/documents';
 import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import { DocumentListEntry } from '@modules/Document/backoffice/DocumentList';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
@@ -49,6 +53,9 @@ export class DocumentSearch extends Component {
     ];
 
     const initialState = setReactSearchKitInitialQueryState('DOCUMENTS');
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'DOCUMENTS'
+    );
 
     return (
       <>
@@ -62,6 +69,7 @@ export class DocumentSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestSearch/DocumentRequestSearch.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestSearch/DocumentRequestSearch.js
@@ -2,7 +2,11 @@ import { responseRejectInterceptor } from '@api/base';
 import { documentRequestApi } from '@api/documentRequests';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
@@ -50,7 +54,9 @@ export class DocumentRequestSearch extends Component {
     const initialState = setReactSearchKitInitialQueryState(
       'DOCUMENT_REQUESTS'
     );
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'DOCUMENT_REQUESTS'
+    );
     return (
       <>
         <Header as="h2">Requests for new literature</Header>
@@ -63,6 +69,7 @@ export class DocumentRequestSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/EItem/EItemSearch/EItemSearch.js
+++ b/src/lib/pages/backoffice/EItem/EItemSearch/EItemSearch.js
@@ -3,7 +3,11 @@ import { eItemApi } from '@api/eitems';
 import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
@@ -66,7 +70,9 @@ export class EItemSearch extends Component {
     ];
 
     const initialState = setReactSearchKitInitialQueryState('EITEMS');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'EITEMS'
+    );
     return (
       <>
         <Header as="h2">Electronic items</Header>
@@ -79,6 +85,7 @@ export class EItemSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestSearch/BorrowingRequestSearch.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestSearch/BorrowingRequestSearch.js
@@ -2,7 +2,11 @@ import { borrowingRequestApi } from '@api/ill';
 import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
@@ -53,6 +57,9 @@ export class BorrowingRequestSearch extends Component {
     const initialState = setReactSearchKitInitialQueryState(
       'ILL_BORROWING_REQUESTS'
     );
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'ILL_BORROWING_REQUESTS'
+    );
 
     return (
       <>
@@ -66,6 +73,7 @@ export class BorrowingRequestSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/ILL/Library/LibrarySearch/LibrarySearch.js
+++ b/src/lib/pages/backoffice/ILL/Library/LibrarySearch/LibrarySearch.js
@@ -2,7 +2,11 @@ import { libraryApi } from '@api/ill';
 import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
 import { SearchControlsOverridesMap } from '@modules/SearchControls/SearchControlsOverrides';
@@ -49,7 +53,9 @@ export class LibrarySearch extends Component {
       },
     ];
     const initialState = setReactSearchKitInitialQueryState('ILL_LIBRARIES');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'ILL_LIBRARIES'
+    );
     return (
       <>
         <Header as="h2">Libraries</Header>
@@ -62,6 +68,7 @@ export class LibrarySearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/Item/ItemSearch/ItemSearch.js
+++ b/src/lib/pages/backoffice/Item/ItemSearch/ItemSearch.js
@@ -4,7 +4,11 @@ import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { Error as IlsError } from '@components/Error';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import { ItemListEntry } from '@modules/Items/backoffice';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
@@ -64,7 +68,9 @@ export class ItemSearch extends Component {
     ];
 
     const initialState = setReactSearchKitInitialQueryState('ITEMS');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'ITEMS'
+    );
     return (
       <>
         <Header as="h2">Physical copies</Header>
@@ -77,6 +83,7 @@ export class ItemSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/Loan/LoanSearch/LoanSearch.js
+++ b/src/lib/pages/backoffice/Loan/LoanSearch/LoanSearch.js
@@ -2,7 +2,11 @@ import { responseRejectInterceptor } from '@api/base';
 import { loanApi } from '@api/loans';
 import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import { LoanListEntry } from '@modules/Loan/backoffice/LoanList/LoanListEntry';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
@@ -47,7 +51,9 @@ export class LoanSearch extends Component {
     ];
 
     const initialState = setReactSearchKitInitialQueryState('LOANS');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'LOANS'
+    );
     return (
       <>
         <Header as="h2">Loans and requests</Header>
@@ -60,6 +66,7 @@ export class LoanSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/Patron/PatronSearch/PatronSearch.js
+++ b/src/lib/pages/backoffice/Patron/PatronSearch/PatronSearch.js
@@ -2,7 +2,11 @@ import { responseRejectInterceptor } from '@api/base';
 import { patronApi } from '@api/patrons';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
 import { SearchControlsOverridesMap } from '@modules/SearchControls/SearchControlsOverrides';
@@ -46,7 +50,9 @@ export class PatronSearch extends Component {
     ];
 
     const initialState = setReactSearchKitInitialQueryState('PATRONS');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'PATRONS'
+    );
     return (
       <>
         <Header as="h2">Patrons</Header>
@@ -59,6 +65,7 @@ export class PatronSearch extends Component {
           <ReactSearchKit
             searchApi={this.searchApi}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/backoffice/Series/SeriesSearch/SeriesSearch.js
+++ b/src/lib/pages/backoffice/Series/SeriesSearch/SeriesSearch.js
@@ -3,7 +3,11 @@ import { seriesApi } from '@api/series/series';
 import { NewButton } from '@components/backoffice/buttons/NewButton';
 import { ExportReactSearchKitResults } from '@components/backoffice/ExportSearchResults';
 import { QueryBuildHelper } from '@components/SearchBar/QueryBuildHelper';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
 import { SearchControls } from '@modules/SearchControls/SearchControls';
@@ -62,7 +66,9 @@ export class SeriesSearch extends Component {
     ];
 
     const initialState = setReactSearchKitInitialQueryState('SERIES');
-
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'SERIES'
+    );
     return (
       <>
         <Header as="h2">Series</Header>
@@ -75,6 +81,7 @@ export class SeriesSearch extends Component {
             searchApi={this.searchApi}
             history={history}
             initialQueryState={initialState}
+            defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
           >
             <>
               <Container fluid className="spaced">

--- a/src/lib/pages/frontsite/Literature/LiteratureSearch/LiteratureSearch.js
+++ b/src/lib/pages/frontsite/Literature/LiteratureSearch/LiteratureSearch.js
@@ -1,6 +1,10 @@
 import { responseRejectInterceptor } from '@api/base';
 import { literatureApi } from '@api/literature/literature';
-import { invenioConfig, setReactSearchKitInitialQueryState } from '@config';
+import {
+  invenioConfig,
+  setReactSearchKitInitialQueryState,
+  setReactSearchKitDefaultSortingOnEmptyQueryString,
+} from '@config';
 import history from '@history';
 import { LiteratureSearchOverridesMap } from '@modules/Literature/LiteratureSearchOverrides';
 import SearchAggregationsCards from '@modules/SearchControls/SearchAggregationsCards';
@@ -41,6 +45,9 @@ class LiteratureSearch extends Component {
 
   render() {
     const initialState = setReactSearchKitInitialQueryState('LITERATURE');
+    const defaultSortingOnEmptyQueryString = setReactSearchKitDefaultSortingOnEmptyQueryString(
+      'LITERATURE'
+    );
 
     return (
       <OverridableContext.Provider
@@ -54,6 +61,7 @@ class LiteratureSearch extends Component {
           history={history}
           overridableId="LiteratureSearchOverridable"
           initialQueryState={initialState}
+          defaultSortingOnEmptyQueryString={defaultSortingOnEmptyQueryString}
         >
           <Overridable id="LiteratureSearch.layout">
             <>


### PR DESCRIPTION
* Adds defaultSortingOnEmptyQueryString prop
  to ReactSearchKit component

Adds missing sort filters. 
Updates the behaviour of RSK, now the `initialState` will always be set to "Most relevant" (`bestmatch`) if it exists otherwise the first sort type will be used. For the `defaultSortingOnEmptyQueryString` will always be "Recently added" except for the patrons (because they only allow "bestmatch").

Behaviour of `defaultSortingOnEmptyQueryString` prop tested and it's correct