### PR TITLE
authors: Improves authors display

### DIFF
--- a/src/lib/modules/Document/DocumentAuthors.js
+++ b/src/lib/modules/Document/DocumentAuthors.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Overridable from 'react-overridable';
 import { Icon, List, Popup } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 const ET_AL_LABEL = 'et al.';
 
@@ -170,6 +171,7 @@ class DocumentAuthors extends Component {
       withPopUpShowMoreFields,
       showAllFieldsInPopUp,
       listItemAs,
+      withVerticalScroll,
     } = this.props;
     const { isExpanded } = this.state;
 
@@ -179,47 +181,57 @@ class DocumentAuthors extends Component {
       displayedAuthors = allAuthors.slice(0, limit);
     }
 
-    const isShowingAllAuthors = displayedAuthors.length === allAuthors.length;
+    const isShowingAllAuthors =
+      allAuthors.slice(0, limit).length === allAuthors.length;
     const showAllAuthorsCmp =
       !isShowingAllAuthors && expandable ? (
-        <>
+        <div>
           {' '}
           <span
             className="button-show-more"
             onClick={this.toggleShowAllAuthors}
           >
-            {isExpanded ? 'Show less' : ET_AL_LABEL}
+            {isExpanded ? 'Show less' : `Show all ${allAuthors.length} authors`}
           </span>
-        </>
+        </div>
       ) : null;
 
     const scrollableClass =
       displayedAuthors.length > scrollLimit && isExpanded ? 'expanded' : '';
     return (
       <Overridable id="DocumentAuthors.layout" {...this.props}>
-        <div className={`document-authors-list-wrapper ${scrollableClass}`}>
-          {prefix}
-          <List horizontal className="document-authors-list" as={listItemAs}>
-            {displayedAuthors.map((author, index) => {
-              const isLast = index === displayedAuthors.length - 1;
-              return (
-                <List.Item key={author.full_name}>
-                  {author.full_name}
-                  {withPopUpShowMoreFields && (
-                    <PopUpShowMoreFields
-                      author={author}
-                      showAllFields={showAllFieldsInPopUp}
-                    />
-                  )}
-                  {!isLast ? delimiter : null}
-                </List.Item>
-              );
-            })}
-            {hasOtherAuthors && ET_AL_LABEL}
-          </List>
-
+        <>
+          <div
+            className={
+              !withVerticalScroll
+                ? `default-margin-bottom`
+                : `document-authors-list-wrapper ${scrollableClass}`
+            }
+          >
+            {prefix}
+            <List horizontal className="document-authors-list" as={listItemAs}>
+              {displayedAuthors.map((author, index) => {
+                const isLast = index === displayedAuthors.length - 1;
+                return (
+                  <List.Item key={author.full_name}>
+                    {author.full_name}
+                    {withPopUpShowMoreFields &&
+                      allAuthors.length <
+                        invenioConfig.LITERATURE.authors.maxDisplay && (
+                        <PopUpShowMoreFields
+                          author={author}
+                          showAllFields={showAllFieldsInPopUp}
+                        />
+                      )}
+                    {!isLast ? delimiter : null}
+                  </List.Item>
+                );
+              })}
+              {hasOtherAuthors && ET_AL_LABEL}
+            </List>
+          </div>
           {showAllAuthorsCmp}
-        </div>
+        </>
       </Overridable>
     );
   }
@@ -236,6 +248,7 @@ DocumentAuthors.propTypes = {
   withPopUpShowMoreFields: PropTypes.bool,
   showAllFieldsInPopUp: PropTypes.bool,
   listItemAs: PropTypes.oneOfType([PropTypes.string, PropTypes.elementType]),
+  withVerticalScroll: PropTypes.bool,
 };
 
 DocumentAuthors.defaultProps = {
@@ -248,6 +261,7 @@ DocumentAuthors.defaultProps = {
   withPopUpShowMoreFields: false,
   showAllFieldsInPopUp: true,
   listItemAs: null,
+  withVerticalScroll: false,
 };
 
 export default Overridable.component('DocumentAuthors', DocumentAuthors);

--- a/src/lib/modules/Document/DocumentCard/DocumentCard.js
+++ b/src/lib/modules/Document/DocumentCard/DocumentCard.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import { Component, default as React } from 'react';
 import Overridable from 'react-overridable';
 import { Card, Label } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 class DocumentCard extends Component {
   renderImage = () => {
@@ -64,7 +65,7 @@ class DocumentCard extends Component {
               <DocumentAuthors
                 authors={data.metadata.authors}
                 hasOtherAuthors={data.metadata.other_authors}
-                limit={10}
+                limit={invenioConfig.LITERATURE.authors.maxDisplay}
               />
               <div>
                 {!_isEmpty(metadata.imprints) ? (

--- a/src/lib/modules/Document/DocumentInfo.js
+++ b/src/lib/modules/Document/DocumentInfo.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Divider, Table } from 'semantic-ui-react';
 import LiteratureKeywords from '@modules/Literature/LiteratureKeywords';
+import { invenioConfig } from '@config';
 
 export class DocumentInfo extends Component {
   renderLanguages() {
@@ -49,9 +50,10 @@ export class DocumentInfo extends Component {
                   authors={metadata.authors}
                   hasOtherAuthors={metadata.other_authors}
                   withPopUpShowMoreFields
-                  limit={20}
+                  limit={invenioConfig.LITERATURE.authors.maxDisplay}
                   scrollLimit={300}
                   expandable
+                  withVerticalScroll
                 />
               </Table.Cell>
             </Table.Row>

--- a/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.js
+++ b/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.js
@@ -11,6 +11,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import Truncate from 'react-truncate';
 import { Grid, Item, Label, List } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export default class DocumentListEntry extends Component {
   constructor(props) {
@@ -112,7 +113,7 @@ export default class DocumentListEntry extends Component {
               authors={this.metadata.authors}
               hasOtherAuthors={this.metadata.other_authors}
               prefix="by "
-              limit={10}
+              limit={invenioConfig.LITERATURE.authors.maxDisplay}
             />
           </Item.Meta>
           <Item.Description>

--- a/src/lib/modules/Document/DocumentListEntry/__snapshots__/DocumentListEntry.test.js.snap
+++ b/src/lib/modules/Document/DocumentListEntry/__snapshots__/DocumentListEntry.test.js.snap
@@ -59,7 +59,7 @@ exports[`should render correctly 1`] = `
             },
           ]
         }
-        limit={10}
+        limit={5}
         prefix="by "
       />
     </ItemMeta>

--- a/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
+++ b/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
@@ -12,6 +12,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Grid, Header, Icon, Item, List } from 'semantic-ui-react';
 import DocumentCirculation from './DocumentCirculation';
+import { invenioConfig } from '@config';
 
 export default class DocumentListEntry extends Component {
   renderMiddleColumn = (document) => {
@@ -113,7 +114,7 @@ export default class DocumentListEntry extends Component {
                   authors={document.metadata.authors}
                   hasOtherAuthors={document.metadata.other_authors}
                   prefix="by "
-                  limit={10}
+                  limit={invenioConfig.LITERATURE.authors.maxDisplay}
                 />
               </Item.Meta>
               <DocumentLanguages

--- a/src/lib/modules/Items/backoffice/ItemListEntry.js
+++ b/src/lib/modules/Items/backoffice/ItemListEntry.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Grid, Header, Item, List } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 class ItemCirculation extends Component {
   render() {
@@ -85,7 +86,7 @@ export class ItemListEntry extends Component {
                   authors={item.metadata.document.authors}
                   hasOtherAuthors={item.metadata.document.other_authors}
                   prefix="by "
-                  limit={10}
+                  limit={invenioConfig.LITERATURE.authors.maxDisplay}
                 />
                 <List>
                   <List.Item>

--- a/src/lib/modules/Loan/backoffice/LoanList/LoanListEntry.js
+++ b/src/lib/modules/Loan/backoffice/LoanList/LoanListEntry.js
@@ -11,6 +11,7 @@ import { Link } from 'react-router-dom';
 import { Grid, Header, Item, Label, List } from 'semantic-ui-react';
 import LiteratureTitle from '../../../Literature/LiteratureTitle';
 import { LoanDates } from './LoanDates';
+import { invenioConfig } from '@config';
 
 export class LoanListEntry extends Component {
   render() {
@@ -46,7 +47,7 @@ export class LoanListEntry extends Component {
                   authors={loan.metadata.document.authors}
                   hasOtherAuthors={loan.metadata.document.other_authors}
                   prefix="by "
-                  limit={10}
+                  limit={invenioConfig.LITERATURE.authors.maxDisplay}
                 />
               </Item.Meta>
             </Grid.Column>

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
@@ -14,6 +14,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Header, Icon, Label } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
+import { invenioConfig } from '@config';
 
 export class DocumentHeader extends Component {
   render() {
@@ -61,7 +62,7 @@ export class DocumentHeader extends Component {
             authors={data.metadata.authors}
             hasOtherAuthors={data.metadata.other_authors}
             prefix="by "
-            limit={10}
+            limit={invenioConfig.LITERATURE.authors.maxDisplay}
           />
         }
         pid={data.metadata.pid}

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentMetadataGeneral.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentMetadataGeneral.js
@@ -10,6 +10,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Container, Divider } from 'semantic-ui-react';
 import { groupedSchemeValueList } from '@components/backoffice/utils';
+import { invenioConfig } from '@config';
 
 export class DocumentMetadataGeneral extends Component {
   prepareGeneral = () => {
@@ -32,9 +33,10 @@ export class DocumentMetadataGeneral extends Component {
             hasOtherAuthors={document.metadata.other_authors}
             withPopUpShowMoreFields
             showAllFieldsInPopUp
-            limit={20}
+            limit={invenioConfig.LITERATURE.authors.maxDisplay}
             scrollLimit={300}
             expandable
+            withVerticalScroll
           />
         ),
       },

--- a/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/components/AuthorsField/AuthorSearchField.js
+++ b/src/lib/pages/backoffice/Document/DocumentForms/DocumentEditor/DocumentForm/components/AuthorsField/AuthorSearchField.js
@@ -83,10 +83,10 @@ export class AuthorSearchField extends React.Component {
 
   render() {
     const { isLoading, results, value } = this.state;
-    const { minCharacters } = this.props;
+    const { minCharacters, authors } = this.props;
     return (
       <Form.Field>
-        <label>Authors</label>
+        <label>{authors.length} authors in total</label>
         <Form.Button
           type="button"
           content="New author"
@@ -94,6 +94,7 @@ export class AuthorSearchField extends React.Component {
           onClick={this.onNewAuthor}
         />
         <Search
+          placeholder="Search for an author..."
           fluid
           input={{ icon: 'search', iconPosition: 'left' }}
           loading={isLoading}

--- a/src/lib/pages/backoffice/EItem/EItemDetails/EItemHeader.js
+++ b/src/lib/pages/backoffice/EItem/EItemDetails/EItemHeader.js
@@ -10,6 +10,7 @@ import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import { invenioConfig } from '@config';
 
 export class EItemHeader extends Component {
   render() {
@@ -44,7 +45,7 @@ export class EItemHeader extends Component {
             authors={data.metadata.document.authors}
             hasOtherAuthors={data.metadata.document.other_authors}
             prefix="by "
-            limit={10}
+            limit={invenioConfig.LITERATURE.authors.maxDisplay}
           />
         }
         pid={data.metadata.pid}

--- a/src/lib/pages/backoffice/EItem/EItemSearch/EItemListEntry.js
+++ b/src/lib/pages/backoffice/EItem/EItemSearch/EItemListEntry.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Grid, Icon, Item, List } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export default class EItemListEntry extends Component {
   render() {
@@ -30,7 +31,7 @@ export default class EItemListEntry extends Component {
                   authors={eitem.metadata.document.authors}
                   hasOtherAuthors={eitem.metadata.document.other_authors}
                   prefix="by "
-                  limit={10}
+                  limit={invenioConfig.LITERATURE.authors.maxDisplay}
                 />
               </Item.Meta>
               {eitem.metadata.doi && (

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemHeader.js
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemHeader.js
@@ -76,7 +76,7 @@ export class ItemHeader extends Component {
             authors={data.metadata.document.authors}
             hasOtherAuthors={data.metadata.document.other_authors}
             prefix="by "
-            limit={10}
+            limit={invenioConfig.LITERATURE.authors.maxDisplay}
           />
         }
         pid={data.metadata.pid}

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanHeader/LoanHeader.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanHeader/LoanHeader.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Header, Label } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
+import { invenioConfig } from '@config';
 
 export default class LoanHeader extends Component {
   render() {
@@ -64,7 +65,7 @@ export default class LoanHeader extends Component {
               authors={data.metadata.document.authors}
               hasOtherAuthors={data.metadata.document.other_authors}
               prefix="by: "
-              limit={10}
+              limit={invenioConfig.LITERATURE.authors.maxDisplay}
             />
           </>
         }

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanel.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanel.js
@@ -14,6 +14,7 @@ import { Grid } from 'semantic-ui-react';
 import { DocumentCirculation } from '../DocumentCirculation';
 import DocumentPanelMobile from './DocumentPanelMobile';
 import { DocumentTitle } from './DocumentTitle';
+import { invenioConfig } from '@config';
 
 class DocumentPanel extends Component {
   render() {
@@ -58,7 +59,7 @@ class DocumentPanel extends Component {
                         hasOtherAuthors={doc.metadata.other_authors}
                         prefix="by "
                         listItemAs="h4"
-                        limit={10}
+                        limit={invenioConfig.LITERATURE.authors.maxDisplay}
                       />
                     </ILSParagraphPlaceholder>
                     <ILSParagraphPlaceholder

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanelMobile.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanelMobile.js
@@ -13,6 +13,7 @@ import Overridable from 'react-overridable';
 import { Grid, Header } from 'semantic-ui-react';
 import { DocumentCirculation } from '../DocumentCirculation';
 import { DocumentTitle } from './DocumentTitle';
+import { invenioConfig } from '@config';
 
 class DocumentPanelMobile extends Component {
   render() {
@@ -43,7 +44,7 @@ class DocumentPanelMobile extends Component {
                     hasOtherAuthors={doc.metadata.other_authors}
                     prefix="by "
                     listItemAs="h4"
-                    limit={10}
+                    limit={invenioConfig.LITERATURE.authors.maxDisplay}
                   />
                 </ILSParagraphPlaceholder>
                 <ILSParagraphPlaceholder linesNumber={1} isLoading={isLoading}>

--- a/src/lib/pages/frontsite/PatronProfile/LoansListEntry.js
+++ b/src/lib/pages/frontsite/PatronProfile/LoansListEntry.js
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import Overridable from 'react-overridable';
 import { Link } from 'react-router-dom';
 import { Grid, Item } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
 
 export default class LoansListEntry extends Component {
   render() {
@@ -57,7 +58,7 @@ export default class LoansListEntry extends Component {
                   <DocumentAuthors
                     authors={documentAuthors}
                     hasOtherAuthors={documentHasOtherAuthors}
-                    limit={10}
+                    limit={invenioConfig.LITERATURE.authors.maxDisplay}
                   />
                   {itemMetaCmp}
                 </Item.Meta>

--- a/src/semantic-ui/site/elements/list.overrides
+++ b/src/semantic-ui/site/elements/list.overrides
@@ -5,11 +5,12 @@ List Overrides - REACT-INVENIO-APP-ILS
 /* GLOBAL */
 .document-authors-list-wrapper {
   width: 100%;
-  margin-bottom: 1rem;
 
   &.expanded {
-    max-height: 5em;
+    max-height: 10em;
     overflow-y: scroll;
+    border: 1px solid rgba(34, 36, 38, 0.15);
+    border-radius: 5px;
   }
 }
 


### PR DESCRIPTION
* Now we can show all authors in the details page
* Reduced overall displayed authors limit from 10 to 5
* closes https://github.com/CERNDocumentServer/cds-ils/issues/231

In terms of performance it's slightly slower when performing a search of 15 documents with 5k authors each. 
While a usual search takes around 400-450 ms, the heavy search takes 150-200 ms longer (550-600 ms).

## Usual search
![image](https://user-images.githubusercontent.com/15194802/104158080-e12ad500-53ec-11eb-9a99-e9f143e8f15e.png)

## Heavy search
![image](https://user-images.githubusercontent.com/15194802/104158085-e2f49880-53ec-11eb-88db-af204874cabe.png)

----

![image](https://user-images.githubusercontent.com/15194802/104159476-a8d8c600-53ef-11eb-9510-d709d67a9259.png)

![image](https://user-images.githubusercontent.com/15194802/104196117-b4de7b00-5423-11eb-8b17-c34e723ee20c.png)

