### PR TITLE
Routes: fix not-found route bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "name": "CERN",
     "email": "info@inveniosoftware.org"
   },
-  "homepage": "https://github.com/inveniosoftware/react-invenio-app-ils/",
   "bugs": {
     "url": "https://github.com/inveniosoftware/react-invenio-app-ils/issues"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"

--- a/src/lib/routes/backoffice/BackOfficeRoutesSwitch.js
+++ b/src/lib/routes/backoffice/BackOfficeRoutesSwitch.js
@@ -261,10 +261,12 @@ export default class BackOfficeRoutesSwitch extends Component {
         <Route exact path={BackOfficeRoutes.stats.home} component={Stats} />
         <Route exact path={BackOfficeRoutes.checkIn} component={CheckIn} />
         <Route exact path={BackOfficeRoutes.checkOut} component={CheckOut} />
-        <Overridable id="Backoffice.CustomRoute" />
-        <Route>
-          <NotFound />
-        </Route>
+
+        <Overridable id="BackOfficeRoutesSwitch.CustomRoute">
+          <Route>
+            <NotFound />
+          </Route>
+        </Overridable>
       </Switch>
     );
   }

--- a/src/lib/routes/frontsite/Frontsite.js
+++ b/src/lib/routes/frontsite/Frontsite.js
@@ -20,7 +20,7 @@ import { Route, Switch } from 'react-router-dom';
 import { Container } from 'semantic-ui-react';
 import Overridable from 'react-overridable';
 
-export class FrontSite extends Component {
+export default class FrontSite extends Component {
   renderCustomStaticPages = () => {
     const { customStaticPages } = this.props;
     customStaticPages();
@@ -76,10 +76,11 @@ export class FrontSite extends Component {
             ))}
             {this.renderCustomStaticPages()}
 
-            <Overridable id="Frontsite.route" {...this.props} />
-            <Route>
-              <NotFound />
-            </Route>
+            <Overridable id="FrontSite.CustomRoute">
+              <Route>
+                <NotFound />
+              </Route>
+            </Overridable>
           </Switch>
         </Container>
         <ILSFooter />
@@ -95,5 +96,3 @@ FrontSite.propTypes = {
 FrontSite.defaultProps = {
   customStaticPages: () => {},
 };
-
-export default Overridable.component('Frontsite', FrontSite);


### PR DESCRIPTION
Closes #312 
- removed `homepage` from package.json because it was setting the static resources url to `https://127.0.0.1/inveniosoftware/react-invenio-app-ils/<static_resource>` instead of `https://127.0.0.1/<static_resource>`
- wrapped Overridable route with NotFound route because before the fallback route was the Overridable instead if the NotFound