### PR TITLE
DocumentItems: fixed internal locations menu overflowing on large names

### DIFF
--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentItems/DocumentTabs.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentItems/DocumentTabs.js
@@ -88,7 +88,7 @@ export default class DocumentTabs extends Component {
             onClick={this.handleLocationClick}
             key={internalLocationName}
           >
-            {internalLocationName}
+            <span>{internalLocationName}</span>
             <Label
               pointing={menuItemIsActive ? 'right' : null}
               active={menuItemIsActive}
@@ -104,7 +104,7 @@ export default class DocumentTabs extends Component {
     );
 
     return (
-      <div className="center">
+      <div className="center internal-location-menu-wrapper">
         <Menu vertical compact fluid>
           {locations}
         </Menu>
@@ -160,22 +160,10 @@ export default class DocumentTabs extends Component {
         <Tab.Pane>
           <Grid stackable>
             <Grid.Row>
-              <Grid.Column
-                computer={3}
-                largeScreen={3}
-                tablet={5}
-                mobile={16}
-                floated="left"
-              >
+              <Grid.Column width={4} floated="left">
                 {this.createInternalLocationsMenu(locationsObject)}
               </Grid.Column>
-              <Grid.Column
-                computer={13}
-                largeScreen={13}
-                tablet={11}
-                mobile={16}
-                floated="right"
-              >
+              <Grid.Column width={12} floated="right">
                 {this.createInternalLocationTables(locationsObject)}
               </Grid.Column>
             </Grid.Row>

--- a/src/semantic-ui/site/collections/menu.overrides
+++ b/src/semantic-ui/site/collections/menu.overrides
@@ -18,6 +18,21 @@ Menu Overrides - REACT-INVENIO-APP-ILS
 
 .frontsite {
 
+  .internal-location-menu-wrapper {
+    .ui.menu.vertical {
+      min-width: 100%;
+
+      .item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        text-align: start;
+      }
+    }
+
+
+  }
+
   .ui.menu {
     &.mobile-header-menu {
       display: block;


### PR DESCRIPTION
now when the internal locations menu has a location with a long name it will not overflow behind the items 


![Screenshot 2021-10-25 at 10 01 23](https://user-images.githubusercontent.com/55200060/138657502-477ad251-cacd-4745-8824-5855d90ca7d7.png)


![Screenshot 2021-10-25 at 10 09 29](https://user-images.githubusercontent.com/55200060/138659396-388ab13a-dc49-4e1a-b77e-661e541ff9ef.png)

![Screenshot 2021-10-25 at 10 09 39](https://user-images.githubusercontent.com/55200060/138659426-55abef55-fa86-48c1-b170-579693f5530c.png)

