### PR TITLE
record relations: show warning message when deleting a relation

### DIFF
--- a/src/lib/modules/Relations/backoffice/components/RelationRemover/RelationRemover.js
+++ b/src/lib/modules/Relations/backoffice/components/RelationRemover/RelationRemover.js
@@ -19,8 +19,9 @@ export default class RelationRemover extends Component {
   };
 
   render() {
-    const { trigger, buttonContent } = this.props;
+    const { trigger, buttonContent, relationType } = this.props;
     const { modalOpen } = this.state;
+    const siblings = ['language', 'edition', 'other'];
 
     return (
       <Modal
@@ -39,10 +40,16 @@ export default class RelationRemover extends Component {
       >
         <Modal.Header>Confirm removal</Modal.Header>
         <Modal.Content>
-          Are you sure you want to delete this relation?
+          <p>Are you sure you want to remove this relation?</p>
+          {siblings.includes(relationType) && (
+            <p>
+              Please note that all {relationType} relations to this literature
+              will be removed.
+            </p>
+          )}
         </Modal.Content>
         <Modal.Actions>
-          <Button onClick={this.handleClose}>No, take me back</Button>
+          <Button onClick={this.handleClose}>Cancel</Button>
           <Button negative onClick={this.handleDelete}>
             Yes, I am sure
           </Button>
@@ -63,6 +70,8 @@ RelationRemover.propTypes = {
   buttonContent: PropTypes.string.isRequired,
 
   trigger: PropTypes.node,
+
+  relationType: PropTypes.string,
 };
 
 RelationRemover.defaultProps = {

--- a/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/BorrowingRequestLoanExtension/BorrowingRequestLoanExtension.js
+++ b/src/lib/pages/backoffice/ILL/BorrowingRequest/BorrowingRequestDetails/BorrowingRequestPatronLoan/BorrowingRequestLoanExtension/BorrowingRequestLoanExtension.js
@@ -133,7 +133,7 @@ export default class BorrowingRequestLoanExtension extends Component {
                         </i>
                       </Modal.Content>
                       <Modal.Actions>
-                        <Button onClick={this.handleCloseModal}>Close</Button>
+                        <Button onClick={this.handleCloseModal}>Cancel</Button>
                         <Button positive onClick={this.acceptHandler}>
                           Accept extension
                         </Button>

--- a/src/lib/pages/frontsite/PatronProfile/PatronCancelModal.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCancelModal.js
@@ -21,7 +21,7 @@ class PatronCancelModal extends Component {
           Your request for "<strong>{documentTitle}</strong>" will be cancelled.
         </Modal.Content>
         <Modal.Actions>
-          <Button onClick={onClose}>No, take me back</Button>
+          <Button onClick={onClose}>Cancel</Button>
           <Button negative onClick={() => onConfirm(data)}>
             Yes, I am sure
           </Button>


### PR DESCRIPTION
Add a text to the document relation removal dialog indicating that deleting a relation would delete all other relations of that type to the document.
Replace the "No, take me back" and "Close" text in the modal's close buttons to "Cancel".
closes: https://github.com/CERNDocumentServer/cds-ils/issues/547
New design.
![Screenshot from 2021-09-15 15-24-22](https://user-images.githubusercontent.com/25476209/133442556-f409f77d-9d01-4707-9cc5-08bb1cfe29d9.png)

First design.
![Screenshot from 2021-09-02 11-13-25](https://user-images.githubusercontent.com/25476209/131817310-b1a93657-6378-410e-94b2-ff13cd4196ad.png)
