### PR TITLE
Document: add details to search and details view

### DIFF
--- a/src/lib/modules/Document/DocumentCard/DocumentCard.js
+++ b/src/lib/modules/Document/DocumentCard/DocumentCard.js
@@ -75,6 +75,7 @@ class DocumentCard extends Component {
                 {metadata.publication_year}
                 {metadata.edition && <> - Edition {metadata.edition}</>}
                 {volume && <> - Vol. {volume}</>}
+                {metadata.imprint?.publisher && <> <br></br> {metadata.imprint.publisher}</>}
               </div>
             </Card.Meta>
           </Card.Content>

--- a/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
+++ b/src/lib/modules/Document/backoffice/DocumentList/DocumentListEntry.js
@@ -138,7 +138,13 @@ export default class DocumentListEntry extends Component {
                   />
                 )}
               </Item.Description>
-              <label>Published</label> {document.metadata.publication_year}
+              <Item.Description>
+                <label>Publication year</label> {document.metadata.publication_year}
+              </Item.Description>
+              <Item.Description>
+                {document.metadata.imprint?.publisher
+                  && <><label> Publisher </label>{document.metadata.imprint.publisher}</>}
+              </Item.Description>
             </Grid.Column>
             <Grid.Column computer={3} largeScreen={4}>
               {this.renderMiddleColumn(document)}

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanel.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanel.js
@@ -51,7 +51,7 @@ class DocumentPanel extends Component {
                     </Overridable>
 
                     <ILSParagraphPlaceholder
-                      linesNumber={1}
+                      linesNumber={2}
                       isLoading={isLoading}
                     >
                       <DocumentAuthors
@@ -65,12 +65,19 @@ class DocumentPanel extends Component {
                         id="DocumentPanel.AfterAuthors"
                         metadata={doc.metadata}
                       />
+                      {doc.metadata.imprint?.publisher
+                        &&
+                      <><div
+                        className={`default-margin-bottom`}>
+                        Published by <b>{doc.metadata.imprint?.publisher}</b>
+                        {doc.metadata.publication_year && (<b>{doc.metadata.publication_year}</b>)}
+                      </div></>}
                     </ILSParagraphPlaceholder>
                     <ILSParagraphPlaceholder
-                      linesNumber={20}
+                      linesNumber={15}
                       isLoading={isLoading}
                     >
-                      <ShowMoreContent lines={20}>
+                      <ShowMoreContent lines={15}>
                         {doc.metadata.abstract}
                       </ShowMoreContent>
                     </ILSParagraphPlaceholder>

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanelMobile.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentPanelMobile.js
@@ -38,7 +38,7 @@ class DocumentPanelMobile extends Component {
                 <ILSHeaderPlaceholder isLoading={isLoading} center="true">
                   <DocumentTitle metadata={doc.metadata} />
                 </ILSHeaderPlaceholder>
-                <ILSParagraphPlaceholder linesNumber={1} isLoading={isLoading}>
+                <ILSParagraphPlaceholder linesNumber={2} isLoading={isLoading}>
                   <DocumentAuthors
                     authors={doc.metadata.authors}
                     hasOtherAuthors={doc.metadata.other_authors}
@@ -50,6 +50,13 @@ class DocumentPanelMobile extends Component {
                     id="DocumentPanelMobile.AfterAuthors"
                     metadata={doc.metadata}
                   />
+                  {doc.metadata.imprint?.publisher
+                    &&
+                  <><div
+                    className={`default-margin-bottom`}>
+                    Published by <b>{doc.metadata.imprint?.publisher}</b>
+                    {doc.metadata.publication_year && (<b>{doc.metadata.publication_year}</b>)}
+                  </div></>}
                 </ILSParagraphPlaceholder>
                 <ILSParagraphPlaceholder linesNumber={1} isLoading={isLoading}>
                   <LiteratureTags tags={doc.metadata.tags} />


### PR DESCRIPTION
Add publication year and publisher to search and details pages of the documents.
closes https://github.com/CERNDocumentServer/cds-ils/issues/357
Backoffice list.
![Captura de pantalla de 2021-07-05 13-47-51](https://user-images.githubusercontent.com/25476209/124467234-e06d6d00-dd97-11eb-9312-893e9fe68f2d.png)
Frontsite search.
![Captura de pantalla de 2021-07-05 13-48-25](https://user-images.githubusercontent.com/25476209/124467243-e2cfc700-dd97-11eb-86a6-bb817af55c13.png)
Frontsite inspect.
![Captura de pantalla de 2021-07-05 13-48-42](https://user-images.githubusercontent.com/25476209/124467245-e2cfc700-dd97-11eb-9995-697ad9b6dc39.png)
