### PR TITLE
backoffice: fix the workflow of LiteratureRequest

### DIFF
--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -85,6 +85,7 @@ export const RECORDS_CONFIG = {
   ACQ_ORDERS: {
     maxShowOrderLines: 3,
     orderedValidStatuses: ['PENDING', 'ORDERED', 'RECEIVED'],
+    pendingStatuses: ['PENDING'],
     orderedStatuses: ['ORDERED'],
     statuses: ACQ_ORDER_STATUSES,
     search: {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -33,6 +33,5 @@ export { BackOfficeBase } from '@routes/backoffice/backofficeUrls';
 export { default as InvenioILSApp } from './App';
 export { default as history } from './history';
 export { default as store } from './store';
-export { http } from '@api/base';
 export { NotFound } from '@components/HttpErrors';
 export { withCancel, recordToPidType } from '@api/utils';

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderEditor/OrderEditor.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderEditor/OrderEditor.js
@@ -65,7 +65,7 @@ export class OrderEditor extends Component {
     const request = _get(this.props, 'location.state', null);
     if (!request) return null;
     return {
-      documentRequestPid: request.pid,
+      documentRequestPid: request.metadata.pid,
       metadata: {
         order_lines: [
           {

--- a/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentEditor.js
+++ b/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentEditor.js
@@ -37,7 +37,7 @@ export class DocumentEditor extends Component {
     const request = _get(this.props, 'location.state', null);
     if (!request) return null;
     return {
-      documentRequestPid: request.pid,
+      documentRequestPid: request.metadata.pid,
       metadata: {
         title: _get(request, 'metadata.title'),
         // NOTE: serializing authors for the document form

--- a/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/DocumentForm.js
+++ b/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/DocumentForm.js
@@ -114,7 +114,7 @@ export class DocumentForm extends Component {
       goTo(BackOfficeRoutes.eitemCreate, { document: doc });
     } else if (documentRequestPid) {
       await documentRequestApi.addDocument(documentRequestPid, {
-        document_pid: doc.pid,
+        document_pid: doc.metadata.pid,
       });
       goTo(BackOfficeRoutes.documentRequestDetailsFor(documentRequestPid));
     } else {

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestSteps/ProviderStep/ProviderStep.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestSteps/ProviderStep/ProviderStep.js
@@ -82,14 +82,7 @@ class AcqProvider extends Component {
             <ESSelector
               icon={<AcquisitionOrderIcon />}
               onSelectResult={this.onSelectResult}
-              query={() =>
-                orderApi.list(
-                  orderApi
-                    .query()
-                    .withState('PENDING')
-                    .qs()
-                )
-              }
+              query={orderApi.listWithPendingStatus}
               serializer={serializeAcqOrder}
             />
           </Grid.Column>
@@ -137,14 +130,7 @@ class IllProvider extends Component {
             <ESSelector
               icon={<ILLBorrowingRequestIcon />}
               onSelectResult={this.onSelectResult}
-              query={() =>
-                borrowingRequestApi.list(
-                  borrowingRequestApi
-                    .query()
-                    .withState('PENDING')
-                    .qs()
-                )
-              }
+              query={borrowingRequestApi.listWithPendingStatus}
               serializer={serializeBorrowingRequest}
             />
           </Grid.Column>

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestEditor/BorrowingRequestEditor.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestEditor/BorrowingRequestEditor.js
@@ -36,6 +36,7 @@ export class BorrowingRequestEditor extends Component {
     } = this.props;
     if (!request) return null;
     return {
+      documentRequestPid: request.metadata.pid,
       metadata: {
         title: _get(request, 'metadata.title'),
         patron: request.metadata.patron,


### PR DESCRIPTION
- redirect order and borrowing request forms to literature request form
- add function `listWithPendingStatus` to be used in Provider's ESSelector because previously it displayed all results with `status=PENDING` without taking into account the search query
Closes #290 