### PR TITLE
PatronBulkExtendLoans: hide the extend loans button if there aren't ongoing loans.

### DIFF
--- a/src/lib/modules/Patron/PatronBulkExtendLoans/PatronBulkExtendLoans.js
+++ b/src/lib/modules/Patron/PatronBulkExtendLoans/PatronBulkExtendLoans.js
@@ -17,7 +17,8 @@ export default class PatronBulkExtendLoans extends Component {
   };
 
   render() {
-    const { patronPid, bulkLoanExtension, isLoading, ...props } = this.props;
+    const { patronPid, bulkLoanExtension, isLoading, hidden, ...props } =
+      this.props;
     const { open } = this.state;
     return (
       <Modal
@@ -25,17 +26,19 @@ export default class PatronBulkExtendLoans extends Component {
         onClose={this.close}
         onOpen={this.open}
         trigger={
-          <Button
-            labelPosition="left"
-            fluid
-            icon
-            primary
-            loading={isLoading}
-            {...props}
-          >
-            <Icon name="refresh" />
-            Extend all loans
-          </Button>
+          !hidden && (
+            <Button
+              labelPosition="left"
+              fluid
+              icon
+              primary
+              loading={isLoading}
+              {...props}
+            >
+              <Icon name="refresh" />
+              Extend all loans
+            </Button>
+          )
         }
       >
         <Modal.Header>Confirm extension action</Modal.Header>
@@ -73,6 +76,7 @@ PatronBulkExtendLoans.propTypes = {
   patronPid: PropTypes.string.isRequired,
   bulkLoanExtension: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
+  hidden: PropTypes.bool,
 };
 
 PatronBulkExtendLoans.defaultProps = {

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronDetails.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronDetails.js
@@ -48,7 +48,7 @@ export default class PatronDetails extends Component {
   }
 
   render() {
-    const { isLoading, error, data, match } = this.props;
+    const { isLoading, error, data, match, currentLoans } = this.props;
     const currentPatronPid = match.params.patronPid;
     return (
       <div ref={this.headerRef}>
@@ -154,6 +154,7 @@ export default class PatronDetails extends Component {
                       <Sticky context={this.menuRef} offset={150}>
                         <PatronBulkExtendLoans
                           patronPid={currentPatronPid}
+                          hidden={currentLoans.total === 0}
                           fluid
                           color="blue"
                         />
@@ -182,6 +183,7 @@ PatronDetails.propTypes = {
       patronPid: PropTypes.string,
     }),
   }).isRequired,
+  currentLoans: PropTypes.object.isRequired,
 };
 
 PatronDetails.defaultProps = {

--- a/src/lib/pages/backoffice/Patron/PatronDetails/index.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/index.js
@@ -7,6 +7,7 @@ const mapStateToProps = (state) => ({
   error: state.patronDetails.error,
   hasError: state.patronDetails.hasError,
   data: state.patronDetails.data,
+  currentLoans: state.patronCurrentLoans.data,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/PatronCurrentLoans.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/PatronCurrentLoans.js
@@ -69,7 +69,12 @@ export default class PatronCurrentLoans extends Component {
         )}
         <Grid>
           <Grid.Column computer={4} tablet={8} mobile={16} floated="right">
-            <PatronBulkExtendLoans color="orange" patronPid={currentUser.id} />
+            <PatronBulkExtendLoans
+              currentLoans={loans}
+              color="orange"
+              hidden={loans.total === 0}
+              patronPid={currentUser.id}
+            />
           </Grid.Column>
         </Grid>
         <ILSItemPlaceholder fluid isLoading={isLoading}>


### PR DESCRIPTION
Hide the "extend all loans" button both in the frontpage and in the backoffice when the patron doesn't have any ongoing loans.
![Screenshot from 2021-10-07 11-07-13](https://user-images.githubusercontent.com/25476209/136355218-1dba3685-614e-4199-aef0-e27910b1be56.png)
![Screenshot from 2021-10-07 11-07-20](https://user-images.githubusercontent.com/25476209/136355222-01534455-3d98-4638-8344-4e26227d1d35.png)
![Screenshot from 2021-10-07 11-07-37](https://user-images.githubusercontent.com/25476209/136355226-4c13f04b-300a-4f4d-89f4-43ccbb8c4669.png)

