### PR TITLE
RecordsTable: Use activePage to render desired rows.

### DIFF
--- a/src/lib/components/ResultsTable/ResultsTable.js
+++ b/src/lib/components/ResultsTable/ResultsTable.js
@@ -22,6 +22,7 @@ export class ResultsTable extends Component {
       headerActionComponent,
       renderEmptyResultsElement,
       showMaxRows,
+      showFooterSummary,
       ...tableProps
     } = this.props;
 
@@ -38,7 +39,14 @@ export class ResultsTable extends Component {
         <ResultsTableHeader columns={columns} />
         <ResultsTableBody
           columns={columns}
-          rows={showAllResults ? data : data.slice(0, showMaxRows)}
+          rows={
+            showAllResults
+              ? data
+              : data.slice(
+                  (currentPage - 1) * showMaxRows,
+                  currentPage * showMaxRows
+                )
+          }
         />
         <ResultsTableFooter
           allRowsNumber={totalHitsCount || data.length}
@@ -48,6 +56,7 @@ export class ResultsTable extends Component {
           currentPage={currentPage}
           paginationComponent={paginationComponent}
           columnsNumber={columns.length}
+          showFooterSummary={showFooterSummary}
         />
       </Table>
     );
@@ -121,6 +130,7 @@ ResultsTable.propTypes = {
   totalHitsCount: PropTypes.number,
   renderEmptyResultsElement: PropTypes.func,
   fixed: PropTypes.bool,
+  showFooterSummary: PropTypes.bool,
 };
 
 ResultsTable.defaultProps = {
@@ -137,4 +147,5 @@ ResultsTable.defaultProps = {
   totalHitsCount: 0,
   showMaxRows: invenioConfig.APP.DEFAULT_RESULTS_SIZE,
   renderEmptyResultsElement: null,
+  showFooterSummary: true,
 };

--- a/src/lib/components/ResultsTable/ResultsTableFooter.js
+++ b/src/lib/components/ResultsTable/ResultsTableFooter.js
@@ -12,6 +12,7 @@ export default class ResultsTableFooter extends Component {
       columnsNumber,
       seeAllComponent,
       paginationComponent,
+      showFooterSummary,
     } = this.props;
     const start = showAllResults ? 0 : (currentPage - 1) * showMaxRows;
     const end = showAllResults
@@ -21,9 +22,11 @@ export default class ResultsTableFooter extends Component {
       <Table.Footer fullWidth data-test="footer">
         <Table.Row>
           <Table.HeaderCell colSpan={columnsNumber + 1} textAlign="right">
-            <span className="results-table-compact-summary">
-              Showing entries {start + 1}-{end} of {allRowsNumber}{' '}
-            </span>
+            {showFooterSummary && (
+              <span className="results-table-compact-summary">
+                Showing entries {start + 1}-{end} of {allRowsNumber}{' '}
+              </span>
+            )}
             <span>{seeAllComponent}</span>
             <span>{paginationComponent}</span>
           </Table.HeaderCell>
@@ -41,6 +44,7 @@ ResultsTableFooter.propTypes = {
   paginationComponent: PropTypes.node,
   showAllResults: PropTypes.bool,
   currentPage: PropTypes.number.isRequired,
+  showFooterSummary: PropTypes.bool.isRequired,
 };
 
 ResultsTableFooter.defaultProps = {

--- a/src/lib/components/ResultsTable/__snapshots__/ResultsTable.test.js.snap
+++ b/src/lib/components/ResultsTable/__snapshots__/ResultsTable.test.js.snap
@@ -61,6 +61,7 @@ exports[`ResultsTable tests should not render the see all button when showing on
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={3}
   singleLine={true}
   subtitle=""
@@ -349,6 +350,7 @@ exports[`ResultsTable tests should not render the see all button when showing on
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={3}
       />
     </table>
@@ -407,6 +409,7 @@ exports[`ResultsTable tests should render the see all button when showing only a
     </Button>
   }
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={1}
   singleLine={true}
   subtitle=""
@@ -621,6 +624,7 @@ exports[`ResultsTable tests should render the see all button when showing only a
           </Button>
         }
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={1}
       >
         <TableFooter

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -41,3 +41,4 @@ export { withCancel, recordToPidType } from '@api/utils';
 export { Media } from '@components/Media';
 export { IEFallback } from '@components/Fallbacks/IEFallback';
 export { InfoPopup } from '@components/InfoPopup';
+export { Pagination } from '@components/Pagination';

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderSearch/__snapshots__/OrderSearch.test.js.snap
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderSearch/__snapshots__/OrderSearch.test.js.snap
@@ -24,6 +24,7 @@ exports[`OrdersSearch ResultsTable tests should not render when empty results 1`
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -101,6 +102,7 @@ exports[`OrdersSearch ResultsTable tests should render a list of results 1`] = `
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -314,6 +316,7 @@ exports[`OrdersSearch ResultsTable tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentItems/__snapshots__/DocumentItems.test.js.snap
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentItems/__snapshots__/DocumentItems.test.js.snap
@@ -61,6 +61,7 @@ exports[`DocumentItems tests should load the DocumentItems component 1`] = `
         />
       }
       showAllResults={false}
+      showFooterSummary={true}
       showMaxRows={5}
       singleLine={true}
       subtitle=""
@@ -251,6 +252,7 @@ exports[`DocumentItems tests should render item 1`] = `
               />
             }
             showAllResults={false}
+            showFooterSummary={true}
             showMaxRows={5}
             singleLine={true}
             subtitle=""
@@ -770,6 +772,7 @@ exports[`DocumentItems tests should render item 1`] = `
                     />
                   }
                   showAllResults={false}
+                  showFooterSummary={true}
                   showMaxRows={5}
                 />
               </table>
@@ -870,6 +873,7 @@ exports[`DocumentItems tests should render show a message with no items 1`] = `
               />
             }
             showAllResults={false}
+            showFooterSummary={true}
             showMaxRows={5}
             singleLine={true}
             subtitle=""
@@ -1091,6 +1095,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
               />
             }
             showAllResults={false}
+            showFooterSummary={true}
             showMaxRows={1}
             singleLine={true}
             subtitle=""
@@ -1475,6 +1480,7 @@ exports[`DocumentItems tests should render the see all button when showing only 
                     />
                   }
                   showAllResults={false}
+                  showFooterSummary={true}
                   showMaxRows={1}
                 >
                   <TableFooter

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPendingLoans/__snapshots__/DocumentPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPendingLoans/__snapshots__/DocumentPendingLoans.test.js.snap
@@ -49,6 +49,7 @@ exports[`DocumentPendingLoans tests should load the details component 1`] = `
         />
       }
       showAllResults={false}
+      showFooterSummary={true}
       showMaxRows={5}
       singleLine={true}
       subtitle=""
@@ -248,6 +249,7 @@ exports[`DocumentPendingLoans tests should render pending loans 1`] = `
               />
             }
             showAllResults={false}
+            showFooterSummary={true}
             showMaxRows={5}
             singleLine={true}
             subtitle=""
@@ -628,6 +630,7 @@ exports[`DocumentPendingLoans tests should render pending loans 1`] = `
                     />
                   }
                   showAllResults={false}
+                  showFooterSummary={true}
                   showMaxRows={5}
                 />
               </table>
@@ -717,6 +720,7 @@ exports[`DocumentPendingLoans tests should render show a message with no pending
               />
             }
             showAllResults={false}
+            showFooterSummary={true}
             showMaxRows={5}
             singleLine={true}
             subtitle=""
@@ -947,6 +951,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
               />
             }
             showAllResults={false}
+            showFooterSummary={true}
             showMaxRows={1}
             singleLine={true}
             subtitle=""
@@ -1226,6 +1231,7 @@ exports[`DocumentPendingLoans tests should render the see all button when showin
                     />
                   }
                   showAllResults={false}
+                  showFooterSummary={true}
                   showMaxRows={1}
                 >
                   <TableFooter

--- a/src/lib/pages/backoffice/Document/DocumentSearch/__snapshots__/DocumentSearch.test.js.snap
+++ b/src/lib/pages/backoffice/Document/DocumentSearch/__snapshots__/DocumentSearch.test.js.snap
@@ -24,6 +24,7 @@ exports[`DocumentsSearch ResultsTable tests should not render when empty results
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -101,6 +102,7 @@ exports[`DocumentsSearch ResultsTable tests should render a list of results 1`] 
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -314,6 +316,7 @@ exports[`DocumentsSearch ResultsTable tests should render a list of results 1`] 
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>

--- a/src/lib/pages/backoffice/DocumentRequest/DocumentRequestSearch/__snapshots__/DocumentRequestSearch.test.js.snap
+++ b/src/lib/pages/backoffice/DocumentRequest/DocumentRequestSearch/__snapshots__/DocumentRequestSearch.test.js.snap
@@ -12,6 +12,7 @@ exports[`DocumentRequestsSearch ResultsTable tests should not render when empty 
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -88,6 +89,7 @@ exports[`DocumentRequestsSearch ResultsTable tests should render a list of resul
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -300,6 +302,7 @@ exports[`DocumentRequestsSearch ResultsTable tests should render a list of resul
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>

--- a/src/lib/pages/backoffice/EItem/EItemDetails/EItemFiles/__snapshots__/EItemFiles.test.js.snap
+++ b/src/lib/pages/backoffice/EItem/EItemDetails/EItemFiles/__snapshots__/EItemFiles.test.js.snap
@@ -73,6 +73,7 @@ exports[`EItemFiles tests should load the files component 1`] = `
           renderEmptyResultsElement={[Function]}
           seeAllComponent={null}
           showAllResults={false}
+          showFooterSummary={true}
           showMaxRows={5}
           singleLine={true}
           subtitle=""

--- a/src/lib/pages/backoffice/EItem/EItemSearch/__snapshots__/EItemSearch.test.js.snap
+++ b/src/lib/pages/backoffice/EItem/EItemSearch/__snapshots__/EItemSearch.test.js.snap
@@ -12,6 +12,7 @@ exports[`EItemsSearch ResultsTable tests should not render when empty results 1`
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -100,6 +101,7 @@ exports[`EItemsSearch ResultsTable tests should render a list of results 1`] = `
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -398,6 +400,7 @@ exports[`EItemsSearch ResultsTable tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemPastLoans/__snapshots__/ItemPastLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemPastLoans/__snapshots__/ItemPastLoans.test.js.snap
@@ -67,6 +67,7 @@ exports[`ItemPastLoans tests should load the past loans component 1`] = `
           />
         }
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={5}
         singleLine={true}
         subtitle=""
@@ -293,6 +294,7 @@ exports[`ItemPastLoans tests should render pending loans 1`] = `
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -769,6 +771,7 @@ exports[`ItemPastLoans tests should render pending loans 1`] = `
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={5}
                     />
                   </table>
@@ -886,6 +889,7 @@ exports[`ItemPastLoans tests should render show a message with no past loans 1`]
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""

--- a/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/__snapshots__/ItemPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Item/ItemDetails/ItemPendingLoans/__snapshots__/ItemPendingLoans.test.js.snap
@@ -107,6 +107,7 @@ exports[`ItemPendingLoans tests should render show a message with no requested l
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""

--- a/src/lib/pages/backoffice/Item/ItemSearch/__snapshots__/ItemSearch.test.js.snap
+++ b/src/lib/pages/backoffice/Item/ItemSearch/__snapshots__/ItemSearch.test.js.snap
@@ -12,6 +12,7 @@ exports[`ItemsSearch ResultsList tests should not render when empty results 1`] 
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -92,6 +93,7 @@ exports[`ItemsSearch ResultsList tests should render a list of results 1`] = `
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -308,6 +310,7 @@ exports[`ItemsSearch ResultsList tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>

--- a/src/lib/pages/backoffice/Loan/LoanSearch/__snapshots__/LoanSearch.test.js.snap
+++ b/src/lib/pages/backoffice/Loan/LoanSearch/__snapshots__/LoanSearch.test.js.snap
@@ -24,6 +24,7 @@ exports[`LoansSearch ResultsTable tests should not render when empty results 1`]
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -99,6 +100,7 @@ exports[`LoansSearch ResultsTable tests should render a list of results 1`] = `
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -310,6 +312,7 @@ exports[`LoansSearch ResultsTable tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
@@ -66,6 +66,7 @@ exports[`PatronCurrentBorrowingRequests tests should load the details component 
         />
       }
       showAllResults={false}
+      showFooterSummary={true}
       showMaxRows={5}
       singleLine={true}
       subtitle=""
@@ -359,6 +360,7 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -1177,6 +1179,7 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={5}
                     />
                   </table>
@@ -1318,6 +1321,7 @@ exports[`PatronCurrentBorrowingRequests tests should render show a message with 
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -1644,6 +1648,7 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={1}
                 singleLine={true}
                 subtitle=""
@@ -2190,6 +2195,7 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={1}
                     >
                       <TableFooter

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentLoans/__snapshots__/PatronCurrentLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentLoans/__snapshots__/PatronCurrentLoans.test.js.snap
@@ -56,6 +56,7 @@ exports[`PatronCurrentLoans tests should load the details component 1`] = `
         />
       }
       showAllResults={false}
+      showFooterSummary={true}
       showMaxRows={5}
       singleLine={true}
       subtitle=""
@@ -300,6 +301,7 @@ exports[`PatronCurrentLoans tests should render patron loans 1`] = `
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -950,6 +952,7 @@ exports[`PatronCurrentLoans tests should render patron loans 1`] = `
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={5}
                     />
                   </table>
@@ -1059,6 +1062,7 @@ exports[`PatronCurrentLoans tests should render show a message with no user loan
               />
             }
             showAllResults={false}
+            showFooterSummary={true}
             showMaxRows={5}
             singleLine={true}
             subtitle=""
@@ -1333,6 +1337,7 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={1}
                 singleLine={true}
                 subtitle=""
@@ -1770,6 +1775,7 @@ exports[`PatronCurrentLoans tests should render the see all button when showing 
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={1}
                     >
                       <TableFooter

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronDocumentRequests/__snapshots__/PatronDocumentRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronDocumentRequests/__snapshots__/PatronDocumentRequests.test.js.snap
@@ -51,6 +51,7 @@ exports[`PatronDocumentRequests tests should load the details component 1`] = `
         />
       }
       showAllResults={false}
+      showFooterSummary={true}
       showMaxRows={5}
       singleLine={true}
       subtitle=""
@@ -247,6 +248,7 @@ exports[`PatronDocumentRequests tests should render patron document requests 1`]
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -678,6 +680,7 @@ exports[`PatronDocumentRequests tests should render patron document requests 1`]
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={5}
                     />
                   </table>
@@ -806,6 +809,7 @@ exports[`PatronDocumentRequests tests should render show a message with no user 
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -1035,6 +1039,7 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={1}
                 singleLine={true}
                 subtitle=""
@@ -1350,6 +1355,7 @@ exports[`PatronDocumentRequests tests should render the see all button when show
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={1}
                     >
                       <TableFooter

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
@@ -65,6 +65,7 @@ exports[`PatronPastBorrowingRequests tests should load the details component 1`]
         />
       }
       showAllResults={false}
+      showFooterSummary={true}
       showMaxRows={5}
       singleLine={true}
       subtitle=""
@@ -357,6 +358,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -1157,6 +1159,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={5}
                     />
                   </table>
@@ -1297,6 +1300,7 @@ exports[`PatronPastBorrowingRequests tests should render show a message with no 
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -1622,6 +1626,7 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={1}
                 singleLine={true}
                 subtitle=""
@@ -2158,6 +2163,7 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={1}
                     >
                       <TableFooter

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
@@ -48,6 +48,7 @@ exports[`PatronLoans tests should load the details component 1`] = `
         />
       }
       showAllResults={false}
+      showFooterSummary={true}
       showMaxRows={5}
       singleLine={true}
       subtitle=""
@@ -346,6 +347,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -925,6 +927,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={5}
                     />
                   </table>
@@ -1049,6 +1052,7 @@ exports[`PatronLoans tests should render show a message with no user loans 1`] =
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={5}
                 singleLine={true}
                 subtitle=""
@@ -1379,6 +1383,7 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                   />
                 }
                 showAllResults={false}
+                showFooterSummary={true}
                 showMaxRows={1}
                 singleLine={true}
                 subtitle=""
@@ -1756,6 +1761,7 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                         />
                       }
                       showAllResults={false}
+                      showFooterSummary={true}
                       showMaxRows={1}
                     >
                       <TableFooter

--- a/src/lib/pages/backoffice/Patron/PatronSearch/__snapshots__/PatronSearch.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronSearch/__snapshots__/PatronSearch.test.js.snap
@@ -32,6 +32,7 @@ exports[`PatronsSearch ResultsList tests should not render when empty results 1`
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -112,6 +113,7 @@ exports[`PatronsSearch ResultsList tests should render a list of results 1`] = `
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -394,6 +396,7 @@ exports[`PatronsSearch ResultsList tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>

--- a/src/lib/pages/backoffice/Providers/ProviderSearch/__snapshots__/ProviderSearch.test.js.snap
+++ b/src/lib/pages/backoffice/Providers/ProviderSearch/__snapshots__/ProviderSearch.test.js.snap
@@ -12,6 +12,7 @@ exports[`ProvidersSearch ResultsTable tests should not render when empty results
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -90,6 +91,7 @@ exports[`ProvidersSearch ResultsTable tests should render a list of results 1`] 
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -378,6 +380,7 @@ exports[`ProvidersSearch ResultsTable tests should render a list of results 1`] 
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesDocuments/__snapshots__/SeriesDocuments.test.js.snap
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesDocuments/__snapshots__/SeriesDocuments.test.js.snap
@@ -43,6 +43,7 @@ exports[`SeriesDocuments tests should load the SeriesDocuments component 1`] = `
         />
       }
       showAllResults={false}
+      showFooterSummary={true}
       showMaxRows={5}
       singleLine={true}
       subtitle=""

--- a/src/lib/pages/backoffice/Series/SeriesSearch/__snapshots__/SeriesSearch.test.js.snap
+++ b/src/lib/pages/backoffice/Series/SeriesSearch/__snapshots__/SeriesSearch.test.js.snap
@@ -24,6 +24,7 @@ exports[`SeriesSearch ResultsTable tests should not render when empty results 1`
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -105,6 +106,7 @@ exports[`SeriesSearch ResultsTable tests should render a list of results 1`] = `
   renderEmptyResultsElement={null}
   seeAllComponent={null}
   showAllResults={false}
+  showFooterSummary={true}
   showMaxRows={15}
   singleLine={true}
   subtitle=""
@@ -322,6 +324,7 @@ exports[`SeriesSearch ResultsTable tests should render a list of results 1`] = `
         paginationComponent={null}
         seeAllComponent={null}
         showAllResults={false}
+        showFooterSummary={true}
         showMaxRows={15}
       />
     </table>


### PR DESCRIPTION
Active page now works.
Allow hiding the text of the footer of the table.
![Screenshot from 2021-11-08 15-39-38](https://user-images.githubusercontent.com/25476209/140761730-04f78d1e-8bc4-4a7a-8c35-96ab66cd4fbd.png)


