### PR TITLE
Acquisition/borrowing: form fields display changes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 public/index.html
+cypress
+rollup.config.js

--- a/src/lib/config/common.js
+++ b/src/lib/config/common.js
@@ -8,52 +8,151 @@ export const DEFAULT_LANGUAGE = 'ENG';
 // text key is used for semantic ui dropdown options display
 
 export const ACQ_ORDER_STATUSES = [
-  { value: 'CANCELLED', text: 'Cancelled', label: 'Cancelled' },
-  { value: 'RECEIVED', text: 'Received', label: 'Received' },
-  { value: 'ORDERED', text: 'Ordered', label: 'Ordered' },
-  { value: 'PENDING', text: 'Pending', label: 'Pending' },
+  {
+    value: 'PENDING',
+    text: 'Pending',
+    label: 'Pending',
+    order: 1,
+    default: true,
+  },
+  {
+    value: 'ORDERED',
+    text: 'Ordered',
+    label: 'Ordered',
+    order: 2,
+    default: false,
+  },
+  {
+    value: 'RECEIVED',
+    text: 'Received',
+    label: 'Received',
+    order: 3,
+    default: false,
+  },
+  {
+    value: 'CANCELLED',
+    text: 'Cancelled',
+    label: 'Cancelled',
+    order: 4,
+    default: false,
+  },
 ];
 
 export const ILL_BORROWING_REQUESTS_STATUSES = [
-  { value: 'CANCELLED', text: 'Cancelled', label: 'Cancelled' },
-  { value: 'PENDING', text: 'Pending', label: 'Pending' },
-  { value: 'REQUESTED', text: 'Requested', label: 'Requested' },
-  { value: 'ON_LOAN', text: 'On loan', label: 'On loan' },
-  { value: 'RETURNED', text: 'Returned', label: 'Returned' },
+  {
+    value: 'CANCELLED',
+    text: 'Cancelled',
+    label: 'Cancelled',
+    order: 1,
+    default: false,
+  },
+  {
+    value: 'PENDING',
+    text: 'Pending',
+    label: 'Pending',
+    order: 2,
+    default: false,
+  },
+  {
+    value: 'REQUESTED',
+    text: 'Requested',
+    label: 'Requested',
+    order: 3,
+    default: false,
+  },
+  {
+    value: 'ON_LOAN',
+    text: 'On loan',
+    label: 'On loan',
+    order: 4,
+    default: false,
+  },
+  {
+    value: 'RETURNED',
+    text: 'Returned',
+    label: 'Returned',
+    order: 5,
+    default: false,
+  },
 ];
 
 export const ITEM_MEDIUMS = [
-  { value: 'NOT_SPECIFIED', text: 'Not specified', label: 'Not specified' },
-  { value: 'PAPER', text: 'Paper', label: 'Paper' },
-  { value: 'CDROM', text: 'CD-ROM', label: 'CD-ROM' },
-  { value: 'DVD', text: 'DVD', label: 'DVD' },
-  { value: 'VHS', text: 'VHS', label: 'VHS' },
-  { value: 'PAPERBACK', text: 'Paperback', label: 'Paperback' },
-  { value: 'HARDCOVER', text: 'Hardcover', label: 'Hardcover' },
+  {
+    value: 'NOT_SPECIFIED',
+    text: 'Not specified',
+    label: 'Not specified',
+    order: 1,
+  },
+  { value: 'PAPER', text: 'Paper', label: 'Paper', order: 2 },
+  { value: 'CDROM', text: 'CD-ROM', label: 'CD-ROM', order: 3 },
+  { value: 'DVD', text: 'DVD', label: 'DVD', order: 4 },
+  { value: 'VHS', text: 'VHS', label: 'VHS', order: 5 },
+  {
+    value: 'PAPERBACK',
+    text: 'Paperback',
+    label: 'Paperback',
+    order: 6,
+  },
+  {
+    value: 'HARDCOVER',
+    text: 'Hardcover',
+    label: 'Hardcover',
+    order: 7,
+  },
 ];
 
 export const DOCUMENT_RELATIONS = [
-  { value: 'edition', label: 'By edition' },
-  { value: 'multipart_monograph', label: 'By series (completed)' },
-  { value: 'serial', label: 'By series (periodic)' },
-  { value: 'language', label: 'By language' },
-  { value: 'previous', label: 'By predecessors' },
-  { value: 'next', label: 'By continuation' },
+  { value: 'edition', label: 'By edition', order: 1 },
+  {
+    value: 'multipart_monograph',
+    label: 'By series (completed)',
+    order: 2,
+  },
+  { value: 'serial', label: 'By series (periodic)', order: 3 },
+  { value: 'language', label: 'By language', order: 4 },
+  { value: 'previous', label: 'By predecessors', order: 5 },
+  { value: 'next', label: 'By continuation', order: 6 },
 ];
 
 export const DOCUMENT_TYPES = [
-  { value: 'BOOK', text: 'Book', label: 'Book' },
-  { value: 'PROCEEDINGS', text: 'Proceedings', label: 'Proceedings' },
-  { value: 'STANDARD', text: 'Standard', label: 'Standard' },
+  { value: 'BOOK', text: 'Book', label: 'Book', order: 1 },
+  {
+    value: 'PROCEEDINGS',
+    text: 'Proceedings',
+    label: 'Proceedings',
+    order: 2,
+  },
+  {
+    value: 'STANDARD',
+    text: 'Standard',
+    label: 'Standard',
+    order: 3,
+  },
   {
     value: 'SERIAL_ISSUE',
     text: 'Serial issue',
     label: 'Serial issue',
+    order: 4,
   },
-  { value: 'ARTICLE', text: 'Article', label: 'Article' },
+  {
+    value: 'ARTICLE',
+    text: 'Article',
+    label: 'Article',
+    order: 5,
+  },
 ];
 
 export const SERIES_TYPES = [
-  { value: 'SERIAL', text: 'Serial', label: 'Serial' },
-  { value: 'PERIODICAL', text: 'Periodical', label: 'Periodical' },
+  {
+    value: 'SERIAL',
+    text: 'Serial',
+    label: 'Serial',
+    order: 1,
+  },
+  {
+    value: 'PERIODICAL',
+    text: 'Periodical',
+    label: 'Periodical',
+    order: 2,
+  },
 ];

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -416,6 +416,7 @@ export const RECORDS_CONFIG = {
     extensionPendingStatuses: ['PENDING'],
     loanMaxDuration: 180,
     statuses: ILL_BORROWING_REQUESTS_STATUSES,
+    defaultType: 'PHYSICAL_COPY',
     search: {
       filters: [
         {

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderEditor/schema.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderEditor/schema.js
@@ -193,8 +193,13 @@ export const schema = () => {
       status: {
         title: 'Status',
         type: 'string',
-        enum: Object.values(invenioConfig.ACQ_ORDERS.statuses).map(
-          (s) => s.value
+        enum: Object.values(invenioConfig.ACQ_ORDERS.statuses)
+          .sort((a, b) => a.order - b.order)
+          .map((s) => s.value),
+        default: _.get(
+          _.find(invenioConfig.ACQ_ORDERS.statuses, { default: true }),
+          'value',
+          null
         ),
       },
       provider_pid: {

--- a/src/lib/pages/backoffice/Document/DocumentEditor/schema.js
+++ b/src/lib/pages/backoffice/Document/DocumentEditor/schema.js
@@ -220,8 +220,12 @@ export const schema = () => {
         type: 'boolean',
       },
       document_type: {
-        enum: invenioConfig.DOCUMENTS.types.map((status) => status.value),
-        enumNames: invenioConfig.DOCUMENTS.types.map((status) => status.text),
+        enum: invenioConfig.DOCUMENTS.types
+          .sort((a, b) => a.order - b.order)
+          .map((status) => status.value),
+        enumNames: invenioConfig.DOCUMENTS.types
+          .sort((a, b) => a.order - b.order)
+          .map((status) => status.text),
         title: 'Document type',
         type: 'string',
       },

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestEditor/schema.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestEditor/schema.js
@@ -124,8 +124,15 @@ export const schema = () => {
       status: {
         title: 'Status',
         type: 'string',
-        enum: Object.values(invenioConfig.ILL_BORROWING_REQUESTS.statuses).map(
-          (s) => s.value
+        enum: Object.values(invenioConfig.ILL_BORROWING_REQUESTS.statuses)
+          .sort((a, b) => a.order - b.order)
+          .map((s) => s.value),
+        default: _.get(
+          _.find(invenioConfig.ILL_BORROWING_REQUESTS.statuses, {
+            default: true,
+          }),
+          'value',
+          null
         ),
       },
       total: {
@@ -139,6 +146,7 @@ export const schema = () => {
       type: {
         title: 'Type',
         type: 'string',
+        default: invenioConfig.ILL_BORROWING_REQUESTS.defaultType,
       },
     },
     required: ['status', 'document_pid', 'patron_pid', 'provider_pid', 'type'],

--- a/src/lib/pages/backoffice/Item/ItemEditor/schema.js
+++ b/src/lib/pages/backoffice/Item/ItemEditor/schema.js
@@ -58,8 +58,12 @@ export const schema = () => {
         type: 'array',
       },
       medium: {
-        enum: invenioConfig.ITEMS.mediums.map((status) => status.value),
-        enumNames: invenioConfig.ITEMS.mediums.map((status) => status.text),
+        enum: invenioConfig.ITEMS.mediums
+          .sort((a, b) => a.order - b.order)
+          .map((status) => status.value),
+        enumNames: invenioConfig.ITEMS.mediums
+          .sort((a, b) => a.order - b.order)
+          .map((status) => status.text),
         type: 'string',
         title: 'Medium',
       },

--- a/src/lib/pages/backoffice/Series/SeriesEditor/schema.js
+++ b/src/lib/pages/backoffice/Series/SeriesEditor/schema.js
@@ -194,10 +194,17 @@ export const schema = () => {
         type: 'array',
       },
       series_type: {
-        enum: ['', ...invenioConfig.SERIES.types.map((status) => status.value)],
+        enum: [
+          '',
+          ...invenioConfig.SERIES.types
+            .sort((a, b) => a.order - b.order)
+            .map((status) => status.value),
+        ],
         enumNames: [
           'None',
-          ...invenioConfig.SERIES.types.map((status) => status.text),
+          ...invenioConfig.SERIES.types
+            .sort((a, b) => a.order - b.order)
+            .map((status) => status.text),
         ],
         title: 'Series type',
         type: 'string',


### PR DESCRIPTION
Changes to acquisitions and borrowing forms:
- Sort status values in the purchase orders form, choosing the first value as the default one.
- Select Physical copy as the default value of the type in the borrowing requests form.
- Refactor code for displaying the fields in the dropdown selectors, adding an order field and the possibility of using a default value.
closes https://github.com/CERNDocumentServer/cds-ils/issues/327
![Screenshot from 2021-07-15 17-06-41](https://user-images.githubusercontent.com/25476209/125811348-31b91e36-73a0-4219-a2ed-643714dfa53f.png)
![Screenshot from 2021-07-15 17-06-56](https://user-images.githubusercontent.com/25476209/125811355-1eb87084-2085-4e3b-990f-284ab3ca9abb.png)
