### PR TITLE
backoffice: fix docs and series content tabs

### DIFF
--- a/src/lib/modules/Series/SeriesListEntry.js
+++ b/src/lib/modules/Series/SeriesListEntry.js
@@ -26,7 +26,6 @@ export default class SeriesListEntry extends Component {
         to={FrontSiteRoutes.seriesDetailsFor(this.metadata.pid)}
       >
         <LiteratureCover
-          asItem
           size="small"
           url={_get(this, 'metadata.cover_metadata.urls.medium')}
         />

--- a/src/lib/modules/Series/__snapshots__/SeriesListEntry.test.js.snap
+++ b/src/lib/modules/Series/__snapshots__/SeriesListEntry.test.js.snap
@@ -21,7 +21,6 @@ exports[`should render correctly 1`] = `
     to="/series/serid-1"
   >
     <Overridable(LiteratureCover)
-      asItem={true}
       size="small"
     />
   </ItemImage>

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentContents.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentContents.js
@@ -16,7 +16,8 @@ export class DocumentContents extends Component {
       !_isEmpty(document.metadata.abstract) ||
       !_isEmpty(document.metadata.table_of_content) ||
       !_isEmpty(document.metadata.subjects) ||
-      !_isEmpty(document.metadata.tags)
+      !_isEmpty(document.metadata.tags) ||
+      !_isEmpty(document.metadata.keywords)
     ) {
       return (
         <>

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesContent/SeriesContent.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesContent/SeriesContent.js
@@ -13,17 +13,21 @@ export class SeriesContent extends Component {
 
     return series.metadata.abstract ||
       series.metadata.keywords ||
-      series.metadata.keywords ? (
+      series.metadata.tags ? (
       <>
-        <Header as="h3">Abstract </Header>
-        <ShowMore
-          lines={10}
-          more="Show more"
-          less="Show less"
-          anchorClass="button-show-more"
-        >
-          {series.metadata.abstract}
-        </ShowMore>
+        {!_isEmpty(series.metadata.abstract) && (
+          <>
+            <Header as="h3">Abstract </Header>
+            <ShowMore
+              lines={10}
+              more="Show more"
+              less="Show less"
+              anchorClass="button-show-more"
+            >
+              {series.metadata.abstract}
+            </ShowMore>
+          </>
+        )}
         {!_isEmpty(series.metadata.tags) && (
           <>
             <Divider />


### PR DESCRIPTION
Before in document details the keywords were not appearing if all the other content fields were empty and in series details the same happened with tags.

Fixes cover for series in list view.