### PR TITLE
DocumentRequest: form state fix

### DIFF
--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -318,7 +318,18 @@ export const RECORDS_CONFIG = {
     },
   },
   DOCUMENT_REQUESTS: {
-    states: ['ACCEPTED', 'PENDING', 'DECLINED'],
+    states: [
+      {
+        value: 'ACCEPTED',
+      },
+      {
+        value: 'PENDING',
+        default: true,
+      },
+      {
+        value: 'DECLINED',
+      },
+    ],
     physicalItemProviders: {
       acq: { name: 'Acquisition', pid_type: 'acqoid' },
       ill: { name: 'Interlibrary loan', pid_type: 'illbid' },

--- a/src/lib/forms/rjsf/RJSForm.js
+++ b/src/lib/forms/rjsf/RJSForm.js
@@ -52,6 +52,7 @@ export class RJSForm extends Component {
       isLoading: false,
       errors: {},
       discardConfirmOpen: false,
+      submittedFormData: {},
     };
   }
 
@@ -59,7 +60,7 @@ export class RJSForm extends Component {
     return { Error: { __errors: [message] } };
   }
 
-  onError(error) {
+  onError(error, formData) {
     let extraErrors = {};
     const errors = _get(error, 'response.data.errors', []);
     if (_isEmpty(errors)) {
@@ -81,7 +82,11 @@ export class RJSForm extends Component {
         };
       }
     }
-    this.setState({ isLoading: false, errors: extraErrors });
+    this.setState({
+      isLoading: false,
+      errors: extraErrors,
+      submittedFormData: formData,
+    });
   }
 
   onSubmit = async ({ formData }, _) => {
@@ -101,7 +106,7 @@ export class RJSForm extends Component {
       sendSuccessNotification('Success!', successMessage);
       successCallback && successCallback(response);
     } catch (error) {
-      this.onError(error);
+      this.onError(error, formData);
     }
     // scroll to top to see success/errors after backend call
     window.scrollTo(0, 0);
@@ -109,12 +114,15 @@ export class RJSForm extends Component {
 
   render() {
     const { schema, uiSchema, formData } = this.props;
-    const { discardConfirmOpen, errors, isLoading } = this.state;
+    const { discardConfirmOpen, errors, isLoading, submittedFormData } =
+      this.state;
+    const formReturnedErrors = !_isEmpty(errors);
+
     return (
       <Form
         schema={schema}
         uiSchema={uiSchema}
-        formData={formData}
+        formData={formReturnedErrors ? submittedFormData : formData}
         widgets={customWidgets}
         fields={customFields}
         transformErrors={(errors) => {

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestEditor/DocumentRequestEditor.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestEditor/DocumentRequestEditor.js
@@ -14,23 +14,26 @@ export class DocumentRequestEditor extends Component {
   constructor(props) {
     super(props);
 
-    const isEditing = !!props.match.params.documentRequestPid;
     this.state = {
       data: {},
-      isLoading: isEditing,
+      isLoading: this.userIsEditing,
       error: {},
     };
   }
 
   componentDidMount() {
     const { match } = this.props;
-    if (match.params.documentRequestPid) {
+    if (this.userIsEditing) {
       this.fetchDocReq(match.params.documentRequestPid);
     }
   }
 
   componentWillUnmount() {
     this.cancellableFetchDocReq && this.cancellableFetchDocReq.cancel();
+  }
+
+  get userIsEditing() {
+    return !!this.props.match.params.documentRequestPid;
   }
 
   fetchDocReq = async (documentRequestPid) => {
@@ -54,8 +57,7 @@ export class DocumentRequestEditor extends Component {
       },
     } = this.props;
 
-    const isEditing = !!documentRequestPid;
-    return isEditing
+    return this.userIsEditing
       ? await documentRequestApi.update(documentRequestPid, formData)
       : await documentRequestApi.create(formData);
   };
@@ -74,11 +76,11 @@ export class DocumentRequestEditor extends Component {
     } = this.props;
     const { isLoading, error, data } = this.state;
 
-    const isEditing = !!documentRequestPid;
-    const formTitle = isEditing
+    const formTitle = this.userIsEditing
       ? `New document request - Edit #${documentRequestPid}`
       : 'New document request - Create';
-    return isEditing ? (
+
+    return this.userIsEditing ? (
       <Loader isLoading={isLoading}>
         <Error error={error}>
           <RJSForm

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestEditor/schema.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestEditor/schema.js
@@ -92,7 +92,12 @@ export const schema = () => {
       state: {
         title: 'State',
         type: 'string',
-        enum: invenioConfig.DOCUMENT_REQUESTS.states,
+        enum: invenioConfig.DOCUMENT_REQUESTS.states.map(
+          (state) => state.value
+        ),
+        default: invenioConfig.DOCUMENT_REQUESTS.states.find(
+          (state) => state.default
+        )?.value,
       },
       title: {
         title: 'Title',

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestEditor/uiSchema.js
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestEditor/uiSchema.js
@@ -49,7 +49,8 @@ export const uiSchema = (title) => {
         'custom:divider': 16,
       },
       {
-        state: 8,
+        state: 4,
+        request_type: 4,
         decline_reason: 8,
       },
       {
@@ -85,7 +86,6 @@ export const uiSchema = (title) => {
         'custom:divider': 16,
       },
       {
-        request_type: 4,
         payment_method: 4,
         payment_info: 8,
       },


### PR DESCRIPTION
FIX the document request form was not holding its state after an error from the api and thus was confusing to the user, lastly also moved the request type next to the state field as it is a required field and easy to miss at the bottom.

closes https://github.com/CERNDocumentServer/cds-ils/issues/584