### PR TITLE
Pending status is now the default for the ILL Borrowing request

### DIFF
--- a/src/lib/config/common.js
+++ b/src/lib/config/common.js
@@ -51,7 +51,7 @@ export const ILL_BORROWING_REQUESTS_STATUSES = [
     text: 'Pending',
     label: 'Pending',
     order: 2,
-    default: false,
+    default: true,
   },
   {
     value: 'REQUESTED',


### PR DESCRIPTION
closes https://github.com/CERNDocumentServer/cds-ils/issues/591