### PR TITLE
LoanActions: warn the users that extend an overbooked loan.

### DIFF
--- a/src/lib/components/CancelModal/CancelModal.js
+++ b/src/lib/components/CancelModal/CancelModal.js
@@ -57,7 +57,6 @@ export default class CancelModal extends Component {
     const { open, value, showPopup } = this.state;
     return (
       <Modal
-        basic
         size="small"
         trigger={
           <Button
@@ -93,10 +92,10 @@ export default class CancelModal extends Component {
           />
         </Modal.Content>
         <Modal.Actions>
-          <Button basic color="black" inverted onClick={this.hide}>
+          <Button secondary onClick={this.hide}>
             Back
           </Button>
-          <Button color="red" inverted onClick={this.cancel}>
+          <Button color="red" onClick={this.cancel}>
             <Icon name="remove" /> {cancelText}
           </Button>
         </Modal.Actions>

--- a/src/lib/components/CancelModal/__snapshots__/CancelModal.test.js.snap
+++ b/src/lib/components/CancelModal/__snapshots__/CancelModal.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`CancelModal tests should load the cancel loan modal component 1`] = `
 <Modal
-  basic={true}
   centered={true}
   closeOnDimmerClick={true}
   closeOnDocumentClick={false}
@@ -62,17 +61,14 @@ exports[`CancelModal tests should load the cancel loan modal component 1`] = `
   <ModalActions>
     <Button
       as="button"
-      basic={true}
-      color="black"
-      inverted={true}
       onClick={[Function]}
+      secondary={true}
     >
       Back
     </Button>
     <Button
       as="button"
       color="red"
-      inverted={true}
       onClick={[Function]}
     >
       <Icon

--- a/src/lib/components/ConfirmModal/ConfirmModal.js
+++ b/src/lib/components/ConfirmModal/ConfirmModal.js
@@ -1,0 +1,59 @@
+import React, { Component } from 'react';
+import { Button, Confirm } from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+
+export default class ConfirmModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false,
+    };
+  }
+
+  hide = () => this.setState({ open: false });
+  show = () => this.setState({ open: true });
+
+  handleCloseModal = () => {
+    this.setState({ open: false });
+  };
+
+  render() {
+    const { content, header, isLoading, action, buttonLabel, actionLabel } =
+      this.props;
+    const { open } = this.state;
+    return (
+      <div>
+        <Button
+          primary
+          fluid
+          content={buttonLabel}
+          onClick={this.show}
+          loading={isLoading}
+          disabled={isLoading}
+        />
+        <Confirm
+          open={open}
+          header={header}
+          content={content}
+          onCancel={this.hide}
+          onConfirm={action}
+          cancelButton="Cancel"
+          confirmButton={actionLabel}
+        />
+      </div>
+    );
+  }
+}
+
+ConfirmModal.propTypes = {
+  action: PropTypes.func.isRequired,
+  content: PropTypes.string.isRequired,
+  header: PropTypes.string.isRequired,
+  buttonLabel: PropTypes.string.isRequired,
+  actionLabel: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool,
+};
+
+ConfirmModal.defaultProps = {
+  isLoading: false,
+};

--- a/src/lib/components/ConfirmModal/index.js
+++ b/src/lib/components/ConfirmModal/index.js
@@ -1,0 +1,1 @@
+export { default as ConfirmModal } from './ConfirmModal';

--- a/src/lib/modules/Loan/actions.js
+++ b/src/lib/modules/Loan/actions.js
@@ -3,6 +3,7 @@ import { searchReady } from '@api/utils';
 import {
   sendErrorNotification,
   sendSuccessNotification,
+  addNotification,
 } from '@components/Notifications';
 import { fetchItemDetails } from './../../pages/backoffice/Item/ItemDetails/state/actions';
 import { invenioConfig } from '@config';
@@ -37,7 +38,7 @@ export const fetchLoanDetails = (
             .query()
             .withDocPid(response.data.metadata.document_pid)
             .withState(invenioConfig.CIRCULATION.loanRequestStates)
-            .sortByRequestStartDate()
+            .sortByRequestStartDateAsc()
             .qs()
         );
         if (pendingLoansResponse.data.total > 0) {
@@ -99,11 +100,13 @@ export const performLoanAction = (
         )
       );
     } catch (error) {
+      console.log(error.message);
       dispatch({
         type: ACTION_HAS_ERROR,
         payload: error,
       });
-      dispatch(sendErrorNotification(error));
+      // TODO: Fix sendErrorNotification and use it here.
+      dispatch(addNotification('Error', error.message, 'error'));
     }
   };
 };

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/CancelButton.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/CancelButton.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CancelModal } from '@components/CancelModal';
+
+export const CancelLoanModal = ({ pid, isLoading, cancelAction }) => {
+  return (
+    <CancelModal
+      header={`Cancel Loan #${pid}`}
+      content={`You are about to cancel loan #${pid}.
+    Please enter a reason for cancelling this loan.`}
+      cancelText="Cancel Loan"
+      buttonText="Cancel"
+      action={cancelAction}
+      isLoading={isLoading}
+    />
+  );
+};
+
+CancelLoanModal.propTypes = {
+  pid: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  cancelAction: PropTypes.func.isRequired,
+};

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal/ExtendModal.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal/ExtendModal.js
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'semantic-ui-react';
+import { ConfirmModal } from '@components/ConfirmModal';
+import { withCancel } from '@api/utils';
+import { documentApi } from '@api/documents';
+import { Loader } from '@components/Loader';
+
+export default class ExtendModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      overbooked: false,
+      isLoading: true,
+    };
+  }
+
+  componentDidMount() {
+    this.fetchCirculation();
+  }
+
+  componentWillUnmount() {
+    this.cancellableCirculation && this.cancellableCirculation.cancel();
+  }
+
+  fetchCirculation = async () => {
+    const { loanDetails, sendErrorNotification } = this.props;
+    const { document_pid } = loanDetails.metadata;
+    try {
+      this.cancellableCirculation = withCancel(documentApi.get(document_pid));
+      const response = await this.cancellableCirculation.promise;
+      const circulation = response.data.metadata.circulation;
+      this.setState({
+        overbooked: circulation.overbooked === true,
+        isLoading: false,
+      });
+    } catch (error) {
+      if (error !== 'UNMOUNTED') {
+        sendErrorNotification(
+          'Something went wrong while checking if the literature is overbooked.',
+          'If the problem persists, please contact technical support.'
+        );
+      }
+    }
+  };
+
+  render() {
+    const { overbooked, isLoading } = this.state;
+    const { pid, loanAction, parentIsLoading } = this.props;
+    return (
+      <>
+        <Loader isLoading={isLoading}>
+          {overbooked ? (
+            <ConfirmModal
+              header={`Extend Loan #${pid}`}
+              content={`Are you sure you want to extend the loan #${pid}?
+            This literature is overbooked.`}
+              buttonLabel="Extend"
+              action={loanAction}
+              isLoading={parentIsLoading}
+              actionLabel="Extend"
+            />
+          ) : (
+            <Button
+              size="small"
+              fluid
+              primary
+              onClick={loanAction}
+              loading={parentIsLoading}
+              disabled={parentIsLoading}
+            >
+              Extend
+            </Button>
+          )}
+        </Loader>
+      </>
+    );
+  }
+}
+
+ExtendModal.propTypes = {
+  pid: PropTypes.string.isRequired,
+  parentIsLoading: PropTypes.bool.isRequired,
+  loanAction: PropTypes.func.isRequired,
+  loanDetails: PropTypes.object.isRequired,
+  sendErrorNotification: PropTypes.func.isRequired,
+};

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal/index.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal/index.js
@@ -1,0 +1,13 @@
+import { addNotification } from '@components/Notifications';
+import { connect } from 'react-redux';
+import ExtendModalComponent from './ExtendModal';
+
+const mapDispatchToProps = (dispatch) => ({
+  sendErrorNotification: (title, message) =>
+    dispatch(addNotification(title, message, 'error')),
+});
+
+export const ExtendModal = connect(
+  null,
+  mapDispatchToProps
+)(ExtendModalComponent);

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
@@ -3,14 +3,15 @@ import { InfoMessage } from '@components/backoffice/InfoMessage';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { List, Button } from 'semantic-ui-react';
+import { ExtendModal } from '@pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal';
+import { CancelLoanModal } from './CancelButton';
 import { omit } from 'lodash/object';
-import { CancelModal } from '@components/CancelModal';
 import _isEmpty from 'lodash/isEmpty';
 import capitalize from 'lodash/capitalize';
 
 export default class LoanActions extends Component {
   renderAvailableActions(pid, patronPid, documentPid, itemPid, actions = {}) {
-    const { performLoanAction, isLoading } = this.props;
+    const { performLoanAction, isLoading, loanDetails } = this.props;
 
     // omit checkout because it must done in one of the available items
     if (!itemPid) {
@@ -27,14 +28,17 @@ export default class LoanActions extends Component {
       return (
         <List.Item key={action}>
           {action === 'cancel' ? (
-            <CancelModal
-              header={`Cancel Loan #${pid}`}
-              content={`You are about to cancel loan #${pid}.
-                Please enter a reason for cancelling this loan.`}
-              cancelText="Cancel Loan"
-              buttonText={capitalize('cancel')}
-              action={cancelAction}
+            <CancelLoanModal
+              pid={pid}
               isLoading={isLoading}
+              cancelAction={cancelAction}
+            />
+          ) : action === 'extend' ? (
+            <ExtendModal
+              pid={pid}
+              parentIsLoading={isLoading}
+              loanAction={loanAction}
+              loanDetails={loanDetails}
             />
           ) : (
             <Button

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanDetails.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanDetails.js
@@ -15,6 +15,7 @@ export default class LoanDetails extends Component {
     super(props);
     this.headerRef = React.createRef();
     this.menuRef = React.createRef();
+    this.isLoading = true;
   }
 
   componentDidMount() {


### PR DESCRIPTION
Fix the cancel modal of loan actions.
closes: https://github.com/CERNDocumentServer/cds-ils/issues/663
![Screenshot from 2021-11-17 11-09-04](https://user-images.githubusercontent.com/25476209/142180680-712155b8-e338-4c2a-bd55-a155e7a697be.png)

