### PR TITLE
Loans: loan already requested modal removed from first loan.

### DIFF
--- a/src/lib/api/loans/loan.js
+++ b/src/lib/api/loans/loan.js
@@ -241,8 +241,13 @@ class QueryBuilder {
     return this;
   }
 
-  sortByRequestStartDate() {
+  sortByRequestStartDateDesc() {
     this.sortBy = `&sort=-request_start_date`;
+    return this;
+  }
+
+  sortByRequestStartDateAsc() {
+    this.sortBy = `&sort=request_start_date`;
     return this;
   }
 

--- a/src/lib/modules/Loan/actions.js
+++ b/src/lib/modules/Loan/actions.js
@@ -37,7 +37,7 @@ export const fetchLoanDetails = (
             .query()
             .withDocPid(response.data.metadata.document_pid)
             .withState(invenioConfig.CIRCULATION.loanRequestStates)
-            .sortByRequestStartDate()
+            .sortByRequestStartDateAsc()
             .qs()
         );
         if (pendingLoansResponse.data.total > 0) {

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPendingLoans/state/actions.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPendingLoans/state/actions.js
@@ -18,6 +18,7 @@ export const fetchPendingLoans = (documentPid) => {
           .query()
           .withDocPid(documentPid)
           .withState(invenioConfig.CIRCULATION.loanRequestStates)
+          .sortByRequestStartDateAsc()
           .qs()
       );
 

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPendingLoans/state/actions.test.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPendingLoans/state/actions.test.js
@@ -45,7 +45,7 @@ describe('Pending loans tests', () => {
 
       store.dispatch(actions.fetchPendingLoans('123')).then(() => {
         expect(mockFetchPendingOnDocument).toHaveBeenCalledWith(
-          'document_pid:123 AND state:(PENDING)'
+          'document_pid:123 AND state:(PENDING)&sort=request_start_date'
         );
         const actions = store.getActions();
         expect(actions[0]).toEqual(expectedAction);
@@ -63,7 +63,7 @@ describe('Pending loans tests', () => {
 
       store.dispatch(actions.fetchPendingLoans('123')).then(() => {
         expect(mockFetchPendingOnDocument).toHaveBeenCalledWith(
-          'document_pid:123 AND state:(PENDING)'
+          'document_pid:123 AND state:(PENDING)&sort=request_start_date'
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);
@@ -81,7 +81,7 @@ describe('Pending loans tests', () => {
 
       store.dispatch(actions.fetchPendingLoans('123')).then(() => {
         expect(mockFetchPendingOnDocument).toHaveBeenCalledWith(
-          'document_pid:123 AND state:(PENDING)'
+          'document_pid:123 AND state:(PENDING)&sort=request_start_date'
         );
         const actions = store.getActions();
         expect(actions[1]).toEqual(expectedAction);


### PR DESCRIPTION
Loan already requested modal added to the rest of loans.
closes: https://github.com/CERNDocumentServer/cds-ils/issues/664
implements https://github.com/inveniosoftware/react-invenio-app-ils/pull/507
![Screenshot from 2021-11-16 11-12-12](https://user-images.githubusercontent.com/25476209/141966242-87c066ef-7168-4122-a7df-06c05c350924.png)
Now the modal appears for the second loan (and not the first). Hovering in the link of the modal we can see it Links correctly to the first loan.
![Screenshot from 2021-11-16 11-12-35](https://user-images.githubusercontent.com/25476209/141966249-d935a11c-17a1-4928-b903-b8833e1bc458.png)

