### PR TITLE
multipartRelations: display volume

### DIFF
--- a/src/lib/modules/Document/DocumentCard/DocumentCard.js
+++ b/src/lib/modules/Document/DocumentCard/DocumentCard.js
@@ -46,6 +46,9 @@ class DocumentCard extends Component {
     if (data.metadata.other_authors) {
       authors = authors + 'et al';
     }
+
+    const volume = _get(metadata, 'relations.multipart_monograph[0].volume');
+
     return (
       <Overridable id="DocumentCard.layout" {...this.props}>
         <Card
@@ -75,6 +78,7 @@ class DocumentCard extends Component {
               <div>
                 {metadata.publication_year}
                 {metadata.edition && <> - Edition {metadata.edition}</>}
+                {volume && <> - Vol. {volume}</>}
               </div>
             </Card.Meta>
           </Card.Content>

--- a/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.js
+++ b/src/lib/modules/Document/DocumentListEntry/DocumentListEntry.js
@@ -11,8 +11,8 @@ import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Grid, Item, Label, List } from 'semantic-ui-react';
 import Overridable from 'react-overridable';
+import { Grid, Item, List } from 'semantic-ui-react';
 
 class DocumentListEntry extends Component {
   constructor(props) {
@@ -49,26 +49,32 @@ class DocumentListEntry extends Component {
   renderImprintInfo = () => {
     if (!_isEmpty(this.metadata.imprint)) {
       return (
-        <Grid.Column width={4}>
-          <List>
-            <List.Item>
-              <List.Content>
-                <span>Published by </span>
-                {this.metadata.imprint.publisher}
-              </List.Content>
-            </List.Item>
-            <List.Item>
-              {this.metadata.imprint.place}, {this.metadata.imprint.date}
-            </List.Item>
-          </List>
-        </Grid.Column>
+        <List>
+          <List.Item>
+            <List.Content>
+              <span>Published by </span>
+              {this.metadata.imprint.publisher}
+            </List.Content>
+          </List.Item>
+          <List.Item>
+            {this.metadata.imprint.place}, {this.metadata.imprint.date}
+          </List.Item>
+        </List>
       );
     }
     return null;
   };
 
+  renderVolume = () => {
+    const volume = _get(
+      this,
+      'metadata.relations.multipart_monograph[0].volume'
+    );
+
+    return volume ? <>Volume: {volume}</> : null;
+  };
+
   renderImage = () => {
-    const { volume } = this.props;
     const image = (
       <Item.Image
         floated="left"
@@ -82,18 +88,6 @@ class DocumentListEntry extends Component {
         />
       </Item.Image>
     );
-
-    if (volume) {
-      return (
-        <div className="search-result-image">
-          <Label floating color="black">
-            Volume {volume}
-          </Label>
-          {image}
-        </div>
-      );
-    }
-
     return image;
   };
 
@@ -125,12 +119,12 @@ class DocumentListEntry extends Component {
             <Truncate lines={2}>{this.metadata.abstract}</Truncate>
           </Item.Description>
           <Item.Meta>
-            <Grid>
-              <Grid.Column width={4}>
+            <Grid columns="equal">
+              <Grid.Column>
                 {this.renderCirculationInfo(this.metadata)}
               </Grid.Column>
-              {this.renderImprintInfo()}
-              <Grid.Column width={4}>
+              <Grid.Column>{this.renderImprintInfo()}</Grid.Column>
+              <Grid.Column>
                 <List>
                   {this.metadata.edition && (
                     <List.Item>
@@ -152,6 +146,7 @@ class DocumentListEntry extends Component {
                   )}
                 </List>
               </Grid.Column>
+              <Grid.Column>{this.renderVolume()}</Grid.Column>
             </Grid>
           </Item.Meta>
           <Item.Extra>
@@ -165,11 +160,6 @@ class DocumentListEntry extends Component {
 
 DocumentListEntry.propTypes = {
   metadata: PropTypes.object.isRequired,
-  volume: PropTypes.string,
-};
-
-DocumentListEntry.defaultProps = {
-  volume: null,
 };
 
 export default Overridable.component('DocumentListEntry', DocumentListEntry);

--- a/src/lib/modules/Document/DocumentListEntry/__snapshots__/DocumentListEntry.test.js.snap
+++ b/src/lib/modules/Document/DocumentListEntry/__snapshots__/DocumentListEntry.test.js.snap
@@ -32,6 +32,5 @@ exports[`should render correctly 1`] = `
       "title": "The Gulf: The Making of An American Sea",
     }
   }
-  volume={null}
 />
 `;

--- a/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
+++ b/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
@@ -45,6 +45,11 @@ export default class DocumentListEntry extends Component {
       .map((rel) => `pid:${rel.pid_value}`)
       .join(' OR ');
 
+    const volume = _get(
+      document,
+      'metadata.relations.multipart_monograph[0].volume'
+    );
+
     return (
       <Item.Description>
         <List verticalAlign="middle" className="document-relations">
@@ -53,6 +58,7 @@ export default class DocumentListEntry extends Component {
               <List.Content floated="right">
                 <Link to={BackOfficeRoutes.seriesListWithQuery(partOfMMQuery)}>
                   <Icon name="paperclip" />
+                  {volume && <>vol. {volume}</>}
                 </Link>
               </List.Content>
               <List.Content>Part of multipart monograph</List.Content>

--- a/src/lib/modules/Literature/LiteratureTitle.js
+++ b/src/lib/modules/Literature/LiteratureTitle.js
@@ -4,17 +4,19 @@ import React, { Component } from 'react';
 import Overridable from 'react-overridable';
 import LiteratureEdition from './LiteratureEdition';
 
-class EditionYear extends Component {
+class EditionYearVolume extends Component {
   render() {
-    const { edition, publicationYear } = this.props;
+    const { edition, publicationYear, volume } = this.props;
+    let displayedElements = [];
+    if (publicationYear) {
+      displayedElements.push(publicationYear);
+    }
+    if (volume) {
+      displayedElements.push('vol. ' + volume);
+    }
+    displayedElements = displayedElements.join(' - ');
 
-    /* render both edition and year, or only edition, or only year or nothing
-     * title (edition - year)
-     * title (edition)
-     * title (year)
-     * title
-     */
-    return edition && publicationYear ? (
+    return edition && displayedElements ? (
       <>
         (<LiteratureEdition edition={edition} /> - {publicationYear})
       </>
@@ -22,20 +24,22 @@ class EditionYear extends Component {
       <>
         (<LiteratureEdition edition={edition} />)
       </>
-    ) : publicationYear ? (
-      `(${publicationYear})`
+    ) : displayedElements ? (
+      `(${displayedElements})`
     ) : null;
   }
 }
 
-EditionYear.propTypes = {
+EditionYearVolume.propTypes = {
   edition: PropTypes.string,
   publicationYear: PropTypes.string,
+  volume: PropTypes.string,
 };
 
-EditionYear.defaultProps = {
+EditionYearVolume.defaultProps = {
   edition: null,
   publicationYear: null,
+  volume: null,
 };
 
 class LiteratureTitle extends Component {
@@ -44,6 +48,7 @@ class LiteratureTitle extends Component {
       title,
       edition,
       publicationYear,
+      volume,
       truncate,
       truncateLines,
       truncateWidth,
@@ -51,8 +56,12 @@ class LiteratureTitle extends Component {
     const cmp = (
       <>
         {title}{' '}
-        {(edition || publicationYear) && (
-          <EditionYear edition={edition} publicationYear={publicationYear} />
+        {(edition || publicationYear || volume) && (
+          <EditionYearVolume
+            edition={edition}
+            publicationYear={publicationYear}
+            volume={volume}
+          />
         )}
       </>
     );
@@ -71,6 +80,7 @@ LiteratureTitle.propTypes = {
   title: PropTypes.string.isRequired,
   edition: PropTypes.string,
   publicationYear: PropTypes.string,
+  volume: PropTypes.string,
   truncate: PropTypes.bool,
   truncateLines: PropTypes.number,
   truncateWidth: PropTypes.string,
@@ -80,6 +90,7 @@ LiteratureTitle.defaultProps = {
   edition: null,
   publicationYear: null,
   truncate: true,
+  volume: null,
   truncateLines: 2,
   truncateWidth: null,
 };

--- a/src/lib/modules/Series/__snapshots__/SeriesCard.test.js.snap
+++ b/src/lib/modules/Series/__snapshots__/SeriesCard.test.js.snap
@@ -99,6 +99,7 @@ exports[`SeriesCard tests should go to book details when clicking on a book 1`] 
                   truncate={true}
                   truncateLines={2}
                   truncateWidth={null}
+                  volume={null}
                 >
                   <Truncate
                     lines={2}
@@ -265,6 +266,7 @@ exports[`SeriesCard tests should render the SeriesCard 1`] = `
                   truncate={true}
                   truncateLines={2}
                   truncateWidth={null}
+                  volume={null}
                 >
                   <Truncate
                     lines={2}

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentHeader.js
@@ -45,6 +45,10 @@ export class DocumentHeader extends Component {
         </Label>
       </>
     );
+    const volume = _get(
+      data,
+      'metadata.relations.multipart_monograph[0].volume'
+    );
     return (
       <DetailsHeader
         title={
@@ -54,6 +58,7 @@ export class DocumentHeader extends Component {
               title={data.metadata.title}
               edition={data.metadata.edition}
               publicationYear={data.metadata.publication_year}
+              volume={volume}
               truncate={false}
             />
           </>

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentRelations/RelationMultipartMonograph/RelationMultipartModal/RelationMultipartModal.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentRelations/RelationMultipartMonograph/RelationMultipartModal/RelationMultipartModal.js
@@ -71,7 +71,6 @@ export default class RelationMultipartModal extends Component {
                 <label>Volume index</label>
                 <Input
                   name="volume"
-                  type="number"
                   onChange={(e, { value }) => this.setState({ volume: value })}
                 />
               </Form.Field>

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActionMenu/LoanActionMenu.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActionMenu/LoanActionMenu.js
@@ -12,7 +12,7 @@ export default class LoanActionMenu extends Component {
   render() {
     const { loan, offset } = this.props;
     return (
-      <div className="bo-action-menu">
+      <div>
         <LoanUpdateDates loan={loan} />
 
         <Message size="small">

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
@@ -771,6 +771,7 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -790,9 +791,10 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -808,7 +810,7 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>
@@ -1003,6 +1005,7 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -1022,9 +1025,10 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -1040,7 +1044,7 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>
@@ -2014,6 +2018,7 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -2033,9 +2038,10 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -2051,7 +2057,7 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentLoans/__snapshots__/PatronCurrentLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentLoans/__snapshots__/PatronCurrentLoans.test.js.snap
@@ -641,6 +641,7 @@ exports[`PatronCurrentLoans tests should render patron loans 1`] = `
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -660,12 +661,13 @@ exports[`PatronCurrentLoans tests should render patron loans 1`] = `
                                               >
                                                 Less: A Novel
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition={null}
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (1950)
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>
@@ -824,6 +826,7 @@ exports[`PatronCurrentLoans tests should render patron loans 1`] = `
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -843,12 +846,13 @@ exports[`PatronCurrentLoans tests should render patron loans 1`] = `
                                               >
                                                 Less: A Novel
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition={null}
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (1950)
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>
@@ -1642,6 +1646,7 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -1661,12 +1666,13 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                                               >
                                                 Less: A Novel
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition={null}
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (1950)
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
@@ -778,6 +778,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -797,9 +798,10 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -815,7 +817,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>
@@ -1002,6 +1004,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -1021,9 +1024,10 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -1039,7 +1043,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>
@@ -2001,6 +2005,7 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -2020,9 +2025,10 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -2038,7 +2044,7 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
@@ -673,6 +673,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -692,9 +693,10 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -710,7 +712,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>
@@ -828,6 +830,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -847,9 +850,10 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -865,7 +869,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>
@@ -1657,6 +1661,7 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                                             truncate={true}
                                             truncateLines={2}
                                             truncateWidth={null}
+                                            volume={null}
                                           >
                                             <Truncate
                                               lines={2}
@@ -1676,9 +1681,10 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                                               >
                                                 The Gulf: The Making of An American Sea
                                                  
-                                                <EditionYear
+                                                <EditionYearVolume
                                                   edition="1"
                                                   publicationYear="1950"
+                                                  volume={null}
                                                 >
                                                   (
                                                   <Overridable(LiteratureEdition)
@@ -1694,7 +1700,7 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                                                    - 
                                                   1950
                                                   )
-                                                </EditionYear>
+                                                </EditionYearVolume>
                                               </span>
                                             </Truncate>
                                           </LiteratureTitle>


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/react-invenio-app-ils/issues/420

- fixes `send overdue reminder` button

## Screenshots

### Frontsite

Literature search card view
<img width="271" alt="Screenshot 2021-03-24 at 15 55 04" src="https://user-images.githubusercontent.com/33685068/112342041-370bdb00-8cc2-11eb-9df0-aa22f1e430ac.png">

Literature search list view
<img width="1379" alt="Screenshot 2021-03-24 at 15 48 57" src="https://user-images.githubusercontent.com/33685068/112342064-3bd08f00-8cc2-11eb-86ff-79b990eb1499.png">

Document details page frontsite (has been already implemented)
<img width="671" alt="Screenshot 2021-03-24 at 15 15 39" src="https://user-images.githubusercontent.com/33685068/112342094-41c67000-8cc2-11eb-8e78-49f3e11d6bbf.png">

Series details page frontsite 
<img width="400" alt="Screenshot 2021-03-24 at 17 11 19" src="https://user-images.githubusercontent.com/33685068/112344043-ff9e2e00-8cc3-11eb-85bc-8291ef0ccc3e.png">


### Backoffice

Document search backoffice
<img width="1045" alt="Screenshot 2021-03-24 at 15 14 06" src="https://user-images.githubusercontent.com/33685068/112342127-4559f700-8cc2-11eb-8982-05a7a26b1586.png">

Document details page backoffice
<img width="1189" alt="Screenshot 2021-03-24 at 17 06 02" src="https://user-images.githubusercontent.com/33685068/112343258-3e7fb400-8cc3-11eb-8471-e0dbf2df0e7e.png">

Series details page backoffice (has been already implemented)
<img width="1068" alt="Screenshot 2021-03-24 at 15 20 32" src="https://user-images.githubusercontent.com/33685068/112342076-3ecb7f80-8cc2-11eb-8a57-4bc5774071f1.png">


