### PR TITLE
Show a warning for overbooked documents during check out

### DIFF
--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanDetails.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanDetails.js
@@ -5,6 +5,7 @@ import { Loader } from '@components/Loader';
 import { Error } from '@components/Error';
 import { CurrentItem } from './CurrentItem';
 import { LoanHeader } from './LoanHeader';
+import { LoanOverbookedWarning } from './LoanOverbookedWarning';
 import { Loan } from './Loan';
 import { AvailableItems } from './AvailableItems';
 import { LoanActionMenu } from './LoanActionMenu';
@@ -54,6 +55,7 @@ export default class LoanDetails extends Component {
                     <Grid.Column width={13}>
                       <Container className="spaced">
                         <Container className="spaced">
+                          {data.metadata?.document_pid && <LoanOverbookedWarning documentPid={data.metadata.document_pid} />}
                           <Loan />
                           <CurrentItem />
                           <AvailableItems

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanOverbookedWarning/LoanOverbookedWarning.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanOverbookedWarning/LoanOverbookedWarning.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withCancel } from '@api/utils';
+import { documentApi } from '@api/documents';
+import { Message } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
+import {
+  BackOfficeRoutes,
+} from '@routes/urls';
+
+const OVERBOOKED_MSG = (documentPid) => <>This literature is <Link to={BackOfficeRoutes.documentDetailsFor(documentPid)}>overbooked</Link></>
+const ERROR_MSG = "Cannot verify if this literature is overbooked. Please refresh the page."
+
+export default class LoanOverbookedWarning extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      msg: ''
+    };
+  }
+
+  componentDidMount() {
+    this.fetchCirculation();
+  }
+
+  componentWillUnmount() {
+    this.cancellableCirculation && this.cancellableCirculation.cancel();
+  }
+
+  fetchCirculation = async () => {
+    const { documentPid } = this.props;
+    try {
+      this.cancellableCirculation = withCancel(
+        documentApi.get(documentPid)
+      );
+      const response = await this.cancellableCirculation.promise;
+      const circulation = response.data.metadata.circulation;
+      if (circulation.overbooked){
+        this.setState({ hasError: false, msg: OVERBOOKED_MSG(documentPid)});
+      }
+    } catch (error) {
+      if (error !== 'UNMOUNTED') {
+        this.setState({ hasError: true, overbooked: OVERBOOKED_STATES.ERROR });
+      }
+    }
+  };
+
+
+  render() {
+    const { hasError, msg } = this.state;
+    const color = hasError ? 'red' : 'yellow';
+    return (
+      <>
+      {msg &&
+        <Message color={color}>
+          {msg}
+        </Message>
+      }
+      </>
+    );
+  }
+}
+
+LoanOverbookedWarning.propTypes = {
+  documentPid: PropTypes.string.isRequired,
+};

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanOverbookedWarning/index.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanOverbookedWarning/index.js
@@ -1,0 +1,1 @@
+export { default as LoanOverbookedWarning } from './LoanOverbookedWarning';


### PR DESCRIPTION
Show a warning in the loans of overbooked documents.
closes:  https://github.com/CERNDocumentServer/cds-ils/issues/523
Loan of an overbooked document.
![Screenshot from 2021-07-14 12-37-15](https://user-images.githubusercontent.com/25476209/125612976-1896b491-4d0c-4a17-9c34-e4742fd5f6d2.png)
Loan of a non overbooked document.
![Screenshot from 2021-07-14 12-36-45](https://user-images.githubusercontent.com/25476209/125612993-334fe274-046e-4ec7-81af-e15ccfafc54f.png)
