### PR TITLE
[BLOCKED]backoffice: display number of overdue reminders in loan details

### DIFF
--- a/src/lib/api/emails/email.js
+++ b/src/lib/api/emails/email.js
@@ -1,0 +1,75 @@
+import { http } from '@api/base';
+import { prepareSumQuery } from '@api/utils';
+
+const apiPaths = {
+  list: '/emails',
+};
+
+class QueryBuilder {
+  constructor() {
+    this.recipientUserIdQuery = '';
+    this.pidTypeQuery = '';
+    this.pidValueQuery = '';
+    this.emailActionQuery = '';
+    this.size = '';
+  }
+
+  withRecipientUserId(recipientUserId) {
+    if (!recipientUserId) {
+      throw TypeError('recipientUserId argument missing');
+    }
+    this.recipientUserIdQuery = `recipient_user_id=${prepareSumQuery(
+      recipientUserId
+    )}`;
+    return this;
+  }
+
+  withPidType(pidType) {
+    if (!pidType) {
+      throw TypeError('pidType argument missing');
+    }
+    this.pidTypeQuery = `pid_type=${prepareSumQuery(pidType)}`;
+    return this;
+  }
+
+  withPidValue(pidValue) {
+    if (!pidValue) {
+      throw TypeError('pidValue argument missing');
+    }
+    this.pidValueQuery = `pid_value=${prepareSumQuery(pidValue)}`;
+    return this;
+  }
+
+  withEmailAction(emailAction) {
+    if (!emailAction) {
+      throw TypeError('emailAction argument missing');
+    }
+    this.emailActionQuery = `email_action=${prepareSumQuery(emailAction)}`;
+    return this;
+  }
+
+  withSize(size) {
+    if (size > 0) this.size = `&size=${size}`;
+    return this;
+  }
+
+  qs() {
+    return `${this.size}&${this.emailActionQuery}&${this.pidTypeQuery}&${this.pidValueQuery}&${this.recipientUserIdQuery}`;
+  }
+}
+
+const queryBuilder = () => {
+  return new QueryBuilder();
+};
+
+const list = async (query) => {
+  const response = await http.get(`${apiPaths.list}?q=${query}`);
+  response.data.total = response.data.hits.total;
+  response.data = response.data.hits;
+  return response;
+};
+
+export const emailApi = {
+  list: list,
+  query: queryBuilder,
+};

--- a/src/lib/api/emails/index.js
+++ b/src/lib/api/emails/index.js
@@ -1,0 +1,1 @@
+export { emailApi } from './email';

--- a/src/lib/components/CancelModal/CancelModal.js
+++ b/src/lib/components/CancelModal/CancelModal.js
@@ -62,6 +62,7 @@ export default class CancelModal extends Component {
         trigger={
           <Button
             primary
+            fluid
             content={buttonText}
             onClick={this.show}
             loading={isLoading}

--- a/src/lib/components/CancelModal/__snapshots__/CancelModal.test.js.snap
+++ b/src/lib/components/CancelModal/__snapshots__/CancelModal.test.js.snap
@@ -16,6 +16,7 @@ exports[`CancelModal tests should load the cancel loan modal component 1`] = `
       as="button"
       content="cancel"
       disabled={false}
+      fluid={true}
       loading={false}
       onClick={[Function]}
       primary={true}

--- a/src/lib/components/backoffice/ChangedBy/ChangedBy.js
+++ b/src/lib/components/backoffice/ChangedBy/ChangedBy.js
@@ -14,10 +14,14 @@ const ChangedBy = ({ metadata, field }) => {
   } else {
     switch (byType) {
       case 'user_id':
-        return (
+        return byValue > 0 ? (
           <Link to={BackOfficeRoutes.patronDetailsFor(byValue)}>
             <PatronIcon /> {byValue}
           </Link>
+        ) : (
+          <>
+            <PatronIcon /> anonymous
+          </>
         );
       default:
         return `${byType}:${byValue}`;

--- a/src/lib/components/backoffice/buttons/ViewDetailsButtons/PatronDetailsLink.js
+++ b/src/lib/components/backoffice/buttons/ViewDetailsButtons/PatronDetailsLink.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 export class PatronDetailsLink extends Component {
   render() {
     const { patronPid, children, ...props } = this.props;
-    return (
+    return patronPid > 0 ? (
       <Link
         to={BackOfficeRoutes.patronDetailsFor(patronPid)}
         data-test={patronPid}
@@ -14,6 +14,8 @@ export class PatronDetailsLink extends Component {
       >
         {children}
       </Link>
+    ) : (
+      <>{children}</>
     );
   }
 }

--- a/src/lib/modules/Document/DocumentCard/DocumentCard.js
+++ b/src/lib/modules/Document/DocumentCard/DocumentCard.js
@@ -1,5 +1,3 @@
-import { invenioConfig } from '@config';
-import { goTo } from '@history';
 import DocumentAuthors from '@modules/Document/DocumentAuthors';
 import LiteratureCover from '@modules/Literature/LiteratureCover';
 import LiteratureTitle from '@modules/Literature/LiteratureTitle';
@@ -9,6 +7,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Overridable from 'react-overridable';
 import { Card, Label } from 'semantic-ui-react';
+import { invenioConfig } from '@config';
+import { Link } from 'react-router-dom';
 
 class DocumentCard extends Component {
   renderImage = () => {
@@ -46,10 +46,8 @@ class DocumentCard extends Component {
           centered
           className="fs-book-card"
           href={url}
-          onClick={(e) => {
-            e.preventDefault();
-            goTo(url);
-          }}
+          as={Link}
+          to={url}
           data-test={metadata.pid}
         >
           <Card.Meta className="discrete">{metadata.document_type}</Card.Meta>

--- a/src/lib/modules/Loan/backoffice/LoanList/LoanListEntry.js
+++ b/src/lib/modules/Loan/backoffice/LoanList/LoanListEntry.js
@@ -1,6 +1,6 @@
 import { DocumentIcon, ItemIcon, LoanIcon } from '@components/backoffice/icons';
 import LoanLinkToItem from '@modules/Loan/backoffice/LoanLinkToItem';
-import { OverdueLoanSendMailModal } from '@modules/Loan/backoffice/OverdueLoanSendMailModal';
+
 import { BackOfficeRoutes } from '@routes/urls';
 import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
@@ -14,7 +14,7 @@ import { LoanDates } from './LoanDates';
 export class LoanListEntry extends Component {
   render() {
     const { record: loan, target } = this.props;
-
+    const patronPid = loan.metadata.patron_pid;
     return (
       <Item>
         <Item.Content>
@@ -30,12 +30,16 @@ export class LoanListEntry extends Component {
           <Grid columns={5}>
             <Grid.Column computer={6} largeScreen={5}>
               <label>Patron</label>{' '}
-              <Link
-                target="_blank"
-                to={BackOfficeRoutes.patronDetailsFor(loan.metadata.patron_pid)}
-              >
-                {loan.metadata.patron.name}
-              </Link>{' '}
+              {patronPid > 0 ? (
+                <Link
+                  target="_blank"
+                  to={BackOfficeRoutes.patronDetailsFor(patronPid)}
+                >
+                  {loan.metadata.patron.name}
+                </Link>
+              ) : (
+                loan.metadata.patron.name
+              )}{' '}
               requested:
               <Item.Meta className="document-authors">
                 <Header className="loan-document-title" as="h5">
@@ -68,7 +72,6 @@ export class LoanListEntry extends Component {
               </List>
             </Grid.Column>
             <Grid.Column width={2} textAlign="center">
-              <OverdueLoanSendMailModal loan={loan} />
               <Overridable
                 id="LoanListEntry.DeliveryIcon"
                 deliveryMethod={

--- a/src/lib/modules/Loan/backoffice/OverdueLoanSendMailModal/index.js
+++ b/src/lib/modules/Loan/backoffice/OverdueLoanSendMailModal/index.js
@@ -3,7 +3,7 @@ import { sendOverdueLoansMailReminder } from './state/actions';
 import OverdueLoanSendMailModalComponent from './OverdueLoanSendMailModal';
 
 const mapStateToProps = (state) => ({
-  ...state.overdueLoanSendMailModal,
+  isLoading: state.overdueLoanSendMailModal.isLoading,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/lib/modules/Loan/backoffice/OverdueLoanSendMailModal/state/actions.js
+++ b/src/lib/modules/Loan/backoffice/OverdueLoanSendMailModal/state/actions.js
@@ -3,7 +3,7 @@ import {
   sendErrorNotification,
   sendSuccessNotification,
 } from '@components/Notifications';
-
+import { fetchLoanDetails } from '@modules/Loan/actions';
 export const IS_LOADING = 'overdueLoanSendMailModal/IS_LOADING';
 export const SUCCESS = 'overdueLoanSendMailModal/SUCCESS';
 export const HAS_ERROR = 'overdueLoanSendMailModal/HAS_ERROR';
@@ -20,6 +20,7 @@ export const sendOverdueLoansMailReminder = (loanPid) => {
         type: SUCCESS,
         payload: response.data,
       });
+      dispatch(fetchLoanDetails(response.data.metadata.pid));
       dispatch(
         sendSuccessNotification(
           'Success!',

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderLines.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderLines.js
@@ -8,14 +8,20 @@ import { Link } from 'react-router-dom';
 import { Divider, Grid, Icon, Item, Message, Popup } from 'semantic-ui-react';
 
 const OrderLineLeftColumn = ({ line }) => {
+  const patronPid = line.patron_pid;
+  const patronName = line.patron.name;
   return (
     <>
       {line.patron && (
         <Item.Description>
           <label>Patron: </label>
-          <Link to={BackOfficeRoutes.patronDetailsFor(line.patron_pid)}>
-            <PatronIcon /> {line.patron.name}
-          </Link>
+          {patronPid > 0 ? (
+            <Link to={BackOfficeRoutes.patronDetailsFor(patronPid)}>
+              <PatronIcon /> {patronName}
+            </Link>
+          ) : (
+            <>{patronName}</>
+          )}
         </Item.Description>
       )}
       <Item.Description>

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderSearch/OrderList/OrderListEntry.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderSearch/OrderList/OrderListEntry.js
@@ -63,9 +63,13 @@ export default class OrderListEntry extends Component {
           <>
             {' '}
             - Patron{' '}
-            <Link to={BackOfficeRoutes.patronDetailsFor(patronPid)}>
-              <code>{patronPid}</code>
-            </Link>
+            {patronPid > 0 ? (
+              <Link to={BackOfficeRoutes.patronDetailsFor(patronPid)}>
+                <code>{patronPid}</code>
+              </Link>
+            ) : (
+              <>anonymous</>
+            )}
           </>
         )}{' '}
         - <em>{totalPrice}</em>

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestHeader.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestDetails/DocumentRequestHeader.js
@@ -40,9 +40,13 @@ export class DocumentRequestHeader extends Component {
     return (
       <>
         by{' '}
-        <Link to={BackOfficeRoutes.patronDetailsFor(patron.id)}>
-          {patron.name}
-        </Link>
+        {patron.id > 0 ? (
+          <Link to={BackOfficeRoutes.patronDetailsFor(patron.id)}>
+            {patron.name}
+          </Link>
+        ) : (
+          <>{patron.name}</>
+        )}
       </>
     );
   }

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestSearch/DocumentRequestListEntry.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestSearch/DocumentRequestListEntry.js
@@ -9,7 +9,8 @@ import { Grid, Header, Item, List } from 'semantic-ui-react';
 export class DocumentRequestListEntry extends Component {
   render() {
     const { record: documentRequest } = this.props;
-
+    const patronPid = documentRequest.metadata.patron_pid;
+    const patronName = documentRequest.metadata.patron.name;
     return (
       <Item>
         <Item.Content>
@@ -26,13 +27,13 @@ export class DocumentRequestListEntry extends Component {
           <Grid columns={3}>
             <Grid.Column computer={7} largeScreen={7}>
               <label>Patron</label>{' '}
-              <Link
-                to={BackOfficeRoutes.patronDetailsFor(
-                  documentRequest.metadata.patron_pid
-                )}
-              >
-                {documentRequest.metadata.patron.name}
-              </Link>{' '}
+              {patronPid > 0 ? (
+                <Link to={BackOfficeRoutes.patronDetailsFor(patronPid)}>
+                  {patronName}
+                </Link>
+              ) : (
+                patronName
+              )}{' '}
               requested:
               <Item.Meta className="document-authors">
                 <Header className="list-entry-title" as="h5">

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestMetadata.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestMetadata.js
@@ -89,6 +89,9 @@ class Metadata extends React.Component {
         ),
       },
     ];
+    if (brwReq.patron_pid > 0) {
+      leftTable[1].value = <>{brwReq.patron.name}</>;
+    }
     const rightTable = [
       { name: 'Created by', value: <CreatedBy metadata={brwReq} /> },
       { name: 'Updated by', value: <UpdatedBy metadata={brwReq} /> },

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestSearch/BorrowingRequestList/BorrowingRequestListEntry.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestSearch/BorrowingRequestList/BorrowingRequestListEntry.js
@@ -56,11 +56,15 @@ export default class BorrowingRequestListEntry extends Component {
     const patronCmp = (
       <>
         Patron{' '}
-        <Link to={BackOfficeRoutes.patronDetailsFor(patronPid)}>
-          <code>
-            {patron.name} ({patronPid})
-          </code>
-        </Link>
+        {patronPid > 0 ? (
+          <Link to={BackOfficeRoutes.patronDetailsFor(patronPid)}>
+            <code>
+              {patron.name} ({patronPid})
+            </code>
+          </Link>
+        ) : (
+          <code>{patron.name}</code>
+        )}
       </>
     );
 

--- a/src/lib/pages/backoffice/Loan/LoanDetails/Loan/Loan.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/Loan/Loan.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import { Divider, Header, Segment } from 'semantic-ui-react';
-import { LoanActions } from '../LoanActions';
+import { Header, Segment } from 'semantic-ui-react';
 import { LoanMetadata } from '../LoanMetadata';
 
 export default class Loan extends Component {
@@ -12,10 +11,6 @@ export default class Loan extends Component {
         </Header>
         <Segment attached className="bo-metadata-segment" id="loan-metadata">
           <LoanMetadata />
-          <Divider horizontal>Manage loan</Divider>
-          <div className="pb-default">
-            <LoanActions />
-          </div>
         </Segment>
       </>
     );

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActionMenu/LoanActionMenu.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActionMenu/LoanActionMenu.js
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Divider, Message } from 'semantic-ui-react';
 import { LoanUpdateDates } from '@pages/backoffice/Loan/LoanDetails/LoanUpdateDates';
+import { LoanActions } from '@pages/backoffice/Loan/LoanDetails/LoanActions';
 
 export default class LoanActionMenu extends Component {
   render() {
@@ -22,6 +23,10 @@ export default class LoanActionMenu extends Component {
             dates by clicking on the button above.
           </p>
         </Message>
+        <Divider horizontal>Actions</Divider>
+        <div className="pb-default">
+          <LoanActions />
+        </div>
         <Divider horizontal>Navigation</Divider>
         <ScrollingMenu offset={offset}>
           <ScrollingMenuItem label="Loan" elementId="loan-metadata" />

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
@@ -2,10 +2,11 @@ import { OverdueLoanSendMailModal } from '@modules/Loan/backoffice/OverdueLoanSe
 import { InfoMessage } from '@components/backoffice/InfoMessage';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { List, Button, Grid } from 'semantic-ui-react';
+import { List, Button } from 'semantic-ui-react';
 import { omit } from 'lodash/object';
 import { CancelModal } from '@components/CancelModal';
 import _isEmpty from 'lodash/isEmpty';
+import capitalize from 'lodash/capitalize';
 
 export default class LoanActions extends Component {
   renderAvailableActions(pid, patronPid, documentPid, itemPid, actions = {}) {
@@ -31,18 +32,20 @@ export default class LoanActions extends Component {
               content={`You are about to cancel loan #${pid}.
                 Please enter a reason for cancelling this loan.`}
               cancelText="Cancel Loan"
-              buttonText="cancel"
+              buttonText={capitalize('cancel')}
               action={cancelAction}
               isLoading={isLoading}
             />
           ) : (
             <Button
+              size="small"
+              fluid
               primary
               onClick={loanAction}
               loading={isLoading}
               disabled={isLoading}
             >
-              {action}
+              {capitalize(action)}
             </Button>
           )}
         </List.Item>
@@ -56,7 +59,7 @@ export default class LoanActions extends Component {
     const { document_pid, item_pid, patron_pid } = loanDetails.metadata;
 
     const loanActions = !_isEmpty(availableActions) && (
-      <List horizontal>
+      <List>
         {this.renderAvailableActions(
           pid,
           patron_pid,
@@ -67,19 +70,14 @@ export default class LoanActions extends Component {
       </List>
     );
     const sendReminderButton = loanDetails.metadata.is_overdue && (
-      <OverdueLoanSendMailModal
-        loan={loanDetails}
-        buttonTriggerText="Send return reminder"
-      />
+      <OverdueLoanSendMailModal loan={loanDetails} />
     );
     if (!_isEmpty(availableActions) || loanDetails.metadata.is_overdue) {
       return (
-        <Grid columns={2}>
-          <Grid.Column width={12}>{loanActions}</Grid.Column>
-          <Grid.Column width={4} textAlign="right">
-            {sendReminderButton}
-          </Grid.Column>
-        </Grid>
+        <>
+          {loanActions}
+          {sendReminderButton}
+        </>
       );
     } else {
       return (

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanMetadata/LoanMetadata.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanMetadata/LoanMetadata.js
@@ -136,7 +136,10 @@ export class LoanMetadata extends Component {
         }
       );
     }
-    rows.push({ name: 'Extensions', value: data.metadata.extension_count });
+    rows.push({
+      name: 'Extensions',
+      value: data.metadata.extension_count || 0,
+    });
     if (state === 'CANCELLED' && !_isEmpty(reason)) {
       rows.push({
         name: 'Cancel Reason',
@@ -165,6 +168,11 @@ export class LoanMetadata extends Component {
 
 LoanMetadata.propTypes = {
   loanDetails: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      loanPid: PropTypes.string,
+    }),
+  }).isRequired,
 };
 
 export default Overridable.component('LoanMetadata', LoanMetadata);

--- a/src/semantic-ui/site/elements/button.overrides
+++ b/src/semantic-ui/site/elements/button.overrides
@@ -55,8 +55,20 @@ Button Overrides - REACT-INVENIO-APP-ILS
   }
 
   .ui.button {
-    &.send-overdue-reminder-button {
+    .label.send-overdue-reminder-button {
+      color: @orange;
+      border-color: @orange;
+      padding: 9.889px 10px;
+    }
+    .icon.send-overdue-reminder-button {
+      margin-left: 0.5em !important;
+    }
+    &.send-overdue-reminder-middle-button {
       background-color: @orange;
+      color: @white;
+    }
+    .icon.button.send-overdue-reminder-middle-button {
+      padding-left: 4em !important;
     }
   }
 }


### PR DESCRIPTION
Closes inveniosoftware/invenio-app-ils#523

- move actions in loan details to side
- make anonymous user unclickable (not in places where user with ongoing loans is displayed)
- in frontsite allow document cards to be opened in a new tab
- remove `send reminder` button from overview and loan search page
- add loading to `send reminder` button

Depends on inveniosoftware/invenio-app-ils#1037

Button:
<img width="521" alt="Screenshot 2021-03-03 at 10 54 15" src="https://user-images.githubusercontent.com/33685068/109787782-e0553900-7c0e-11eb-8c4e-b53d5360f4a6.png">

Popup:
<img width="521" alt="Screenshot 2021-03-03 at 10 54 19" src="https://user-images.githubusercontent.com/33685068/109787793-e21efc80-7c0e-11eb-9c10-d6e1c124bdeb.png">


Loading:
<img width="521" alt="Screenshot 2021-03-03 at 10 54 27" src="https://user-images.githubusercontent.com/33685068/109787801-e4815680-7c0e-11eb-9a21-a7257062aeb5.png">

