### PR TITLE
backoffice: Add alternative titles to details page

### DIFF
--- a/src/lib/modules/Document/DocumentAlternativeAbstracts.js
+++ b/src/lib/modules/Document/DocumentAlternativeAbstracts.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Overridable from 'react-overridable';
+import { List } from 'semantic-ui-react';
+import _isEmpty from 'lodash/isEmpty';
+import { ShowMoreContent } from '@components/ShowMoreContent';
+
+class DocumentAlternativeAbstracts extends Component {
+  render() {
+    const {
+      metadata: { alternative_abstracts: alternativeAbstracts },
+    } = this.props;
+    if (_isEmpty(alternativeAbstracts))
+      return 'There are no alternative abstracts';
+    return (
+      <Overridable id="DocumentAlternativeAbstracts.layout" {...this.props}>
+        <List ordered>
+          {alternativeAbstracts.map((entry) => (
+            <List.Item key={entry}>
+              <ShowMoreContent content={entry} lines={10} />
+            </List.Item>
+          ))}
+        </List>
+      </Overridable>
+    );
+  }
+}
+
+DocumentAlternativeAbstracts.propTypes = {
+  metadata: PropTypes.object.isRequired,
+};
+
+export default Overridable.component(
+  'DocumentAlternativeAbstracts',
+  DocumentAlternativeAbstracts
+);

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentContents.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentContents.js
@@ -7,6 +7,7 @@ import _isEmpty from 'lodash/isEmpty';
 import { ShowMoreContent } from '@components/ShowMoreContent';
 import LiteratureTags from '@modules/Literature/LiteratureTags';
 import LiteratureKeywords from '@modules/Literature/LiteratureKeywords';
+import DocumentAlternativeAbstracts from '@modules/Document/DocumentAlternativeAbstracts';
 
 export class DocumentContents extends Component {
   render() {
@@ -30,6 +31,9 @@ export class DocumentContents extends Component {
         ) : (
           'There is no abstract'
         )}
+
+        <Header as="h3">Alternative Abstracts</Header>
+        <DocumentAlternativeAbstracts metadata={metadata} />
 
         <Header as="h3">Physical description</Header>
         {!_isEmpty(physicalDescription) ? (

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentMetadataGeneral.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentMetadata/DocumentMetadataGeneral.js
@@ -8,7 +8,7 @@ import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Container, Divider } from 'semantic-ui-react';
+import { Container, Divider, List } from 'semantic-ui-react';
 import { groupedSchemeValueList } from '@components/backoffice/utils';
 import { invenioConfig } from '@config';
 
@@ -58,6 +58,24 @@ export class DocumentMetadataGeneral extends Component {
           <Link to={BackOfficeRoutes.documentRequestDetailsFor(request.pid)}>
             {request.state}
           </Link>
+        ),
+      });
+    }
+
+    const alternativeTitles = document.metadata.alternative_titles;
+    if (!_isEmpty(alternativeTitles)) {
+      rows.splice(1, 0, {
+        name: 'Alternative titles',
+        value: (
+          <List bulleted>
+            {document.metadata.alternative_titles.map((entry) => (
+              <List.Item key={entry.value}>
+                <List.Content>
+                  {entry.value + '(' + entry.type + ')'}
+                </List.Content>
+              </List.Item>
+            ))}
+          </List>
         ),
       });
     }


### PR DESCRIPTION
## ALternative titles
![image](https://user-images.githubusercontent.com/15194802/151839525-62235932-27eb-4a52-a284-f3308b7b3826.png)

## Alternative abstracts
![image](https://user-images.githubusercontent.com/15194802/151839578-8e266302-0cb5-449a-8e08-207c1b03d474.png)

