### PR TITLE
RSJF: Fix bug on enter press

### DIFF
--- a/src/lib/forms/rjsf/RJSForm.js
+++ b/src/lib/forms/rjsf/RJSForm.js
@@ -56,6 +56,25 @@ export class RJSForm extends Component {
     };
   }
 
+  componentDidMount() {
+    const inputs = document.getElementsByTagName('input');
+
+    this.ignoreEnterEvent(inputs);
+  }
+
+  ignoreEnterEvent = (inputElements) => {
+    /* For unknown reasons empty fields are spawned when pressing
+    the 'enter' key inside a RJSF input element so we have to manually prevent it*/
+
+    for (const input of inputElements) {
+      const isRJSFInput = input.id.includes('root');
+      if (isRJSFInput) {
+        input.onkeydown = (event) =>
+          event.key === 'Enter' ? event.preventDefault() : null;
+      }
+    }
+  };
+
   getGenericError(message) {
     return { Error: { __errors: [message] } };
   }


### PR DESCRIPTION
Now disables the onEnter event on RJSF inputs because it was causing some odd behaviour with empty fields spawning out of nowhere when pressing enter.

closes https://github.com/CERNDocumentServer/cds-ils/issues/673