### PR TITLE
ill: show patron loan extension status

### DIFF
--- a/src/lib/api/ill/borrowingRequest.js
+++ b/src/lib/api/ill/borrowingRequest.js
@@ -1,8 +1,8 @@
 import { apiConfig, http } from '@api/base';
 import { prepareSumQuery } from '@api/utils';
 import { sessionManager } from '@authentication/services/SessionManager';
-import { borrowingRequestSerializer as serializer } from './serializers';
 import { invenioConfig } from '@config';
+import { borrowingRequestSerializer as serializer } from './serializers';
 
 const borrowingRequestUrl = '/ill/borrowing-requests/';
 
@@ -109,6 +109,7 @@ class QueryBuilder {
     this.size = '';
     this.sortByQuery = '';
     this.stateQuery = [];
+    this.patronLoanExtensionStatusQuery = [];
   }
 
   withState(state) {
@@ -124,6 +125,16 @@ class QueryBuilder {
       throw TypeError('Patron PID argument missing');
     }
     this.patronQuery.push(`patron_pid:${patronPid}`);
+    return this;
+  }
+
+  withPatronLoanExtensionStatus(status) {
+    if (!status) {
+      throw TypeError('Status argument missing');
+    }
+    this.patronLoanExtensionStatusQuery.push(
+      `patron_loan.extension.status:${prepareSumQuery(status)}`
+    );
     return this;
   }
 
@@ -170,6 +181,7 @@ class QueryBuilder {
     const searchCriteria = this.patronQuery
       .concat(this.libraryQuery, this.libraryPidQuery)
       .concat(this.stateQuery)
+      .concat(this.patronLoanExtensionStatusQuery)
       .concat(this.query)
       .join(' AND ');
     return `(${searchCriteria})${this.sortByQuery}${this.size}${this.page}`;

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -353,7 +353,7 @@ export const RECORDS_CONFIG = {
           aggName: 'state',
         },
         {
-          title: 'Reject reason',
+          title: 'Decline reason',
           field: 'reject_reason',
           aggName: 'reject_reason',
         },
@@ -430,6 +430,7 @@ export const RECORDS_CONFIG = {
     completedStatuses: ['CANCELLED', 'RETURNED'],
     extensionDeclinedStatuses: ['DECLINED'],
     extensionPendingStatuses: ['PENDING'],
+    loanMaxDuration: 180,
     statuses: ILL_BORROWING_REQUESTS_STATUSES,
     search: {
       filters: [
@@ -440,12 +441,18 @@ export const RECORDS_CONFIG = {
           labels: ILL_BORROWING_REQUESTS_STATUSES,
         },
         {
+          title: 'Loan extension',
+          field: 'patron_loan_extension',
+          aggName: 'patron_loan_extension',
+          labels: ILL_BORROWING_REQUESTS_STATUSES,
+        },
+        {
           title: 'Library',
           field: 'library.name',
           aggName: 'library',
         },
         {
-          title: 'Type',
+          title: 'Item type',
           field: 'type',
           aggName: 'type',
         },

--- a/src/lib/modules/Location/LocationDatePicker.js
+++ b/src/lib/modules/Location/LocationDatePicker.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { DatePicker } from '@components/DatePicker';
 import { locationApi } from '@api/locations';
+import { DatePicker } from '@components/DatePicker';
 import _isEmpty from 'lodash/isEmpty';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export class LocationDatePicker extends Component {
   constructor(props) {

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestActions/RejectAction.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestActions/RejectAction.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { Dropdown, Confirm, Menu } from 'semantic-ui-react';
 import { documentApi } from '@api/documents';
 import { ESSelectorModal } from '@modules/ESSelector';
 import { serializeDocument } from '@modules/ESSelector/serializer';
 import get from 'lodash/get';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Confirm, Dropdown, Menu } from 'semantic-ui-react';
 
 export class RejectAction extends React.Component {
   state = {
@@ -80,11 +80,11 @@ export class RejectAction extends React.Component {
             trigger={dropdown}
             query={documentApi.list}
             serializer={serializeDocument}
-            title="Reject request: Already in the catalog"
-            content="Select document to attach to the reject."
-            emptySelectionInfoText="No document selected"
+            title="Decline request: already in the catalog"
+            content="Select literature to attach."
+            emptySelectionInfoText="No literature selected"
             onSave={this.onRejectWithDocument}
-            saveButtonContent="Reject request"
+            saveButtonContent="Decline request"
           />
         );
       }
@@ -100,7 +100,7 @@ export class RejectAction extends React.Component {
         <Menu.Menu position="right">
           <Dropdown
             disabled={disabled}
-            text="Reject request"
+            text="Decline request"
             icon="cancel"
             floating
             labeled
@@ -109,14 +109,14 @@ export class RejectAction extends React.Component {
           >
             <Dropdown.Menu>
               <Confirm
-                confirmButton="Reject request"
-                content="Are you sure you want to reject this request?"
-                header={`Reject: ${header}`}
+                confirmButton="Decline request"
+                content="Are you sure you want to decline this request?"
+                header={`Decline: ${header}`}
                 open={open}
                 onCancel={this.onCancel}
                 onConfirm={() => this.onConfirm(type)}
               />
-              <Dropdown.Header content="Specify a reject reason" />
+              <Dropdown.Header content="Specify a reason" />
               {this.renderOptions()}
             </Dropdown.Menu>
           </Dropdown>

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestHeader/DocumentRequestHeader.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestHeader/DocumentRequestHeader.js
@@ -1,19 +1,19 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
-import { BackOfficeRoutes } from '@routes/urls';
-import { Label } from 'semantic-ui-react';
 import { toShortDate } from '@api/date';
-import { CopyButton } from '@components/CopyButton';
-import { DocumentRequestIcon } from '@components/backoffice/icons';
 import { DetailsHeader } from '@components/backoffice/DetailsHeader';
+import { DocumentRequestIcon } from '@components/backoffice/icons';
+import { CopyButton } from '@components/CopyButton';
+import { BackOfficeRoutes } from '@routes/urls';
 import { DateTime } from 'luxon';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Label } from 'semantic-ui-react';
 
 export default class DocumentRequestHeader extends Component {
   renderStatus(status) {
     switch (status) {
       case 'REJECTED':
-        return <Label color="grey">Rejected</Label>;
+        return <Label color="grey">Declined</Label>;
       case 'PENDING':
         return <Label color="yellow">Pending</Label>;
       case 'ACCEPTED':

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestMetadata/DocumentRequestMetadata.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestMetadata/DocumentRequestMetadata.js
@@ -43,7 +43,7 @@ export default class DocumentRequestMetadata extends Component {
     this.addRow(rows, 'Publication Year', data.metadata.publication_year);
     this.addRow(rows, 'Medium', data.metadata.medium);
     this.addRow(rows, 'Note', data.metadata.note);
-    this.addRow(rows, 'Reject Reason', data.metadata.reject_reason);
+    this.addRow(rows, 'Reason', data.metadata.reject_reason);
     this.addRow(rows, 'Payment info', data.metadata.payment_info);
     return rows;
   }

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestSteps/DocumentRequestSteps.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestSteps/DocumentRequestSteps.js
@@ -1,15 +1,15 @@
 import _get from 'lodash/get';
-import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Container, Message, Step, Divider } from 'semantic-ui-react';
-import { DocumentStep } from './DocumentStep/DocumentStep';
+import React, { Component } from 'react';
+import { Container, Divider, Message, Step } from 'semantic-ui-react';
 import { DocumentStepContent } from './DocumentStep';
-import { ProviderStep } from './ProviderStep/ProviderStep';
+import { DocumentStep } from './DocumentStep/DocumentStep';
 import { ProviderStepContent } from './ProviderStep/';
-import { ReviewStep } from './ReviewStep/ReviewStep';
+import { ProviderStep } from './ProviderStep/ProviderStep';
 import { ReviewStepContent } from './ReviewStep';
-import { StepsActions } from './StepsActions';
+import { ReviewStep } from './ReviewStep/ReviewStep';
 import { STEPS } from './Steps';
+import { StepsActions } from './StepsActions';
 
 export default class DocumentRequestSteps extends Component {
   calculateStep = (docPid = undefined, providerPid = undefined) => {
@@ -47,8 +47,8 @@ export default class DocumentRequestSteps extends Component {
       </Container>
     ) : (
       <Message info>
-        <Message.Header>Rejected request!</Message.Header>
-        <p>You cannot modify a rejected document request.</p>
+        <Message.Header>Declined request!</Message.Header>
+        <p>You cannot modify a declined request.</p>
       </Message>
     );
   }

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestSearch/DocumentRequestListEntry.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestSearch/DocumentRequestListEntry.js
@@ -1,9 +1,9 @@
 import { DocumentRequestIcon } from '@components/backoffice/icons';
 import { BackOfficeRoutes } from '@routes/urls';
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Grid, Header, Item, List } from 'semantic-ui-react';
-import PropTypes from 'prop-types';
 
 export class DocumentRequestListEntry extends Component {
   render() {
@@ -60,7 +60,7 @@ export class DocumentRequestListEntry extends Component {
                 {documentRequest.metadata.reject_reason && (
                   <List.Item>
                     <List.Content>
-                      <label>Reject reason </label>
+                      <label>Reason </label>
                       {documentRequest.metadata.reject_reason}
                     </List.Content>
                   </List.Item>

--- a/src/lib/pages/backoffice/Home/Home.js
+++ b/src/lib/pages/backoffice/Home/Home.js
@@ -1,13 +1,14 @@
 import React, { Component } from 'react';
 import { Grid } from 'semantic-ui-react';
-import { LoansCard, DocumentCard, ACQRequestsCard, ILLCard } from './widgets';
 import {
+  IdleLoansList,
   OverbookedDocumentsList,
   OverdueLoansList,
-  IdleLoansList,
-  RenewedLoansList,
+  PendingILLPatronLoanExtensions,
   PendingOverdueDocumentsList,
+  RenewedLoansList,
 } from './lists';
+import { ACQRequestsCard, DocumentCard, ILLCard, LoansCard } from './widgets';
 
 export default class Home extends Component {
   render() {
@@ -37,6 +38,7 @@ export default class Home extends Component {
           <Grid.Column>
             <OverbookedDocumentsList />
             <PendingOverdueDocumentsList />
+            <PendingILLPatronLoanExtensions />
           </Grid.Column>
         </Grid.Row>
       </Grid>

--- a/src/lib/pages/backoffice/Home/lists/PendingILLPatronLoanExtensions/PendingILLPatronLoanExtensions.js
+++ b/src/lib/pages/backoffice/Home/lists/PendingILLPatronLoanExtensions/PendingILLPatronLoanExtensions.js
@@ -1,0 +1,94 @@
+import { dateFormatter } from '@api/date';
+import { borrowingRequestApi } from '@api/ill';
+import { SeeAllButton } from '@components/backoffice/buttons/SeeAllButton';
+import { Error } from '@components/Error';
+import { Loader } from '@components/Loader';
+import { ResultsTable } from '@components/ResultsTable/ResultsTable';
+import { invenioConfig } from '@config';
+import { ILLRoutes } from '@routes/urls';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from 'semantic-ui-react';
+
+export default class PendingILLPatronLoanExtensions extends Component {
+  componentDidMount() {
+    const { fetchPendingILLPatronLoanExtensions } = this.props;
+    fetchPendingILLPatronLoanExtensions();
+  }
+
+  seeAllButton = () => {
+    const path = ILLRoutes.borrowingRequestListWithQuery(
+      borrowingRequestApi
+        .query()
+        .withState(invenioConfig.ILL_BORROWING_REQUESTS.activeStatuses)
+        .withPatronLoanExtensionStatus(
+          invenioConfig.ILL_BORROWING_REQUESTS.extensionPendingStatuses
+        )
+        .qs()
+    );
+    return <SeeAllButton to={path} />;
+  };
+
+  viewDetails = ({ row }) => {
+    return (
+      <Button
+        as={Link}
+        to={ILLRoutes.borrowingRequestDetailsFor(row.metadata.pid)}
+        compact
+        icon="info"
+        data-test={row.metadata.pid}
+      />
+    );
+  };
+
+  renderTable(data) {
+    const { showMaxEntries } = this.props;
+    const columns = [
+      { title: '', field: '', formatter: this.viewDetails },
+      { title: 'ID', field: 'metadata.pid' },
+      { title: 'Patron ID', field: 'metadata.patron_pid' },
+      { title: 'Document ID', field: 'metadata.document_pid' },
+      {
+        title: 'Request start date',
+        field: 'metadata.patron_loan.extension.request_date',
+        formatter: dateFormatter,
+      },
+    ];
+    return (
+      <ResultsTable
+        data={data.hits}
+        columns={columns}
+        totalHitsCounts={data.total}
+        title="ILL - Pending patron loan extension requests"
+        subtitle="ILLs with a pending extension request from a patron."
+        name="pending ILL patron loan extension requests"
+        seeAllComponent={this.seeAllButton()}
+        showMaxRows={showMaxEntries}
+      />
+    );
+  }
+
+  render() {
+    const { data, isLoading, error } = this.props;
+    return (
+      <Loader isLoading={isLoading}>
+        <Error error={error}>{this.renderTable(data)}</Error>
+      </Loader>
+    );
+  }
+}
+
+PendingILLPatronLoanExtensions.propTypes = {
+  showMaxEntries: PropTypes.number,
+  /* redux */
+  fetchPendingILLPatronLoanExtensions: PropTypes.func.isRequired,
+  data: PropTypes.object.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  error: PropTypes.object,
+};
+
+PendingILLPatronLoanExtensions.defaultProps = {
+  showMaxEntries: 5,
+  error: {},
+};

--- a/src/lib/pages/backoffice/Home/lists/PendingILLPatronLoanExtensions/index.js
+++ b/src/lib/pages/backoffice/Home/lists/PendingILLPatronLoanExtensions/index.js
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import PendingILLPatronLoanExtensionsComponent from './PendingILLPatronLoanExtensions';
+import { fetchPendingILLPatronLoanExtensions } from './state/actions';
+
+const mapStateToProps = state => ({
+  data: state.pendingILLPatronLoanExtensions.data,
+  error: state.pendingILLPatronLoanExtensions.error,
+  isLoading: state.pendingILLPatronLoanExtensions.isLoading,
+  hasError: state.pendingILLPatronLoanExtensions.hasError,
+});
+
+const mapDispatchToProps = dispatch => ({
+  fetchPendingILLPatronLoanExtensions: () =>
+    dispatch(fetchPendingILLPatronLoanExtensions()),
+});
+
+export const PendingILLPatronLoanExtensions = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(PendingILLPatronLoanExtensionsComponent);

--- a/src/lib/pages/backoffice/Home/lists/PendingILLPatronLoanExtensions/state/actions.js
+++ b/src/lib/pages/backoffice/Home/lists/PendingILLPatronLoanExtensions/state/actions.js
@@ -1,0 +1,38 @@
+import { borrowingRequestApi } from '@api/ill';
+import { sendErrorNotification } from '@components/Notifications';
+import { invenioConfig } from '@config';
+
+export const IS_LOADING =
+  'fetchILLsPendingPatronLoanExtensionRequests/IS_LOADING';
+export const SUCCESS = 'fetchILLsPendingPatronLoanExtensionRequests/SUCCESS';
+export const HAS_ERROR =
+  'fetchILLsPendingPatronLoanExtensionRequests/HAS_ERROR';
+
+export const fetchPendingILLPatronLoanExtensions = () => {
+  return async dispatch => {
+    dispatch({
+      type: IS_LOADING,
+    });
+    try {
+      const response = await borrowingRequestApi.list(
+        borrowingRequestApi
+          .query()
+          .withState(invenioConfig.ILL_BORROWING_REQUESTS.activeStatuses)
+          .withPatronLoanExtensionStatus(
+            invenioConfig.ILL_BORROWING_REQUESTS.extensionPendingStatuses
+          )
+          .qs()
+      );
+      dispatch({
+        type: SUCCESS,
+        payload: response.data,
+      });
+    } catch (error) {
+      dispatch({
+        type: HAS_ERROR,
+        payload: error,
+      });
+      dispatch(sendErrorNotification(error));
+    }
+  };
+};

--- a/src/lib/pages/backoffice/Home/lists/PendingILLPatronLoanExtensions/state/reducer.js
+++ b/src/lib/pages/backoffice/Home/lists/PendingILLPatronLoanExtensions/state/reducer.js
@@ -1,0 +1,32 @@
+import { IS_LOADING, SUCCESS, HAS_ERROR } from './actions';
+
+export const initialState = {
+  isLoading: true,
+  hasError: false,
+  data: { hits: [], total: 0 },
+  error: {},
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case IS_LOADING:
+      return { ...state, isLoading: true };
+    case SUCCESS:
+      return {
+        ...state,
+        isLoading: false,
+        data: action.payload,
+        error: {},
+        hasError: false,
+      };
+    case HAS_ERROR:
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        hasError: true,
+      };
+    default:
+      return state;
+  }
+};

--- a/src/lib/pages/backoffice/Home/lists/index.js
+++ b/src/lib/pages/backoffice/Home/lists/index.js
@@ -1,5 +1,6 @@
 export { IdleLoansList } from './IdleLoansList';
 export { OverbookedDocumentsList } from './OverbookedDocumentsList';
 export { OverdueLoansList } from './OverdueLoansList';
+export { PendingILLPatronLoanExtensions } from './PendingILLPatronLoanExtensions';
 export { PendingOverdueDocumentsList } from './PendingOverdueDocumentsList';
 export { RenewedLoansList } from './RenewedLoansList';

--- a/src/lib/pages/backoffice/Home/reducer.js
+++ b/src/lib/pages/backoffice/Home/reducer.js
@@ -1,9 +1,10 @@
-export { default as loansCardReducer } from './widgets/LoansCard/state/reducer';
-export { default as documentCardReducer } from './widgets/DocumentCard/state/reducer';
-export { default as acquisitionCardReducer } from './widgets/ACQRequestsCard/state/reducer';
-export { default as illCardReducer } from './widgets/ILLCard/state/reducer';
+export { default as idleLoansReducer } from './lists/IdleLoansList/state/reducer';
 export { default as overbookedDocumentsReducer } from './lists/OverbookedDocumentsList/state/reducer';
 export { default as overdueLoansReducer } from './lists/OverdueLoansList/state/reducer';
+export { default as pendingILLPatronLoanExtensions } from './lists/PendingILLPatronLoanExtensions/state/reducer';
 export { default as pendingOverdueDocumentsReducer } from './lists/PendingOverdueDocumentsList/state/reducer';
-export { default as idleLoansReducer } from './lists/IdleLoansList/state/reducer';
 export { default as renewedLoansReducer } from './lists/RenewedLoansList/state/reducer';
+export { default as acquisitionCardReducer } from './widgets/ACQRequestsCard/state/reducer';
+export { default as documentCardReducer } from './widgets/DocumentCard/state/reducer';
+export { default as illCardReducer } from './widgets/ILLCard/state/reducer';
+export { default as loansCardReducer } from './widgets/LoansCard/state/reducer';

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/BorrowingRequestLoanExtension/BorrowingRequestLoanExtension.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/BorrowingRequestLoanExtension/BorrowingRequestLoanExtension.js
@@ -1,7 +1,9 @@
-import { DatePicker } from '@components/DatePicker';
+import { toShortDate } from '@api/date';
 import { InfoMessage } from '@components/InfoMessage';
 import { invenioConfig } from '@config';
+import { LocationDatePicker } from '@modules/Location';
 import _isEmpty from 'lodash/isEmpty';
+import { DateTime } from 'luxon';
 import { PropTypes } from 'prop-types';
 import React, { Component } from 'react';
 import {
@@ -14,7 +16,6 @@ import {
   Modal,
   Table,
 } from 'semantic-ui-react';
-import { DateTime } from 'luxon';
 
 export default class BorrowingRequestLoanExtension extends Component {
   constructor(props) {
@@ -51,10 +52,16 @@ export default class BorrowingRequestLoanExtension extends Component {
   render() {
     const {
       isLoading,
+      patron,
       patronLoan,
       patronLoan: { extension },
     } = this.props;
     const { modalOpen } = this.state;
+    const max = new DateTime(
+      DateTime.local().plus({
+        days: invenioConfig.ILL_BORROWING_REQUESTS.loanMaxDuration,
+      })
+    );
     return (
       <Container>
         <Divider horizontal>Loan extension</Divider>
@@ -105,9 +112,11 @@ export default class BorrowingRequestLoanExtension extends Component {
                           <Form.Group>
                             <Form.Field inline required>
                               <label>Extension end date</label>
-                              <DatePicker
-                                minDate={this.today}
+                              <LocationDatePicker
+                                locationPid={patron.location_pid}
                                 defaultValue={this.endDate}
+                                minDate={toShortDate(DateTime.local())}
+                                maxDate={toShortDate(max)}
                                 placeholder="End date"
                                 handleDateChange={value =>
                                   this.handleEndDateChange(value)
@@ -160,6 +169,7 @@ export default class BorrowingRequestLoanExtension extends Component {
 }
 
 BorrowingRequestLoanExtension.propTypes = {
+  patron: PropTypes.object.isRequired,
   patronLoan: PropTypes.object.isRequired,
   brwReqPid: PropTypes.string.isRequired,
   isLoading: PropTypes.bool,

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/BorrowingRequestPatronLoan.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/BorrowingRequestPatronLoan.js
@@ -1,8 +1,8 @@
 import { toShortDate } from '@api/date';
 import { LoanIcon } from '@components/backoffice/icons';
 import { MetadataTable } from '@components/backoffice/MetadataTable';
-import { invenioConfig } from '@config';
-import { getDisplayVal } from '@config';
+import { getDisplayVal, invenioConfig } from '@config';
+import { LocationDatePicker } from '@modules/Location';
 import { BackOfficeRoutes } from '@routes/urls';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
@@ -21,7 +21,6 @@ import {
   Modal,
 } from 'semantic-ui-react';
 import { BorrowingRequestLoanExtension } from './BorrowingRequestLoanExtension';
-import { LocationDatePicker } from '@modules/Location';
 
 class CreateLoanButton extends React.Component {
   render() {
@@ -136,9 +135,10 @@ class CreateLoan extends React.Component {
   render() {
     const { brwReq, isLoading, hasError, error } = this.props;
     const { modalOpen } = this.state;
-    const today = DateTime.local();
     const max = new DateTime(
-      today.plus({ days: invenioConfig.CIRCULATION.requestDuration })
+      DateTime.local().plus({
+        days: invenioConfig.ILL_BORROWING_REQUESTS.loanMaxDuration,
+      })
     );
     return (
       <>
@@ -285,6 +285,7 @@ export default class BorrowingRequestPatronLoan extends React.Component {
 
         {!_isEmpty(brwReq.patron_loan) && (
           <BorrowingRequestLoanExtension
+            patron={brwReq.patron}
             patronLoan={brwReq.patron_loan}
             brwReqPid={brwReq.pid}
           />

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -36,6 +36,7 @@ import {
   loansCardReducer,
   overbookedDocumentsReducer,
   overdueLoansReducer,
+  pendingILLPatronLoanExtensions,
   pendingOverdueDocumentsReducer,
   renewedLoansReducer,
 } from '@pages/backoffice/Home/reducer';
@@ -104,6 +105,7 @@ const rootReducer = combineReducers({
   overdueLoans: overdueLoansReducer,
   pendingOverdueDocuments: pendingOverdueDocumentsReducer,
   idlePendingLoans: idleLoansReducer,
+  pendingILLPatronLoanExtensions: pendingILLPatronLoanExtensions,
   latestRenewedLoans: renewedLoansReducer,
   overdueLoanSendMailModal: overdueLoanSendMailModalReducer,
   loanDetails: loanDetailsReducer,


### PR DESCRIPTION
* adds a search filter to immediately find pending extension requests
* adds a new home dashboard panel to show the pending extension requests
* fixed calendar for loans and extensions