### PR TITLE
LoanActions: warn the users that extend an overbooked loan.

### DIFF
--- a/src/lib/components/CancelModal/CancelModal.js
+++ b/src/lib/components/CancelModal/CancelModal.js
@@ -57,7 +57,6 @@ export default class CancelModal extends Component {
     const { open, value, showPopup } = this.state;
     return (
       <Modal
-        basic
         size="small"
         trigger={
           <Button
@@ -93,10 +92,10 @@ export default class CancelModal extends Component {
           />
         </Modal.Content>
         <Modal.Actions>
-          <Button basic color="black" inverted onClick={this.hide}>
+          <Button secondary onClick={this.hide}>
             Back
           </Button>
-          <Button color="red" inverted onClick={this.cancel}>
+          <Button color="red" onClick={this.cancel}>
             <Icon name="remove" /> {cancelText}
           </Button>
         </Modal.Actions>

--- a/src/lib/components/CancelModal/__snapshots__/CancelModal.test.js.snap
+++ b/src/lib/components/CancelModal/__snapshots__/CancelModal.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`CancelModal tests should load the cancel loan modal component 1`] = `
 <Modal
-  basic={true}
   centered={true}
   closeOnDimmerClick={true}
   closeOnDocumentClick={false}
@@ -62,17 +61,14 @@ exports[`CancelModal tests should load the cancel loan modal component 1`] = `
   <ModalActions>
     <Button
       as="button"
-      basic={true}
-      color="black"
-      inverted={true}
       onClick={[Function]}
+      secondary={true}
     >
       Back
     </Button>
     <Button
       as="button"
       color="red"
-      inverted={true}
       onClick={[Function]}
     >
       <Icon

--- a/src/lib/components/Error/Error.js
+++ b/src/lib/components/Error/Error.js
@@ -5,16 +5,18 @@ import React, { Component } from 'react';
 import { Container, Message } from 'semantic-ui-react';
 import { DefaultFallbackComponent } from './DefaultFallbackComponent';
 
-const isAPIError = (error) => {
+export const isAPIError = (error) => {
   return get(error, 'response.data.message') !== undefined;
 };
 
-export const shouldShowErrorPage = (error) => {
-  if (!isAPIError(error)) {
-    return true;
+const shouldShowErrorPage = (error) => {
+  if (isAPIError(error)) {
+    // do not display the error in a full page, show the error only in the specific component (probably a notification).
+    return false;
   }
-
-  return error.response.status !== 400;
+  // when the exception is handled, we don't want to display a full page error (probably a notification).
+  const handledException = error?.response?.status === 400;
+  return handledException ? false : true;
 };
 
 export class Error extends Component {

--- a/src/lib/components/Notifications/actions.js
+++ b/src/lib/components/Notifications/actions.js
@@ -1,4 +1,4 @@
-import { shouldShowErrorPage } from '@components/Error/Error';
+import { isAPIError } from '@components/Error/Error';
 
 export const ADD = 'notifications/ADD';
 export const REMOVE = 'notifications/REMOVE';
@@ -6,13 +6,14 @@ export const CLEAR_ALL = 'notifications/CLEAR_ALL';
 
 export const sendErrorNotification = (error) => {
   return (dispatch) => {
-    if (!shouldShowErrorPage(error)) {
+    if (isAPIError(error)) {
       const errorData = error.response.data;
       const { error_module: errorModule, message } = errorData;
 
       const title = errorModule ? `${errorModule}` : 'Something went wrong';
-
       dispatch(addNotification(title, message, 'error'));
+    } else {
+      dispatch(addNotification('Something went wrong', error.message, 'error'));
     }
   };
 };

--- a/src/lib/modules/Loan/actions.js
+++ b/src/lib/modules/Loan/actions.js
@@ -3,6 +3,7 @@ import { searchReady } from '@api/utils';
 import {
   sendErrorNotification,
   sendSuccessNotification,
+  addNotification,
 } from '@components/Notifications';
 import { fetchItemDetails } from './../../pages/backoffice/Item/ItemDetails/state/actions';
 import { invenioConfig } from '@config';
@@ -37,7 +38,7 @@ export const fetchLoanDetails = (
             .query()
             .withDocPid(response.data.metadata.document_pid)
             .withState(invenioConfig.CIRCULATION.loanRequestStates)
-            .sortByRequestStartDate()
+            .sortByRequestStartDateAsc()
             .qs()
         );
         if (pendingLoansResponse.data.total > 0) {
@@ -103,7 +104,8 @@ export const performLoanAction = (
         type: ACTION_HAS_ERROR,
         payload: error,
       });
-      dispatch(sendErrorNotification(error));
+      // TODO: Fix sendErrorNotification and use it here.
+      dispatch(addNotification('Error', error.message, 'error'));
     }
   };
 };

--- a/src/lib/modules/Loan/actions.js
+++ b/src/lib/modules/Loan/actions.js
@@ -3,10 +3,9 @@ import { searchReady } from '@api/utils';
 import {
   sendErrorNotification,
   sendSuccessNotification,
-  addNotification,
 } from '@components/Notifications';
-import { fetchItemDetails } from './../../pages/backoffice/Item/ItemDetails/state/actions';
 import { invenioConfig } from '@config';
+import { fetchItemDetails } from './../../pages/backoffice/Item/ItemDetails/state/actions';
 
 export const ACTION_IS_LOADING = 'loanAction/IS_LOADING';
 export const ACTION_SUCCESS = 'loanAction/SUCCESS';
@@ -104,8 +103,7 @@ export const performLoanAction = (
         type: ACTION_HAS_ERROR,
         payload: error,
       });
-      // TODO: Fix sendErrorNotification and use it here.
-      dispatch(addNotification('Error', error.message, 'error'));
+      dispatch(sendErrorNotification(error));
     }
   };
 };

--- a/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/state/actions.js
+++ b/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/state/actions.js
@@ -1,9 +1,9 @@
 import { itemApi } from '@api/items';
 import { loanApi } from '@api/loans';
 import {
+  addNotification,
   sendErrorNotification,
   sendSuccessNotification,
-  addNotification,
 } from '@components/Notifications';
 
 export const LOAN_IS_LOADING = 'itemLoansSearch/IS_LOADING';
@@ -63,7 +63,7 @@ export const checkin = (barcode, onSuccess) => {
         type: LOAN_HAS_ERROR,
         payload: error,
       });
-      dispatch(sendErrorNotification('Error'));
+      dispatch(sendErrorNotification(error));
     }
   };
 };

--- a/src/lib/pages/backoffice/Actions/CheckOut/state/actions.js
+++ b/src/lib/pages/backoffice/Actions/CheckOut/state/actions.js
@@ -88,7 +88,7 @@ export const checkOutSearch = (term) => {
         type: SEARCH_HAS_ERROR,
         payload: error,
       });
-      dispatch(sendErrorNotification('Error'));
+      dispatch(sendErrorNotification(error));
     }
   };
 };

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/CancelButton.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/CancelButton.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { CancelModal } from '@components/CancelModal';
+
+export const CancelLoanModal = ({ pid, isLoading, cancelAction }) => {
+  return (
+    <CancelModal
+      header={`Cancel Loan #${pid}`}
+      content={`You are about to cancel loan #${pid}.
+    Please enter a reason for cancelling this loan.`}
+      cancelText="Cancel Loan"
+      buttonText="Cancel"
+      action={cancelAction}
+      isLoading={isLoading}
+    />
+  );
+};
+
+CancelLoanModal.propTypes = {
+  pid: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  cancelAction: PropTypes.func.isRequired,
+};

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal/ExtendModal.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal/ExtendModal.js
@@ -1,0 +1,120 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Modal, Header, Icon, Grid } from 'semantic-ui-react';
+import { withCancel } from '@api/utils';
+import { documentApi } from '@api/documents';
+
+export default class ExtendModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      overbooked: false,
+      open: false,
+    };
+  }
+
+  componentDidMount() {
+    this.fetchCirculation();
+  }
+
+  componentWillUnmount() {
+    this.cancellableCirculation && this.cancellableCirculation.cancel();
+  }
+
+  fetchCirculation = async () => {
+    const { loanDetails, sendErrorNotification } = this.props;
+    const { document_pid } = loanDetails.metadata;
+    try {
+      this.cancellableCirculation = withCancel(documentApi.get(document_pid));
+      const response = await this.cancellableCirculation.promise;
+      const circulation = response.data.metadata.circulation;
+      this.setState({
+        overbooked: circulation.overbooked === true,
+      });
+    } catch (error) {
+      if (error !== 'UNMOUNTED') {
+        sendErrorNotification(
+          'Something went wrong while checking if the literature is overbooked.',
+          'If the problem persists, please contact technical support.'
+        );
+      }
+    }
+  };
+
+  extend = () => {
+    const { loanAction } = this.props;
+    loanAction();
+    this.hide();
+  };
+
+  hide = () => this.setState({ open: false });
+  show = () => this.setState({ open: true });
+
+  render() {
+    const { pid, isLoading } = this.props;
+    const { open, overbooked } = this.state;
+    return (
+      <>
+        {overbooked ? (
+          <Modal
+            size="small"
+            trigger={
+              <Button
+                primary
+                fluid
+                content="Extend"
+                onClick={this.show}
+                loading={isLoading}
+                disabled={isLoading}
+              />
+            }
+            open={open}
+            onClose={this.hide}
+          >
+            <Header content={`Extend Loan #${pid}`} />
+            <Modal.Content>
+              <Grid>
+                <Grid.Column width={1}>
+                  <Icon name="warning sign" color="red" size="large" />
+                </Grid.Column>
+                <Grid.Column width={15}>
+                  <p>
+                    {`Are you sure you want to extend the loan #${pid}?
+            This literature is overbooked.`}
+                  </p>
+                </Grid.Column>
+              </Grid>
+            </Modal.Content>
+            <Modal.Actions>
+              <Button secondary onClick={this.hide}>
+                Cancel
+              </Button>
+              <Button primary onClick={this.extend}>
+                Extend
+              </Button>
+            </Modal.Actions>
+          </Modal>
+        ) : (
+          <Button
+            size="small"
+            fluid
+            primary
+            onClick={this.extend}
+            loading={isLoading}
+            disabled={isLoading}
+          >
+            Extend
+          </Button>
+        )}
+      </>
+    );
+  }
+}
+
+ExtendModal.propTypes = {
+  pid: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+  loanAction: PropTypes.func.isRequired,
+  loanDetails: PropTypes.object.isRequired,
+  sendErrorNotification: PropTypes.func.isRequired,
+};

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal/index.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal/index.js
@@ -1,0 +1,13 @@
+import { addNotification } from '@components/Notifications';
+import { connect } from 'react-redux';
+import ExtendModalComponent from './ExtendModal';
+
+const mapDispatchToProps = (dispatch) => ({
+  sendErrorNotification: (title, message) =>
+    dispatch(addNotification(title, message, 'error')),
+});
+
+export const ExtendModal = connect(
+  null,
+  mapDispatchToProps
+)(ExtendModalComponent);

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
@@ -3,14 +3,15 @@ import { InfoMessage } from '@components/backoffice/InfoMessage';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { List, Button } from 'semantic-ui-react';
+import { ExtendModal } from '@pages/backoffice/Loan/LoanDetails/LoanActions/ExtendModal';
+import { CancelLoanModal } from './CancelButton';
 import { omit } from 'lodash/object';
-import { CancelModal } from '@components/CancelModal';
 import _isEmpty from 'lodash/isEmpty';
 import capitalize from 'lodash/capitalize';
 
 export default class LoanActions extends Component {
   renderAvailableActions(pid, patronPid, documentPid, itemPid, actions = {}) {
-    const { performLoanAction, isLoading } = this.props;
+    const { performLoanAction, isLoading, loanDetails } = this.props;
 
     // omit checkout because it must done in one of the available items
     if (!itemPid) {
@@ -27,14 +28,17 @@ export default class LoanActions extends Component {
       return (
         <List.Item key={action}>
           {action === 'cancel' ? (
-            <CancelModal
-              header={`Cancel Loan #${pid}`}
-              content={`You are about to cancel loan #${pid}.
-                Please enter a reason for cancelling this loan.`}
-              cancelText="Cancel Loan"
-              buttonText={capitalize('cancel')}
-              action={cancelAction}
+            <CancelLoanModal
+              pid={pid}
               isLoading={isLoading}
+              cancelAction={cancelAction}
+            />
+          ) : action === 'extend' ? (
+            <ExtendModal
+              pid={pid}
+              isLoading={isLoading}
+              loanAction={loanAction}
+              loanDetails={loanDetails}
             />
           ) : (
             <Button


### PR DESCRIPTION
Fix the cancel modal of loan actions.
closes: CERNDocumentServer/cds-ils#663
re-implements: https://github.com/inveniosoftware/react-invenio-app-ils/pull/508

Modal:
![Screenshot from 2021-12-01 15-02-13](https://user-images.githubusercontent.com/25476209/144248631-5fd4b5ae-963d-4782-8221-58d51f0fc143.png)

After successfully pressing extend:
![Screenshot from 2021-12-01 15-02-20](https://user-images.githubusercontent.com/25476209/144248897-81a2f857-9b75-48e4-b017-e9291da5c0ed.png)


After unsuccessfully pressing extend:
![Screenshot from 2021-12-01 15-02-35](https://user-images.githubusercontent.com/25476209/144248720-c4bda683-bfe3-49ee-88c2-05c56e10edc5.png)


