### PR TITLE
Routes: add overridable route

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -30,3 +30,6 @@ export { FrontSiteRoutes } from '@routes/frontsite/frontsiteUrls';
 export { default as InvenioILSApp } from './App';
 export { default as history } from './history';
 export { default as store } from './store';
+export { http } from '@api/base';
+export { NotFound } from '@components/HttpErrors';
+export { withCancel, recordToPidType } from '@api/utils';

--- a/src/lib/routes/frontsite/Frontsite.js
+++ b/src/lib/routes/frontsite/Frontsite.js
@@ -18,8 +18,9 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { Container } from 'semantic-ui-react';
+import Overridable from 'react-overridable';
 
-export default class FrontSite extends Component {
+export class FrontSite extends Component {
   renderCustomStaticPages = () => {
     const { customStaticPages } = this.props;
     customStaticPages();
@@ -74,6 +75,8 @@ export default class FrontSite extends Component {
               <Route key={route} exact path={route} component={StaticPage} />
             ))}
             {this.renderCustomStaticPages()}
+
+            <Overridable id="Frontsite.route" {...this.props} />
             <Route>
               <NotFound />
             </Route>
@@ -92,3 +95,5 @@ FrontSite.propTypes = {
 FrontSite.defaultProps = {
   customStaticPages: () => {},
 };
+
+export default Overridable.component('Frontsite', FrontSite);


### PR DESCRIPTION
- adds overridable routes in frontsite
- exports necessary components to be used in cds-ils ([pr](https://github.com/CERNDocumentServer/cds-ils/pull/228))