### PR TITLE
PurchaseOrderDetails: show related request literature

### DIFF
--- a/src/lib/api/documentRequests/documentRequest.js
+++ b/src/lib/api/documentRequests/documentRequest.js
@@ -82,6 +82,7 @@ class QueryBuilder {
     this.documentQuery = [];
     this.page = '';
     this.patronQuery = [];
+    this.physicalItemProviderQuery = [];
     this.size = '';
     this.sortBy = '';
     this.stateQuery = [];
@@ -111,6 +112,19 @@ class QueryBuilder {
     return this;
   }
 
+  withPhysicalItemProviderPid(physicalItemProviderPid, pidType) {
+    if (!physicalItemProviderPid || _isEmpty(physicalItemProviderPid)) {
+      throw TypeError('physicalItemProviderPid argument missing');
+    }
+    if (!pidType || _isEmpty(pidType)) {
+      throw TypeError('physicalItemProviderPid argument missing');
+    }
+    this.physicalItemProviderQuery.push(
+      `physical_item_provider.pid:${physicalItemProviderPid} AND physical_item_provider.pid_type:${pidType}`
+    );
+    return this;
+  }
+
   withPage(page = 0) {
     if (page > 0) this.page = `&page=${page}`;
     return this;
@@ -128,7 +142,7 @@ class QueryBuilder {
 
   qs() {
     const searchCriteria = this.documentQuery
-      .concat(this.patronQuery, this.stateQuery)
+      .concat(this.patronQuery, this.stateQuery, this.physicalItemProviderQuery)
       .join(' AND ');
     return `${searchCriteria}${this.sortBy}${this.size}${this.page}`;
   }

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderDocumentRequest.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderDocumentRequest.js
@@ -1,0 +1,96 @@
+import { PropTypes } from 'prop-types';
+import React from 'react';
+import { withCancel } from '@api/utils';
+import { documentRequestApi } from '@api/documentRequests/documentRequest';
+import { Link } from 'react-router-dom';
+import { BackOfficeRoutes } from '@routes/urls';
+import { Message } from 'semantic-ui-react';
+import { Loader } from '@components/Loader';
+
+export class OrderDocumentRequest extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      documentRequest: {},
+      isLoading: true,
+      hasError: false,
+    };
+  }
+
+  componentDidMount() {
+    const {
+      orderId: { pid },
+    } = this.props;
+    this.fetchDocumentRequest(pid);
+  }
+
+  componentWillUnmount() {
+    this.cancellableDocumentRequest && this.cancellableDocumentRequest.cancel();
+  }
+
+  fetchDocumentRequest = async (pid) => {
+    try {
+      this.cancellableDocumentRequest = withCancel(
+        documentRequestApi.list(
+          documentRequestApi
+            .query()
+            .withPhysicalItemProviderPid(pid, 'acqoid')
+            .qs()
+        )
+      );
+      const response = await this.cancellableDocumentRequest.promise;
+      this.setState({
+        documentRequest: response.data.hits.length
+          ? response.data.hits[0]
+          : null,
+        hasError: false,
+        isLoading: false,
+      });
+    } catch (error) {
+      if (error !== 'UNMOUNTED') {
+        this.setState({ hasError: true, isLoading: false });
+      }
+    }
+  };
+
+  renderResultsOrEmpty(documentRequest) {
+    return documentRequest?.metadata ? (
+      <Link
+        to={BackOfficeRoutes.documentRequestDetailsFor(
+          documentRequest.metadata.pid
+        )}
+      >
+        {documentRequest.metadata.title}
+      </Link>
+    ) : (
+      <>-</>
+    );
+  }
+
+  renderError() {
+    return (
+      <Message negative>
+        <Message.Content>
+          Error loading the related literature request.
+        </Message.Content>
+      </Message>
+    );
+  }
+
+  render() {
+    const { documentRequest, isLoading, hasError } = this.state;
+    return (
+      <>
+        <Loader isLoading={isLoading}>
+          {hasError
+            ? this.renderError()
+            : this.renderResultsOrEmpty(documentRequest)}
+        </Loader>
+      </>
+    );
+  }
+}
+
+OrderDocumentRequest.propTypes = {
+  orderId: PropTypes.object,
+};

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderInformation.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderInformation.js
@@ -5,6 +5,7 @@ import React from 'react';
 import { Grid } from 'semantic-ui-react';
 import { DateTime } from 'luxon';
 import { toShortDateTime } from '@api/date';
+import { OrderDocumentRequest } from './OrderDocumentRequest';
 
 export class OrderInformation extends React.Component {
   render() {
@@ -19,6 +20,10 @@ export class OrderInformation extends React.Component {
       },
       { name: 'Delivered on', value: metadata.received_date || '-' },
       { name: 'Notes', value: metadata.notes || '-' },
+      {
+        name: 'Literature request',
+        value: <OrderDocumentRequest orderId={order} />,
+      },
     ];
     const rightTable = [
       { name: 'Status', value: metadata.status },


### PR DESCRIPTION
Show the related request literature if any in the purchase order details page.
closes https://github.com/CERNDocumentServer/cds-ils/issues/568
New purchase order with related literature request.
![Screenshot from 2021-09-15 11-29-00](https://user-images.githubusercontent.com/25476209/133408591-c9f0275a-862f-40a1-a48c-c02ba58682ac.png)
New purchase order without related literature request.
![Screenshot from 2021-09-15 11-28-50](https://user-images.githubusercontent.com/25476209/133408608-f70d93d5-05aa-469c-a190-43063a07e69e.png)
New purchase order with error fetching related literature request.
![Screenshot from 2021-09-15 11-28-22](https://user-images.githubusercontent.com/25476209/133408627-e3fa931a-fb89-47ed-a621-59b603b5fd3d.png)

Old purchase order with related literature request.
![Screenshot from 2021-09-06 11-20-58](https://user-images.githubusercontent.com/25476209/132194029-b2d05ed8-5213-495e-8a4e-d2c866608f7b.png)
Old purchase order without related literature request.
![Screenshot from 2021-09-06 11-21-07](https://user-images.githubusercontent.com/25476209/132194163-fcd1f843-79a6-4a66-9894-51420e901d62.png)
