### PR TITLE
[BLOCKED]series: add facets and display series type

### DIFF
--- a/src/lib/api/series/series.js
+++ b/src/lib/api/series/series.js
@@ -54,6 +54,7 @@ class QueryBuilder {
     this.withSeriesQuery = [];
     this.withStringQuery = [];
     this.withExcludeQuery = [];
+    this.withSeriesTypeQuery = [];
   }
 
   withModeOfIssuance(moi) {
@@ -87,6 +88,14 @@ class QueryBuilder {
     return this;
   }
 
+  withSeriesType(seriesType) {
+    if (!seriesType) {
+      throw TypeError('seriesType argument missing');
+    }
+    this.withSeriesTypeQuery.push(`series_type:"${seriesType}"`);
+    return this;
+  }
+
   exclude(series) {
     if (!series) {
       throw TypeError('series argument missing');
@@ -108,7 +117,12 @@ class QueryBuilder {
 
   qs() {
     return this.withModeOfIssuanceQuery
-      .concat(this.withSeriesQuery, this.withStringQuery, this.withExcludeQuery)
+      .concat(
+        this.withSeriesQuery,
+        this.withStringQuery,
+        this.withExcludeQuery,
+        this.withSeriesTypeQuery
+      )
       .join(' AND ');
   }
 }

--- a/src/lib/api/series/series.test.js
+++ b/src/lib/api/series/series.test.js
@@ -8,4 +8,9 @@ describe('Series query builder tests', () => {
       .qs();
     expect(query).toEqual('mode_of_issuance:MULTIPART_MONOGRAPH');
   });
+
+  it('should build the query string for series of a type', () => {
+    const query = seriesApi.query().withSeriesType('SERIAL').qs();
+    expect(query).toEqual('series_type:"SERIAL"');
+  });
 });

--- a/src/lib/config/common.js
+++ b/src/lib/config/common.js
@@ -52,3 +52,8 @@ export const DOCUMENT_TYPES = [
   },
   { value: 'ARTICLE', text: 'Article', label: 'Article' },
 ];
+
+export const SERIES_TYPES = [
+  { value: 'SERIAL', text: 'Serial', label: 'Serial' },
+  { value: 'PERIODICAL', text: 'Periodical', label: 'Periodical' },
+];

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -4,6 +4,7 @@ import {
   DEFAULT_LANGUAGE,
   DOCUMENT_RELATIONS,
   DOCUMENT_TYPES,
+  SERIES_TYPES,
   ILL_BORROWING_REQUESTS_STATUSES,
   ITEM_MEDIUMS,
 } from './common';
@@ -234,11 +235,6 @@ export const RECORDS_CONFIG = {
           aggName: 'tag',
         },
         {
-          title: 'Languages',
-          field: 'languages',
-          aggName: 'language',
-        },
-        {
           title: 'Related content',
           field: 'relations',
           aggName: 'relation',
@@ -253,6 +249,11 @@ export const RECORDS_CONFIG = {
           title: 'Restricted',
           field: 'restricted',
           aggName: 'access',
+        },
+        {
+          title: 'Languages',
+          field: 'languages',
+          aggName: 'language',
         },
       ],
       sort: [
@@ -583,7 +584,7 @@ export const RECORDS_CONFIG = {
           title: 'Literature types',
           field: 'document_type',
           aggName: 'doctype',
-          labels: DOCUMENT_TYPES,
+          labels: DOCUMENT_TYPES + SERIES_TYPES,
         },
         {
           title: 'Availability',
@@ -596,14 +597,14 @@ export const RECORDS_CONFIG = {
           aggName: 'tag',
         },
         {
-          title: 'Languages',
-          field: 'languages',
-          aggName: 'language',
-        },
-        {
           title: 'Medium',
           field: 'stock.mediums',
           aggName: 'medium',
+        },
+        {
+          title: 'Languages',
+          field: 'languages',
+          aggName: 'language',
         },
       ],
       sort: [
@@ -763,23 +764,30 @@ export const RECORDS_CONFIG = {
       label: 'Other',
       fields: {},
     },
+    types: SERIES_TYPES,
     search: {
       filters: [
+        {
+          title: 'Series types',
+          field: 'series_type',
+          aggName: 'sertype',
+          labels: SERIES_TYPES,
+        },
         {
           title: 'Mode of Issuance',
           field: 'mode_of_issuance',
           aggName: 'moi',
         },
         {
-          title: 'Languages',
-          field: 'languages',
-          aggName: 'language',
-        },
-        {
           title: 'Related content',
           field: 'relations',
           aggName: 'relation',
           labels: DOCUMENT_RELATIONS,
+        },
+        {
+          title: 'Languages',
+          field: 'languages',
+          aggName: 'language',
         },
       ],
       sort: [

--- a/src/lib/modules/Literature/LiteratureRelations.js
+++ b/src/lib/modules/Literature/LiteratureRelations.js
@@ -79,7 +79,8 @@ export default class LiteratureRelations extends Component {
       <Link key={rel.pid_value} to={this.getLinkTo(rel)}>
         {rel.record_metadata.languages
           ? rel.record_metadata.languages.join(' ')
-          : rel.record_metadata.mode_of_issuance}
+          : rel.record_metadata.series_type ||
+            rel.record_metadata.mode_of_issuance}
       </Link>
     ));
 

--- a/src/lib/modules/Relations/backoffice/components/RelationCard/SeriesCard.js
+++ b/src/lib/modules/Relations/backoffice/components/RelationCard/SeriesCard.js
@@ -16,7 +16,7 @@ export default class SeriesCard extends Component {
       <Card centered className="bo-relation-card" data-test={data.metadata.pid}>
         <Card.Meta className="discrete">
           {actions}
-          {data.metadata.document_type || data.metadata.mode_of_issuance}
+          {data.metadata.series_type || data.metadata.mode_of_issuance}
         </Card.Meta>
         <SeriesIcon size="huge" color="grey" />
         <Card.Content>

--- a/src/lib/modules/Relations/backoffice/components/RelationListEntry.js
+++ b/src/lib/modules/Relations/backoffice/components/RelationListEntry.js
@@ -38,7 +38,9 @@ export class RelationListEntry extends Component {
         <div className="item-image-wrapper">
           {cover}
           <div className="document-type discrete tiny ellipsis">
-            {record.metadata.document_type || record.metadata.mode_of_issuance}
+            {record.metadata.document_type ||
+              record.metadata.series_type ||
+              record.metadata.mode_of_issuance}
           </div>
         </div>
         <Item.Content>

--- a/src/lib/modules/Series/SeriesInfo.js
+++ b/src/lib/modules/Series/SeriesInfo.js
@@ -30,6 +30,12 @@ export const SeriesInfo = ({ metadata }) => {
               />
             </Table.Cell>
           </Table.Row>
+          {metadata.series_type && (
+            <Table.Row>
+              <Table.Cell>Type</Table.Cell>
+              <Table.Cell>{metadata.series_type}</Table.Cell>
+            </Table.Row>
+          )}
           {metadata.publisher && (
             <Table.Row>
               <Table.Cell>Publisher</Table.Cell>

--- a/src/lib/modules/Series/SeriesTitle.js
+++ b/src/lib/modules/Series/SeriesTitle.js
@@ -7,13 +7,13 @@ import { Header } from 'semantic-ui-react';
 export const SeriesTitle = ({
   title,
   subtitle,
-  modeOfIssuance,
+  TypeOrModeOfIssuance,
   truncate,
   truncateLines,
   truncateWidth,
 }) => (
   <>
-    {modeOfIssuance.toUpperCase()}
+    {TypeOrModeOfIssuance.toUpperCase()}
     <Header as="h2" className="document-title">
       {truncate ? (
         <Truncate lines={truncateLines} width={truncateWidth}>
@@ -30,7 +30,7 @@ export const SeriesTitle = ({
 SeriesTitle.propTypes = {
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string,
-  modeOfIssuance: PropTypes.string.isRequired,
+  TypeOrModeOfIssuance: PropTypes.string.isRequired,
   truncate: PropTypes.bool,
   truncateLines: PropTypes.number,
   truncateWidth: PropTypes.number,

--- a/src/lib/modules/Series/backoffice/SeriesSelectListEntry.js
+++ b/src/lib/modules/Series/backoffice/SeriesSelectListEntry.js
@@ -10,7 +10,8 @@ export default class SeriesSelectListEntry extends Component {
         className={disabled ? 'select-disabled' : ''}
       >
         <div className="price">
-          {series.metadata.mode_of_issuance} #{series.metadata.pid}
+          {series.metadata.series_type || series.metadata.mode_of_issuance} #
+          {series.metadata.pid}
         </div>
         <div className="title">{series.metadata.title}</div>
         <div className="description">{description}</div>

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesHeader.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesHeader.js
@@ -47,7 +47,7 @@ export class SeriesHeader extends Component {
         title={
           <>
             <Header.Subheader>
-              {data.metadata.mode_of_issuance}
+              {data.metadata.series_type || data.metadata.mode_of_issuance}
             </Header.Subheader>
             <LiteratureTitle
               title={data.metadata.title}

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesMetadata/SeriesMetadata.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesMetadata/SeriesMetadata.js
@@ -19,6 +19,10 @@ export default class SeriesMetadata extends Component {
         value: seriesDetails.metadata.mode_of_issuance,
       },
       {
+        name: 'Type',
+        value: seriesDetails.metadata.series_type,
+      },
+      {
         name: 'Languages',
         value: <SeriesLanguages languages={seriesDetails.metadata.languages} />,
       },

--- a/src/lib/pages/backoffice/Series/SeriesEditor/schema.js
+++ b/src/lib/pages/backoffice/Series/SeriesEditor/schema.js
@@ -188,6 +188,15 @@ export const schema = () => {
         title: 'Physical volumes',
         type: 'array',
       },
+      series_type: {
+        enum: ['', ...invenioConfig.SERIES.types.map((status) => status.value)],
+        enumNames: [
+          'None',
+          ...invenioConfig.SERIES.types.map((status) => status.text),
+        ],
+        title: 'Series type',
+        type: 'string',
+      },
       tags: {
         items: {
           title: 'Tag name',

--- a/src/lib/pages/backoffice/Series/SeriesEditor/uiSchema.js
+++ b/src/lib/pages/backoffice/Series/SeriesEditor/uiSchema.js
@@ -196,9 +196,10 @@ export const uiSchema = (title) => {
         alternative_titles: 8,
       },
       {
-        mode_of_issuance: 6,
+        mode_of_issuance: 4,
+        series_type: 4,
         edition: 3,
-        languages: 7,
+        languages: 5,
       },
       {
         abstract: 16,

--- a/src/lib/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
+++ b/src/lib/pages/backoffice/Series/SeriesSearch/SeriesListEntry.js
@@ -101,7 +101,7 @@ export class SeriesListEntry extends Component {
         {this.renderImage(series.metadata)}
         <Item.Content>
           <Header disabled size="tiny" className="document-type">
-            {series.metadata.mode_of_issuance}
+            {series.metadata.series_type || series.metadata.mode_of_issuance}
           </Header>
           <br />
           <Item.Header

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesPanel/SeriesPanel.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesPanel/SeriesPanel.js
@@ -48,7 +48,10 @@ class SeriesPanel extends Component {
                                 .find(() => true)
                             : null
                         }
-                        modeOfIssuance={series.metadata.mode_of_issuance}
+                        TypeOrModeOfIssuance={
+                          series.metadata.series_type ||
+                          series.metadata.mode_of_issuance
+                        }
                         truncate={false}
                       />
                     )}

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesPanel/SeriesPanelMobile.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesPanel/SeriesPanelMobile.js
@@ -32,7 +32,10 @@ class SeriesPanelMobile extends Component {
               <ILSHeaderPlaceholder isLoading={isLoading} center="true">
                 <SeriesTitle
                   title={series.metadata.title}
-                  modeOfIssuance={series.metadata.mode_of_issuance}
+                  TypeOrModeOfIssuance={
+                    series.metadata.series_type ||
+                    series.metadata.mode_of_issuance
+                  }
                   truncate={false}
                 />
               </ILSHeaderPlaceholder>


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-ils/issues/1073
Depends on https://github.com/inveniosoftware/invenio-app-ils/pull/1075

- Moved language facets to the bottom

### Series form:
<img width="1082" alt="Screenshot 2021-03-31 at 15 22 55" src="https://user-images.githubusercontent.com/33685068/113167559-1dc7d900-9244-11eb-9015-41bf4049cc79.png">

### Literature facet (frontsite)
<img width="335" alt="Screenshot 2021-04-01 at 09 35 29" src="https://user-images.githubusercontent.com/33685068/113259787-d1c17680-92cd-11eb-819c-3e32dc9093aa.png">

### Series facet (backoffice)
<img width="302" alt="Screenshot 2021-04-01 at 10 19 13" src="https://user-images.githubusercontent.com/33685068/113264875-c4a78600-92d3-11eb-8a1a-c811443f76b7.png">

