### PR TITLE
backoffice: Fixes internal location form bug

### DIFF
--- a/src/lib/api/acquisition/serializers.js
+++ b/src/lib/api/acquisition/serializers.js
@@ -2,6 +2,9 @@ import { recordResponseSerializer } from '@api/utils';
 
 const OrderSerializers = {
   responseSerializer: function(hit) {
+    // This line is needed to get the resolved fields
+    // to be able to display them later in the form
+    hit.metadata.order_lines = hit.metadata.resolved_order_lines;
     return recordResponseSerializer(hit);
   },
 };

--- a/src/lib/api/acquisition/serializers.test.js
+++ b/src/lib/api/acquisition/serializers.test.js
@@ -56,6 +56,7 @@ describe('Order request/response serializers tests', () => {
         notes: 'abc',
         order_date: stringDate,
         order_lines: orderLines,
+        resolved_order_lines: orderLines,
         payment: payment,
         status: 'RECEIVED',
         vendor_pid: '1',
@@ -82,6 +83,7 @@ describe('Order request/response serializers tests', () => {
         notes: 'abc',
         order_date: stringDate,
         order_lines: orderLines,
+        resolved_order_lines: orderLines,
         payment: {
           ...payment,
           debit_date: stringDate,

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderStatistics.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderStatistics.js
@@ -91,10 +91,14 @@ export class OrderStatistics extends React.Component {
     return (
       <Statistic>
         <Statistic.Label>Total</Statistic.Label>
-        <Statistic.Value>
-          {formatPrice(order.grand_total, false)}
-        </Statistic.Value>
-        <Statistic.Label>{order.grand_total.currency}</Statistic.Label>
+        {order.grand_total ? (
+          <>
+            <Statistic.Value>
+              {formatPrice(order.grand_total, false)}
+            </Statistic.Value>
+            <Statistic.Label>{order.grand_total.currency}</Statistic.Label>
+          </>
+        ) : null}
       </Statistic>
     );
   }

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderEditor/OrderForm/OrderForm.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderEditor/OrderForm/OrderForm.js
@@ -114,7 +114,6 @@ export class OrderForm extends Component {
 
   render() {
     const { successSubmitMessage, data, title, pid, isCreate } = this.props;
-
     return (
       <BaseForm
         initialValues={data ? data.metadata : this.getDefaultValues()}

--- a/src/lib/pages/backoffice/Location/LocationForms/InternalLocationEditor/components/InternalLocationForm/InternalLocationForm.js
+++ b/src/lib/pages/backoffice/Location/LocationForms/InternalLocationEditor/components/InternalLocationForm/InternalLocationForm.js
@@ -18,7 +18,7 @@ import { Header, Segment } from 'semantic-ui-react';
 import * as Yup from 'yup';
 
 const InternalLocationSchema = Yup.object().shape({
-  location: Yup.object('missing').shape({
+  location: Yup.object().shape({
     pid: Yup.string().required(),
   }),
 });


### PR DESCRIPTION
- Fixes internal location form error, when creating or editing it was displaying an error.
- If an ACQ order has status != CANCELLED and does not have a total price (which could be possible because is not a required field) it breaks when accesing the ACQ order details page. Added a check to display the value if it exists.
- If we edit an ACQ with order lines, the document and patron (of the order lines) will not appear even if they already exist and they do exist because they are required fields. Fixed by updating the `data.metadata.order_lines` with the values of `data.metadata.resolved_order_lines`. This makes me wonder why do we have `resolved_order_lines` and `order_lines` ?
