### PR TITLE
attach multipart modal: fix cover image appearing

### DIFF
--- a/src/lib/modules/Document/DocumentCard/DocumentCard.js
+++ b/src/lib/modules/Document/DocumentCard/DocumentCard.js
@@ -120,4 +120,4 @@ DocumentCard.defaultProps = {
   volume: null,
 };
 
-export default Overridable.component('DocumenteCard', DocumentCard);
+export default Overridable.component('DocumentCard', DocumentCard);

--- a/src/lib/modules/Relations/backoffice/components/RelationCard/SeriesCard.js
+++ b/src/lib/modules/Relations/backoffice/components/RelationCard/SeriesCard.js
@@ -1,4 +1,3 @@
-import { SeriesIcon } from '@components/backoffice/icons';
 import LiteratureTitle from '@modules/Literature/LiteratureTitle';
 import { SeriesAuthors } from '@modules/Series/SeriesAuthors';
 import { BackOfficeRoutes } from '@routes/urls';
@@ -8,7 +7,6 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Card } from 'semantic-ui-react';
 import _get from 'lodash/get';
-import { recordToPidType } from '@api/utils';
 import LiteratureCover from '@modules/Literature/LiteratureCover';
 
 export default class SeriesCard extends Component {
@@ -21,14 +19,10 @@ export default class SeriesCard extends Component {
           {actions}
           {data.metadata.series_type || data.metadata.mode_of_issuance}
         </Card.Meta>
-        {recordToPidType(data) === 'serid' ? (
-          <LiteratureCover
-            size="small"
-            url={_get(data, 'metadata.cover_metadata.urls.medium')}
-          />
-        ) : (
-          <SeriesIcon size="huge" color="grey" />
-        )}
+        <LiteratureCover
+          size="small"
+          url={_get(data, 'metadata.cover_metadata.urls.medium')}
+        />
         <Card.Content>
           <Card.Header as={Link} to={linkTo} target="_blank">
             <LiteratureTitle title={data.metadata.title} />

--- a/src/lib/modules/Relations/backoffice/components/RelationCard/SeriesCard.js
+++ b/src/lib/modules/Relations/backoffice/components/RelationCard/SeriesCard.js
@@ -7,6 +7,9 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { Card } from 'semantic-ui-react';
+import _get from 'lodash/get';
+import { recordToPidType } from '@api/utils';
+import LiteratureCover from '@modules/Literature/LiteratureCover';
 
 export default class SeriesCard extends Component {
   render() {
@@ -18,7 +21,14 @@ export default class SeriesCard extends Component {
           {actions}
           {data.metadata.series_type || data.metadata.mode_of_issuance}
         </Card.Meta>
-        <SeriesIcon size="huge" color="grey" />
+        {recordToPidType(data) === 'serid' ? (
+          <LiteratureCover
+            size="small"
+            url={_get(data, 'metadata.cover_metadata.urls.medium')}
+          />
+        ) : (
+          <SeriesIcon size="huge" color="grey" />
+        )}
         <Card.Content>
           <Card.Header as={Link} to={linkTo} target="_blank">
             <LiteratureTitle title={data.metadata.title} />


### PR DESCRIPTION
* add missing covering component to multipart and serials attaching modals
* fix overridable component name
* closes https://github.com/inveniosoftware/react-invenio-app-ils/issues/424


Covers appearing preview:
![cover appearing prefill](https://user-images.githubusercontent.com/61321254/181294583-6ea2c6b8-2ae5-4b9e-9ec5-f390cfee1736.gif)

