### PR TITLE
importer: Creates importer UI

### DIFF
--- a/src/lib/components/backoffice/Sidebar/Sidebar.js
+++ b/src/lib/components/backoffice/Sidebar/Sidebar.js
@@ -60,6 +60,7 @@ class Sidebar extends Component {
     const statsActive = activePath.includes(BackOfficeRoutes.stats.home);
     const checkInActive = activePath.includes(BackOfficeRoutes.checkIn);
     const checkOutActive = activePath.includes(BackOfficeRoutes.checkOut);
+    const importerActive = activePath.includes(BackOfficeRoutes.importer);
 
     return (
       <Overridable id="Sidebar.layout">
@@ -241,6 +242,19 @@ class Sidebar extends Component {
                       to={BackOfficeRoutes.stats.home}
                     >
                       Most Loaned
+                    </Menu.Item>
+                  </Menu.Menu>
+                </Menu.Item>
+
+                <Menu.Item>
+                  <Menu.Header>Importer</Menu.Header>
+                  <Menu.Menu>
+                    <Menu.Item
+                      as={importerActive ? '' : Link}
+                      active={importerActive}
+                      to={BackOfficeRoutes.importer}
+                    >
+                      Import
                     </Menu.Item>
                   </Menu.Menu>
                 </Menu.Item>

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -918,6 +918,7 @@ export const RECORDS_CONFIG = {
       { key: 'springer', text: 'Springer', value: 'springer' },
       { key: 'cds', text: 'CDS', value: 'cds' },
       { key: 'ebl', text: 'EBL', value: 'ebl' },
+      { key: 'safari', text: 'Safari', value: 'safari' },
     ],
     modes: [
       { key: 'create', text: 'Create', value: 'create' },

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -913,4 +913,15 @@ export const RECORDS_CONFIG = {
       ill_payment_mode: 'ill_payment_mode',
     },
   },
+  IMPORTER: {
+    providers: [
+      { key: 'springer', text: 'Springer', value: 'springer' },
+      { key: 'cds', text: 'CDS', value: 'cds' },
+      { key: 'ebl', text: 'EBL', value: 'ebl' },
+    ],
+    modes: [
+      { key: 'create', text: 'Create', value: 'create' },
+      { key: 'delete', text: 'Delete', value: 'delete' },
+    ],
+  },
 };

--- a/src/lib/pages/backoffice/Importer/ImportedDocuments.js
+++ b/src/lib/pages/backoffice/Importer/ImportedDocuments.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Accordion, Header, Icon, Message } from 'semantic-ui-react';
+import _isEmpty from 'lodash/isEmpty';
+import { http } from '@api/base';
+import _isEqual from 'lodash/isEqual';
+import _get from 'lodash/get';
+import { ReportDetails } from './ReportDetails';
+import { Link } from 'react-router-dom';
+import { BackOfficeRoutes } from '@routes/urls';
+import { DocumentIcon } from '@components/backoffice/icons';
+
+const importerURL = '/importer/check';
+
+export class ImportedDocuments extends React.Component {
+  state = {
+    activeIndex: -1,
+    importCompleted: false,
+    count: 0,
+    data: null,
+  };
+
+  componentDidMount() {
+    var idVar = setInterval(() => this.checkForData(idVar), 3000);
+  }
+
+  checkForData = async idVar => {
+    const { importCompleted, count, data } = this.state;
+
+    if (!importCompleted) {
+      const response = await http.get(`${importerURL}`);
+      const reports = _get(data, 'reports', []);
+
+      if (_isEqual(response.data.reports.length, reports.length)) {
+        this.setState({
+          importCompleted: true,
+        });
+      } else {
+        this.setState({
+          count: count + 1,
+          data: response.data,
+        });
+      }
+    } else {
+      console.log('ClearInterval');
+      clearInterval(idVar);
+    }
+  };
+
+  handleClick = (e, titleProps) => {
+    const { index } = titleProps;
+    const { activeIndex } = this.state;
+    const newIndex = activeIndex === index ? -1 : index;
+
+    this.setState({ activeIndex: newIndex });
+  };
+
+  renderErrorMessage = error => {
+    let message = _get(error, 'response.data.message');
+    return (
+      <Message negative>
+        <Message.Header>Something went wrong</Message.Header>
+        <p>{message}</p>
+      </Message>
+    );
+  };
+
+  renderData = isLoading => {
+    const { count, data, activeIndex } = this.state;
+    console.log(data, count);
+    return (
+      <>
+        {isLoading ? (
+          <>
+            <Icon loading name="circle notch" />
+            Importing documents... This may take a while.
+          </>
+        ) : (
+          <>
+            <Icon name="check" />
+            Documents imported succesfully.
+          </>
+        )}
+        {!_isEmpty(data) ? (
+          <>
+            <Header as="h2">Documents</Header>
+            {!_isEmpty(data) &&
+              ' Imported ' + data.reports.length + ' documents'}
+
+            <Accordion>
+              {data.reports.map((elem, index) => {
+                const document = !_isEmpty(elem.created)
+                  ? elem.created
+                  : elem.updated;
+                return (
+                  <>
+                    <Accordion.Title
+                      active={activeIndex === index}
+                      index={index}
+                      onClick={this.handleClick}
+                    >
+                      <Icon name="dropdown" />
+                      {!_isEmpty(document) ? (
+                        <Link
+                          to={BackOfficeRoutes.documentDetailsFor(document.pid)}
+                          target="_blank"
+                        >
+                          <DocumentIcon />
+                          {document.title}
+                        </Link>
+                      ) : (
+                        'No document created or updated'
+                      )}
+                    </Accordion.Title>
+                    <Accordion.Content active={activeIndex === index}>
+                      <ReportDetails report={elem} />
+                    </Accordion.Content>
+                  </>
+                );
+              })}
+            </Accordion>
+          </>
+        ) : null}
+      </>
+    );
+  };
+
+  render() {
+    const { data, error, isLoading } = this.props;
+    console.log('ImportedDocuments', data, error, isLoading);
+
+    return (
+      <>
+        {!_isEmpty(error) ? this.renderErrorMessage(error) : null}
+        {this.renderData(isLoading)}
+      </>
+    );
+  }
+}
+
+ImportedDocuments.propTypes = {
+  data: PropTypes.object.isRequired,
+  error: PropTypes.object.isRequired,
+  isLoading: PropTypes.object.isRequired,
+};

--- a/src/lib/pages/backoffice/Importer/Importer.js
+++ b/src/lib/pages/backoffice/Importer/Importer.js
@@ -1,0 +1,178 @@
+import React, { Component } from 'react';
+import {
+  Container,
+  Header,
+  Segment,
+  Button,
+  Form,
+  Modal,
+  Icon,
+} from 'semantic-ui-react';
+import { invenioConfig } from '@config';
+import PropTypes from 'prop-types';
+import { ImportedDocuments } from './ImportedDocuments';
+
+export default class Importer extends Component {
+  constructor(props) {
+    super(props);
+    this.filesRef = React.createRef();
+    this.state = {
+      provider: '',
+      mode: '',
+      file: null,
+      openModal: false,
+      postDone: false,
+    };
+  }
+
+  handleChange = (e, { name, value }) => this.setState({ [name]: value });
+
+  handleSubmit = async () => {
+    const { provider, mode, file } = this.state;
+    const { postData } = this.props;
+    var formData = new FormData();
+    formData.append('provider', provider);
+    formData.append('mode', mode);
+    formData.append('file', file);
+    postData(formData);
+    this.setState({
+      provider: '',
+      mode: '',
+      file: null,
+      postDone: true,
+    });
+  };
+
+  onChange = async event => {
+    const file = this.filesRef.current.files[0];
+    this.setState({
+      file: file,
+    });
+  };
+
+  renderData = () => {
+    const { data, error, isLoading } = this.props;
+    return (
+      <ImportedDocuments data={data} error={error} isLoading={isLoading} />
+    );
+  };
+
+  renderModal = () => {
+    const { openModal } = this.state;
+
+    return (
+      <Modal
+        onClose={() => this.setState({ openModal: false })}
+        onOpen={() => this.setState({ openModal: true })}
+        open={openModal}
+        size="small"
+        trigger={<Button primary>Submit</Button>}
+      >
+        <Header>Deleting Records</Header>
+        <Modal.Content>
+          <p>Are you sure you want to delete these records?</p>
+        </Modal.Content>
+        <Modal.Actions>
+          <Button
+            color="red"
+            onClick={() => this.setState({ openModal: false })}
+          >
+            <Icon name="remove" /> No
+          </Button>
+          <Button
+            primary
+            onClick={() => {
+              this.setState({ openModal: false });
+              this.handleSubmit();
+            }}
+          >
+            <Icon name="checkmark" /> Yes
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    );
+  };
+
+  renderForm = () => {
+    const { provider, mode, file } = this.state;
+    return (
+      <Form onSubmit={mode !== 'delete' ? this.handleSubmit : null}>
+        <Segment>
+          <Form.Group widths="equal">
+            <Form.Select
+              placeholder="Select a provider ..."
+              label="Provider"
+              search
+              selection
+              name="provider"
+              value={provider}
+              options={invenioConfig.IMPORTER.providers}
+              onChange={this.handleChange}
+              required
+            />
+            <Form.Select
+              placeholder="Select a mode ..."
+              label="Mode"
+              search
+              selection
+              name="mode"
+              value={mode}
+              options={invenioConfig.IMPORTER.modes}
+              onChange={this.handleChange}
+              required
+            />
+          </Form.Group>
+          <Form.Group widths="equal">
+            <Form.Field className="default-margin-top">
+              <Button
+                icon="file"
+                content="Choose File"
+                labelPosition="left"
+                onClick={e => {
+                  e.preventDefault();
+                  this.filesRef.current.click();
+                }}
+              />
+              <input
+                hidden
+                ref={this.filesRef}
+                id="upload"
+                type="file"
+                accept=".xml"
+                onChange={this.onChange}
+              />
+              {file ? file.name : 'No file selected.'}
+            </Form.Field>
+          </Form.Group>
+        </Segment>
+        {mode === 'delete' ? (
+          this.renderModal()
+        ) : (
+          <Form.Button primary content="Submit" />
+        )}
+      </Form>
+    );
+  };
+
+  render() {
+    const { postDone } = this.state;
+    return (
+      <Container id="importer" className="spaced">
+        <>
+          <Header as="h1">Documents Importer</Header>
+          <p>
+            {!postDone ? 'Fill in the form below to import documents.' : null}
+          </p>
+        </>
+        {postDone ? this.renderData() : this.renderForm()}
+      </Container>
+    );
+  }
+}
+
+Importer.propTypes = {
+  postData: PropTypes.func.isRequired,
+  data: PropTypes.object.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  error: PropTypes.object.isRequired,
+};

--- a/src/lib/pages/backoffice/Importer/ReportDetails.js
+++ b/src/lib/pages/backoffice/Importer/ReportDetails.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Item, Grid } from 'semantic-ui-react';
+import _isEmpty from 'lodash/isEmpty';
+
+const ReportDetailsLeftColumn = ({ report }) => {
+  return (
+    <>
+      <Item.Description>
+        <label>Created: </label>
+        {!_isEmpty(report.created) ? 'Yes' : 'No'}
+      </Item.Description>
+      <Item.Description>
+        <label>Updated: </label>
+        {!_isEmpty(report.updated) ? 'Yes' : 'No'}
+      </Item.Description>
+    </>
+  );
+};
+
+ReportDetailsLeftColumn.propTypes = {
+  report: PropTypes.object.isRequired,
+};
+
+const ReportDetailsMiddleColumn = ({ report }) => {
+  return (
+    <>
+      <Item.Description>
+        <label>Ambiguous: </label>
+        {!_isEmpty(report.ambiguous) ? report.ambiguous.map(e => e) : 'No'}
+      </Item.Description>
+      <Item.Description>
+        <label>Fuzzy: </label>
+        {!_isEmpty(report.fuzzy) ? report.fuzzy.map(e => e) : 'No'}
+      </Item.Description>
+    </>
+  );
+};
+
+ReportDetailsMiddleColumn.propTypes = {
+  report: PropTypes.object.isRequired,
+};
+
+const ReportDetailsRightColumn = ({ report }) => {
+  return (
+    <>
+      <Item.Description>
+        <label>Created eitem: </label>
+        {!_isEmpty(report.created_eitem) ? report.created_eitem.pid : 'No'}
+      </Item.Description>
+      <Item.Description>
+        <label>Updated eitem: </label>
+        {!_isEmpty(report.updated_eitem) ? report.updated_eitem.pid : 'No'}
+      </Item.Description>
+      <Item.Description>
+        <label>Deleted eitems: </label>
+        {!_isEmpty(report.deleted_eitem_list)
+          ? report.deleted_eitem_list.map(e => e)
+          : 'No'}
+      </Item.Description>
+    </>
+  );
+};
+
+ReportDetailsRightColumn.propTypes = {
+  report: PropTypes.object.isRequired,
+};
+
+export class ReportDetails extends React.Component {
+  render() {
+    const { report } = this.props;
+    return (
+      <Item>
+        <Item.Content>
+          <Grid columns={3}>
+            <Grid.Column>
+              <ReportDetailsLeftColumn report={report} />
+            </Grid.Column>
+            <Grid.Column>
+              <ReportDetailsMiddleColumn report={report} />
+            </Grid.Column>
+            <Grid.Column>
+              <ReportDetailsRightColumn report={report} />
+            </Grid.Column>
+          </Grid>
+        </Item.Content>
+      </Item>
+    );
+  }
+}
+
+ReportDetails.propTypes = {
+  report: PropTypes.object.isRequired,
+};

--- a/src/lib/pages/backoffice/Importer/ReportDetails.js
+++ b/src/lib/pages/backoffice/Importer/ReportDetails.js
@@ -2,6 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Item, Grid } from 'semantic-ui-react';
 import _isEmpty from 'lodash/isEmpty';
+import { Link } from 'react-router-dom';
+import { BackOfficeRoutes } from '@routes/urls';
+
+const displayLinkToDocument = (e, index = 0) => {
+  return (
+    <Link to={BackOfficeRoutes.documentDetailsFor(e)} target="_blank">
+      {index > 0 ? ', ' + e : e}
+    </Link>
+  );
+};
+
+const displayLinkToEitem = (e, index = 0) => {
+  return (
+    <Link to={BackOfficeRoutes.eitemDetailsFor(e)} target="_blank">
+      {index > 0 ? ', ' + e : e}
+    </Link>
+  );
+};
 
 const ReportDetailsLeftColumn = ({ report }) => {
   return (
@@ -13,6 +31,20 @@ const ReportDetailsLeftColumn = ({ report }) => {
       <Item.Description>
         <label>Updated: </label>
         {!_isEmpty(report.updated) ? 'Yes' : 'No'}
+      </Item.Description>
+      <Item.Description>
+        <label>Series: </label>
+        {!_isEmpty(report.series)
+          ? report.series.map((e, index) => (
+              <Link
+                key={e.pid}
+                to={BackOfficeRoutes.seriesDetailsFor(e.pid)}
+                target="_blank"
+              >
+                {index > 0 ? ', ' + e.title : e.title}
+              </Link>
+            ))
+          : 'No'}
       </Item.Description>
     </>
   );
@@ -27,11 +59,23 @@ const ReportDetailsMiddleColumn = ({ report }) => {
     <>
       <Item.Description>
         <label>Ambiguous: </label>
-        {!_isEmpty(report.ambiguous) ? report.ambiguous.map(e => e) : 'No'}
+        {!_isEmpty(report.ambiguous)
+          ? report.ambiguous.map((e, index) => displayLinkToDocument(e, index))
+          : 'No'}
       </Item.Description>
       <Item.Description>
         <label>Fuzzy: </label>
-        {!_isEmpty(report.fuzzy) ? report.fuzzy.map(e => e) : 'No'}
+        {!_isEmpty(report.fuzzy)
+          ? report.fuzzy.map((e, index) => displayLinkToDocument(e, index))
+          : 'No'}
+      </Item.Description>
+      <Item.Description>
+        <label>Ambiguous eitems: </label>
+        {!_isEmpty(report.ambiguous_eitems_list)
+          ? report.ambiguous_eitems_list.map((e, index) =>
+              displayLinkToEitem(e, index)
+            )
+          : 'No'}
       </Item.Description>
     </>
   );
@@ -46,16 +90,22 @@ const ReportDetailsRightColumn = ({ report }) => {
     <>
       <Item.Description>
         <label>Created eitem: </label>
-        {!_isEmpty(report.created_eitem) ? report.created_eitem.pid : 'No'}
+        {!_isEmpty(report.created_eitem)
+          ? displayLinkToEitem(report.created_eitem.pid)
+          : 'No'}
       </Item.Description>
       <Item.Description>
         <label>Updated eitem: </label>
-        {!_isEmpty(report.updated_eitem) ? report.updated_eitem.pid : 'No'}
+        {!_isEmpty(report.updated_eitem)
+          ? displayLinkToEitem(report.updated_eitem.pid)
+          : 'No'}
       </Item.Description>
       <Item.Description>
         <label>Deleted eitems: </label>
         {!_isEmpty(report.deleted_eitem_list)
-          ? report.deleted_eitem_list.map(e => e)
+          ? report.deleted_eitem_list.map((e, index) =>
+              displayLinkToEitem(e, index)
+            )
           : 'No'}
       </Item.Description>
     </>

--- a/src/lib/pages/backoffice/Importer/index.js
+++ b/src/lib/pages/backoffice/Importer/index.js
@@ -1,0 +1,19 @@
+import { connect } from 'react-redux';
+import ImporterComponent from './Importer';
+import { postData } from './state/actions';
+
+const mapStateToProps = state => ({
+  data: state.importer.data,
+  isLoading: state.importer.isLoading,
+  error: state.importer.error,
+  hasError: state.importer.hasError,
+});
+
+const mapDispatchToProps = dispatch => ({
+  postData: formdata => dispatch(postData(formdata)),
+});
+
+export const Importer = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ImporterComponent);

--- a/src/lib/pages/backoffice/Importer/state/actions.js
+++ b/src/lib/pages/backoffice/Importer/state/actions.js
@@ -1,0 +1,33 @@
+import { http } from '@api/base';
+
+export const IS_LOADING = 'importer/IS_LOADING';
+export const SUCCESS = 'importer/SUCCESS';
+export const HAS_ERROR = 'importer/HAS_ERROR';
+
+const importerURL = '/importer';
+const headers = {
+  headers: {
+    'Content-Type': 'multipart/form-data',
+  },
+};
+
+export const postData = formData => {
+  return async dispatch => {
+    dispatch({
+      type: IS_LOADING,
+    });
+
+    try {
+      const response = await http.post(`${importerURL}`, formData, headers);
+      await dispatch({
+        type: SUCCESS,
+        payload: response.data,
+      });
+    } catch (error) {
+      await dispatch({
+        type: HAS_ERROR,
+        payload: error,
+      });
+    }
+  };
+};

--- a/src/lib/pages/backoffice/Importer/state/reducer.js
+++ b/src/lib/pages/backoffice/Importer/state/reducer.js
@@ -1,0 +1,38 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './actions';
+
+export const initialState = {
+  isLoading: false,
+  hasError: false,
+  data: {},
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return {
+        ...state,
+        isLoading: true,
+        error: {},
+        hasError: false,
+        data: {},
+      };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/lib/routes/backoffice/BackOfficeRoutesSwitch.js
+++ b/src/lib/routes/backoffice/BackOfficeRoutesSwitch.js
@@ -43,6 +43,7 @@ import { VendorDetails } from '@pages/backoffice/Acquisition/Vendor/VendorDetail
 import { VendorEditor } from '@pages/backoffice/Acquisition/Vendor/VendorEditor';
 import { VendorSearch } from '@pages/backoffice/Acquisition/Vendor/VendorSearch';
 import CheckIn from '@pages/backoffice/Actions/CheckIn/CheckIn';
+import { Importer } from '@pages/backoffice/Importer';
 
 export default class BackOfficeRoutesSwitch extends Component {
   render() {
@@ -260,6 +261,7 @@ export default class BackOfficeRoutesSwitch extends Component {
         <Route exact path={BackOfficeRoutes.stats.home} component={Stats} />
         <Route exact path={BackOfficeRoutes.checkIn} component={CheckIn} />
         <Route exact path={BackOfficeRoutes.checkOut} component={CheckOut} />
+        <Route exact path={BackOfficeRoutes.importer} component={Importer} />
         <Route>
           <NotFound />
         </Route>

--- a/src/lib/routes/backoffice/backofficeUrls.js
+++ b/src/lib/routes/backoffice/backofficeUrls.js
@@ -37,6 +37,7 @@ const BackOfficeRoutesList = {
   stats: {
     home: `${BackOfficeBase}/stats`,
   },
+  importer: `${BackOfficeBase}/importer`,
 };
 
 export const BackOfficeRouteGenerators = {

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -43,6 +43,7 @@ import { borrowingRequestLoanExtensionReducer } from '@pages/backoffice/ILL/Borr
 import { borrowingRequestPatronLoanCreateReducer } from '@pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/reducer';
 import borrowingRequestDetailsReducer from '@pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/state/reducer';
 import libraryDetailsReducer from '@pages/backoffice/ILL/Library/LibraryDetails/state/reducer';
+import ImporterReducer from '@pages/backoffice/Importer/state/reducer';
 import {
   itemDetailsReducer,
   itemPastLoansReducer,
@@ -127,6 +128,7 @@ const rootReducer = combineReducers({
   seriesMultipartMonographs: seriesMultipartMonographsReducer,
   seriesRelations: seriesRelationsReducer,
   itemDetails: itemDetailsReducer,
+  importer: ImporterReducer,
   itemPastLoans: itemPastLoansReducer,
   eitemDetails: eitemDetailsReducer,
   eitemDetailsFile: eitemDetailsFileReducer,


### PR DESCRIPTION
* address https://github.com/CERNDocumentServer/cds-ils/issues/213

This new page allows us to import documents slecting the provider, the mode and uploading the file.

- All the fields are required. 
- The file estension must be `.xml`.
- If we select `delete` as mode, a confirmation modal will appear.
- While processing data (importing records), if we try to close/reload the results page we will get an alert.
- Each 30 seconds we will fetch the data (this can be changed).

Some screenshots:

### Importer form
![image](https://user-images.githubusercontent.com/15194802/100065045-969ccb80-2e33-11eb-9165-56b4d57e3ee9.png)

### Form validation (frontend)
![image](https://user-images.githubusercontent.com/15194802/100065079-a2888d80-2e33-11eb-8b9c-962ff5c1db2e.png)

### Display of backend errrors on POST
![image](https://user-images.githubusercontent.com/15194802/100065107-afa57c80-2e33-11eb-973c-46b6fb666ed1.png)

### Confirmation modal on delete
![image](https://user-images.githubusercontent.com/15194802/100065746-76214100-2e34-11eb-8de1-f69f6b6ebda0.png)

### Loading
![image](https://user-images.githubusercontent.com/15194802/100065326-f1362780-2e33-11eb-8abc-f5efa8fd6509.png)

### Alert while loading on close/reload of tab
![image](https://user-images.githubusercontent.com/15194802/100066279-2d1dbc80-2e35-11eb-8d6d-04220d78032d.png)

### Results page
![image](https://user-images.githubusercontent.com/15194802/100065155-be8c2f00-2e33-11eb-8dc8-d2a476c9392b.png)
