### PR TITLE
access urls: truncate url, add open access/login required text

### DIFF
--- a/src/lib/modules/Document/DocumentLinks.js
+++ b/src/lib/modules/Document/DocumentLinks.js
@@ -33,6 +33,7 @@ export class DocumentLinks extends Component {
       <>
         {this.renderTitle('Read online')}
         <LiteratureAccessUrls
+          truncate
           urls={eitems.hits.flatMap((eitem) => eitem.urls)}
         />
       </>

--- a/src/lib/modules/Literature/LiteratureAccessUrls.js
+++ b/src/lib/modules/Literature/LiteratureAccessUrls.js
@@ -15,6 +15,7 @@ const AccessUrl = ({ truncate, url }) => {
         <a href={url.login_required_url ? url.login_required_url : url.value}>
           {truncate ? _truncate(description, { length: 35 }) : description}{' '}
         </a>
+        {url.login_required ? '(login required)' : '(open access)'}
       </List.Content>
     </List.Item>
   );
@@ -26,6 +27,7 @@ AccessUrl.propTypes = {
     value: PropTypes.string.isRequired,
     login_required: PropTypes.bool,
     login_required_url: PropTypes.string,
+    open_access: PropTypes.bool,
   }).isRequired,
   truncate: PropTypes.bool,
 };


### PR DESCRIPTION
Screenshot:
<img width="388" alt="Screenshot 2021-02-17 at 14 32 49" src="https://user-images.githubusercontent.com/33685068/108211651-3b762e80-712d-11eb-9abd-34876fd34b43.png">

Closes #358 