### PR TITLE
RJSFVocabulary: validate value

### DIFF
--- a/src/lib/forms/rjsf/widgets/RJSFVocabulary.js
+++ b/src/lib/forms/rjsf/widgets/RJSFVocabulary.js
@@ -30,6 +30,18 @@ export class RJSFVocabulary extends Component {
     this.cancellableFetchData && this.cancellableFetchData.cancel();
   }
 
+  validateValue = (value, options, isLoading) => {
+    const noOptionSelected = !value;
+    if (noOptionSelected) return true;
+
+    if (!options.length || isLoading) return;
+
+    const foundValue = (value) =>
+      options.find((option) => option.value === value);
+
+    return !!foundValue(value);
+  };
+
   serializer = (hit) => ({
     key: hit.metadata.key,
     value: hit.metadata.key,
@@ -82,13 +94,21 @@ export class RJSFVocabulary extends Component {
   render() {
     const { autofocus, label, placeholder, readonly, required } = this.props;
     const { options, isLoading, value, error } = this.state;
+
+    const valueIsValid = this.validateValue(value, options, isLoading);
+
+    const invalidValueError = {
+      content: ' Invalid option was selected',
+      pointing: 'above',
+    };
+
     return (
       <Form.Select
         fluid
         selection
         options={options}
         label={label}
-        value={value}
+        value={valueIsValid ? value : undefined}
         clearable
         required={required}
         autoFocus={autofocus}
@@ -97,6 +117,7 @@ export class RJSFVocabulary extends Component {
         disabled={isLoading || readonly}
         loading={isLoading}
         noResultsMessage={error ? error : 'No results found'}
+        error={!valueIsValid && invalidValueError}
       />
     );
   }


### PR DESCRIPTION
Now validates if the value passed to a vocabulary field is a valid option of that vocabulary



![Screenshot 2021-11-15 at 15 04 07](https://user-images.githubusercontent.com/55200060/141796645-2c5c284c-4a5d-449f-9c6d-150438c03f26.png)


closes https://github.com/CERNDocumentServer/cds-ils/issues/653