### PR TITLE
covers: alignment on frontsite search

### DIFF
--- a/src/lib/modules/Literature/LiteratureCover.js
+++ b/src/lib/modules/Literature/LiteratureCover.js
@@ -39,6 +39,7 @@ class LiteratureCover extends Component {
             onError={e => (e.target.style.display = 'none')}
             src={url}
             size={size}
+            className="image-cover"
             {...uiProps}
           />
         )}

--- a/src/lib/modules/Series/__snapshots__/SeriesCard.test.js.snap
+++ b/src/lib/modules/Series/__snapshots__/SeriesCard.test.js.snap
@@ -64,6 +64,7 @@ exports[`SeriesCard tests should go to book details when clicking on a book 1`] 
             <Image
               as="img"
               centered={true}
+              className="image-cover"
               disabled={false}
               label={null}
               onError={[Function]}
@@ -72,7 +73,7 @@ exports[`SeriesCard tests should go to book details when clicking on a book 1`] 
               ui={true}
             >
               <img
-                className="ui small centered image"
+                className="ui small centered image image-cover"
                 onError={[Function]}
                 src={null}
               />
@@ -234,6 +235,7 @@ exports[`SeriesCard tests should render the SeriesCard 1`] = `
             <Image
               as="img"
               centered={true}
+              className="image-cover"
               disabled={false}
               label={null}
               onError={[Function]}
@@ -242,7 +244,7 @@ exports[`SeriesCard tests should render the SeriesCard 1`] = `
               ui={true}
             >
               <img
-                className="ui small centered image"
+                className="ui small centered image image-cover"
                 onError={[Function]}
                 src={null}
               />

--- a/src/semantic-ui/site/elements/image.overrides
+++ b/src/semantic-ui/site/elements/image.overrides
@@ -5,3 +5,18 @@ Image Overrides - REACT-INVENIO-APP-ILS
 .document-panel .ui.image.large{
     width: 350px;
 }
+
+.ui.grid.grid-documents-search {
+    .ui.image.image-cover {
+         object-fit: contain;
+         width: 100%;
+         height: 200px;
+         background: none !important;
+    }
+}
+
+.ui {
+    a > .image.image-cover, .image.image-cover {
+         filter: drop-shadow(0px 1px 0px #eee) drop-shadow(1px 0px 0px #eee) drop-shadow(0px -1px 0px #eee) drop-shadow(-1px 0px 0px #eee);
+    }
+}


### PR DESCRIPTION
Make the cover frame constant, fit the image in it while preserving the aspect ratio and avoiding overflow. The images are always centred.

Closes #296

Notes:
* this does not apply on mobile, but it applies on the computer stacked view
* I didn't find a way to inherit the height or make it relative to the width, so I hardcoded it (`200px`)
* there is no left/right margins so the wide covers will match the overlay width (typically square or landscape images). I personally don't find it odd but it can be changed if necessary

![image](https://user-images.githubusercontent.com/9027075/103551155-3aa17a00-4eaa-11eb-8bcd-b35a8e2bd6c8.png)

[A screenshot of the stacked view](https://user-images.githubusercontent.com/9027075/103626245-358d0b00-4f3c-11eb-8a14-a2e51b1cbc4f.png)
