### PR TITLE
PatronPastLoans: fix wrong query in 'see all' loans history

### DIFF
--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastLoans/PatronPastLoans.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastLoans/PatronPastLoans.js
@@ -28,7 +28,7 @@ export default class PatronPastLoans extends Component {
       loanApi
         .query()
         .withPatronPid(patronPid)
-        .withState(invenioConfig.CIRCULATION.loanRequestStates)
+        .withState(invenioConfig.CIRCULATION.loanCompletedStates)
         .qs()
     );
     return <SeeAllButton to={path} />;


### PR DESCRIPTION
closes: https://github.com/CERNDocumentServer/cds-ils/issues/638
![Screenshot from 2021-11-23 10-12-28](https://user-images.githubusercontent.com/25476209/143059486-7e06782f-f180-45a7-87bb-bc9e701532f1.png)


