### PR TITLE
DocumentDetails: show purchase orders in document details

### DIFF
--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentActionMenu/DocumentActionMenu.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentActionMenu/DocumentActionMenu.js
@@ -99,6 +99,10 @@ export default class DocumentActionMenu extends Component {
           />
           <ScrollingMenuItem elementId="document-siblings" label="Relations" />
           <ScrollingMenuItem
+            elementId="document-purchase-orders"
+            label="Purchase orders"
+          />
+          <ScrollingMenuItem
             elementId="document-statistics"
             label="Statistics"
           />

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentContent.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentContent.js
@@ -9,6 +9,7 @@ import {
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Accordion } from 'semantic-ui-react';
+import { DocumentPurchaseOrders } from './DocumentPurchaseOrders';
 
 export class DocumentContent extends Component {
   render() {
@@ -70,6 +71,17 @@ export class DocumentContent extends Component {
         ),
       },
       {
+        key: 'document-purchase-orders',
+        title: 'Purchase orders',
+        content: (
+          <Accordion.Content>
+            <div ref={anchors.purchaseOrdersRef} id="document-purchase-orders">
+              <DocumentPurchaseOrders />
+            </div>
+          </Accordion.Content>
+        ),
+      },
+      {
         key: 'document-statistics',
         title: 'Statistics',
         content: (
@@ -81,7 +93,7 @@ export class DocumentContent extends Component {
         ),
       },
     ];
-    const defaultIndexes = [0, 1, 2, 3, 4, 5];
+    const defaultIndexes = [0, 1, 2, 3, 4, 5, 6];
 
     return (
       <Accordion

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentDetails.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentDetails.js
@@ -22,6 +22,7 @@ export default class DocumentDetails extends Component {
       attachedEItemsRef: React.createRef(),
       seriesRef: React.createRef(),
       relatedRef: React.createRef(),
+      purchaseOrdersRef: React.createRef(),
       statisticsRef: React.createRef(),
     };
   }

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPurchaseOrders/DocumentPurchaseOrders.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPurchaseOrders/DocumentPurchaseOrders.js
@@ -1,0 +1,152 @@
+
+import { dateFormatter } from '@api/date';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withCancel } from '@api/utils';
+import { SeeAllButton } from '@components/backoffice/buttons/SeeAllButton';
+import { orderApi } from '@api/acquisition';
+import { ResultsTable } from '@components/ResultsTable/ResultsTable';
+import { Loader } from '@components/Loader';
+import { Link } from 'react-router-dom';
+import { AcquisitionRoutes } from '@routes/urls';
+import { Message } from 'semantic-ui-react';
+
+export default class DocumentPurchaseOrders extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      orders: {},
+      isLoading: true,
+      hasError: false
+    };
+  }
+
+  componentDidMount() {
+    const {
+      documentDetails: { pid },
+    } = this.props;
+    this.fetchPurchaseOrders(pid)
+  }
+
+  componentWillUnmount() {
+    this.cancellablePurchaseOrders && this.cancellablePurchaseOrders.cancel();
+  }
+
+
+  seeAllButton = () => {
+    const {
+      documentDetails: { pid },
+    } = this.props;
+    const path = AcquisitionRoutes.ordersListWithQuery(
+      orderApi
+        .query()
+        .withDocPid(pid)
+        .qs()
+    );
+    return <SeeAllButton to={path} />;
+  };
+
+  fetchPurchaseOrders = async (pid) => {
+    try {
+      this.cancellablePurchaseOrders = withCancel(
+        orderApi.list(orderApi.query().withDocPid(pid).qs())
+      );
+      const response = await this.cancellablePurchaseOrders.promise;
+      this.setState({ orders: response.data, hasError: false, isLoading: false});
+    } catch (error) {
+      if (error !== 'UNMOUNTED') {
+        this.setState({hasError: true, isLoading: false});
+      }
+    }
+  };
+
+  viewDetails = ({ row }) => {
+    return (
+      <Link
+        to={AcquisitionRoutes.orderDetailsFor(row.id)}
+      >
+        {row.id}
+      </Link>
+    );
+  };
+
+
+  renderTable(data){
+    const { showMaxPurchaseOrders } = this.props;
+    const columns = [
+      { title: 'Order', formatter: this.viewDetails },
+      {
+        title: 'Status',
+        field: 'metadata.status',
+      },
+      {
+        title: 'Provider',
+        field: 'metadata.provider.name',
+      },
+      {
+        title: 'Created date',
+        field: 'created',
+        formatter: dateFormatter,
+      },
+      {
+        title: 'Expected delivery date',
+        field: 'metadata.expected_delivery_date',
+        formatter: dateFormatter,
+      },
+    ];
+
+    return (
+      <ResultsTable
+        data={data.hits}
+        columns={columns}
+        totalHitsCount={data.total}
+        name="Orders"
+        seeAllComponent={this.seeAllButton()}
+        showMaxRows={showMaxPurchaseOrders}
+      />
+    );
+  }
+
+
+  renderResultsOrEmpty(data) {
+    return data.total > 0
+      ? this.renderTable(data)
+      : (
+        <Message info icon data-test="no-results">
+          <Message.Content>
+            <Message.Header>No results found</Message.Header>
+            There are no purchase orders.
+          </Message.Content>
+        </Message>
+      );
+  }
+
+  renderError() {
+    <Message info icon data-test="no-results">
+      <Message.Content>
+        <Message.Header>Error</Message.Header>
+          There was an error loading the purchase orders.
+      </Message.Content>
+    </Message>
+  }
+
+  render() {
+    const { orders, isLoading, hasError } = this.state;
+    return (
+      <>
+      <Loader isLoading={isLoading}>
+        {hasError ? this.renderError() : this.renderResultsOrEmpty(orders)}
+      </Loader>
+      </>
+    );
+  }
+}
+
+DocumentPurchaseOrders.propTypes = {
+  documentDetails: PropTypes.object,
+};
+
+DocumentPurchaseOrders.defaultProps = {
+  showMaxPurchaseOrders: 5,
+};

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPurchaseOrders/index.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPurchaseOrders/index.js
@@ -1,0 +1,13 @@
+import { connect } from 'react-redux';
+
+import DocumentPurchaseOrdersComponent from './DocumentPurchaseOrders';
+
+const mapStateToProps = (state) => ({
+  documentDetails: state.documentDetails.data,
+});
+
+
+export const DocumentPurchaseOrders = connect(
+  mapStateToProps,
+  null
+)(DocumentPurchaseOrdersComponent);


### PR DESCRIPTION
Create a new panel before statistics showing all the purchased orders of the current document.
closes https://github.com/CERNDocumentServer/cds-ils/issues/528
![Screenshot from 2021-07-29 10-38-29](https://user-images.githubusercontent.com/25476209/127461717-8eaff3da-77f3-49fe-a321-da6e10e29009.png)

