### PR TITLE
http error pages: add page for 400 error code

### DIFF
--- a/src/lib/api/base.js
+++ b/src/lib/api/base.js
@@ -11,7 +11,7 @@ const apiConfig = {
 };
 const http = axios.create(apiConfig);
 
-const HTTP_STATUS_CODES_WITH_ERROR_PAGE = [404, 429, 500];
+const HTTP_STATUS_CODES_WITH_ERROR_PAGE = [400, 404, 429, 500];
 const URLS_NOT_TO_REDIRECT_IF_UNAUTHORIZED = ['/me', '/me/loans'];
 // CSRF possible errors
 const CSRF_ERROR_REASON_NO_COOKIE = 'CSRF cookie';

--- a/src/lib/api/base.test.js
+++ b/src/lib/api/base.test.js
@@ -25,47 +25,6 @@ describe('Axios response interceptor tests no error', () => {
 
     return promise;
   });
-
-  it('should do not nothing if generic 400 error without message', () => {
-    const errorPayload = {
-      config: {
-        url: '/backoffice',
-      },
-      response: {
-        status: 400,
-      },
-    };
-    const promise = expect(
-      errorInterceptor.rejected(errorPayload)
-    ).rejects.toMatchObject(errorPayload);
-
-    expect(goTo).not.toHaveBeenCalled();
-    expect(replaceTo).not.toHaveBeenCalled();
-
-    return promise;
-  });
-
-  it('should do not nothing if generic 400 error with no CSRF message', () => {
-    const errorPayload = {
-      config: {
-        url: '/backoffice',
-      },
-      response: {
-        status: 400,
-        data: {
-          message: 'another error...',
-        },
-      },
-    };
-    const promise = expect(
-      errorInterceptor.rejected(errorPayload)
-    ).rejects.toMatchObject(errorPayload);
-
-    expect(goTo).not.toHaveBeenCalled();
-    expect(replaceTo).not.toHaveBeenCalled();
-
-    return promise;
-  });
 });
 
 describe('Axios response interceptor tests for 401', () => {
@@ -127,7 +86,7 @@ describe('Axios response interceptor tests for 401', () => {
   });
 });
 
-describe('Axios response interceptor tests for CSRF errors', () => {
+describe('Axios response interceptor tests for CSRF error related cases', () => {
   it('should retry on CSRF cookie/token missing errors', () => {
     const errorPayload = {
       config: {
@@ -175,13 +134,54 @@ describe('Axios response interceptor tests for CSRF errors', () => {
     ).rejects.toMatchObject(errorPayload);
 
     expect(goTo).not.toHaveBeenCalled();
-    expect(replaceTo).not.toHaveBeenCalled();
+    expect(replaceTo).toHaveBeenCalledWith('/error', { errorCode: 400 });
+
+    return promise;
+  });
+
+  it('should redirect to error page if generic 400 error with no CSRF message', () => {
+    const errorPayload = {
+      config: {
+        url: '/backoffice',
+      },
+      response: {
+        status: 400,
+        data: {
+          message: 'another error...',
+        },
+      },
+    };
+    const promise = expect(
+      errorInterceptor.rejected(errorPayload)
+    ).rejects.toMatchObject(errorPayload);
+
+    expect(goTo).not.toHaveBeenCalled();
+    expect(replaceTo).toHaveBeenCalledWith('/error', { errorCode: 400 });
 
     return promise;
   });
 });
 
 describe('Axios response interceptor tests for errors with dedicated page', () => {
+  it('should redirect to error page on 400', () => {
+    const errorPayload = {
+      config: {
+        url: '/api/importer/non-existing/cancel',
+      },
+      response: {
+        status: 400,
+      },
+    };
+    const promise = expect(
+      errorInterceptor.rejected(errorPayload)
+    ).rejects.toMatchObject(errorPayload);
+
+    expect(goTo).not.toHaveBeenCalled();
+    expect(replaceTo).toHaveBeenCalledWith('/error', { errorCode: 400 });
+
+    return promise;
+  });
+
   it('should redirect to error page on 404', () => {
     const errorPayload = {
       config: {

--- a/src/lib/components/HttpErrors/HttpErrors.js
+++ b/src/lib/components/HttpErrors/HttpErrors.js
@@ -122,3 +122,25 @@ export const InternalServerError = Overridable.component(
   'InternalServerError',
   InternalServerErrorComponent
 );
+
+function BadRequestComponent(props) {
+  const {
+    title = 'Bad Request',
+    message = 'Something went wrong while processing your request. Please contact our support team if the problem persists. (Error code: 400)',
+    icon = 'warning',
+  } = props;
+  const newProps = { ...props, ...{ title, message, icon } };
+  return (
+    <Overridable id="BadRequest.layout" {...newProps}>
+      <HttpError {...newProps} />
+    </Overridable>
+  );
+}
+
+BadRequestComponent.propTypes = propTypes;
+BadRequestComponent.defaultProps = defaultProps;
+
+export const BadRequest = Overridable.component(
+  'BadRequest',
+  BadRequestComponent
+);

--- a/src/lib/components/HttpErrors/index.js
+++ b/src/lib/components/HttpErrors/index.js
@@ -4,6 +4,7 @@ export {
   NotFound,
   TooManyRequests,
   InternalServerError,
+  BadRequest,
 } from './HttpErrors';
 
 export { default as HttpError } from './HttpError';

--- a/src/lib/pages/frontsite/ErrorsPage/ErrorsPage.js
+++ b/src/lib/pages/frontsite/ErrorsPage/ErrorsPage.js
@@ -3,6 +3,7 @@ import {
   InternalServerError,
   NotFound,
   TooManyRequests,
+  BadRequest,
 } from '@components/HttpErrors';
 
 export class ErrorsPage extends Component {
@@ -19,6 +20,8 @@ export class ErrorsPage extends Component {
         return <NotFound />;
       } else if (params.errorCode === 429) {
         return <TooManyRequests />;
+      } else if (params.errorCode === 400) {
+        return <BadRequest />;
       }
     }
     return null;


### PR DESCRIPTION
* add component for displaying bad request error page
* fix 400-error related tests
* addresses https://github.com/CERNDocumentServer/cds-ils/issues/759

Bad Request error page preview:
![Screenshot 2022-08-08 at 14 52 33](https://user-images.githubusercontent.com/61321254/183900833-8c06920c-d0b7-4c26-b713-0c2f2c62c7b6.png)

