### PR TITLE
improve series search tip popup, fix searchbar autofocus

### DIFF
--- a/src/lib/components/SearchBar/SearchBarILS.js
+++ b/src/lib/components/SearchBar/SearchBarILS.js
@@ -10,11 +10,9 @@ export class SearchBarILS extends Component {
   state = { currentValue: '' };
 
   componentDidMount() {
-    const { responsiveAutofocus } = this.props;
+    const { focusOnRender } = this.props;
     const autofocus = screenIsWiderThan(Breakpoints.computer);
-    if (responsiveAutofocus && autofocus) {
-      this.inputRef.current.focus();
-    } else if (!responsiveAutofocus) {
+    if (focusOnRender && autofocus) {
       this.inputRef.current.focus();
     }
   }
@@ -50,7 +48,7 @@ export class SearchBarILS extends Component {
       onChangeHandler,
       placeholder,
       ref,
-      responsiveAutofocus,
+      focusOnRender,
       ...rest
     } = this.props;
     const { currentValue } = this.state;
@@ -86,7 +84,7 @@ SearchBarILS.propTypes = {
   onChangeHandler: PropTypes.func,
   placeholder: PropTypes.string,
   className: PropTypes.string,
-  responsiveAutofocus: PropTypes.bool,
+  focusOnRender: PropTypes.bool,
 };
 
 SearchBarILS.defaultProps = {
@@ -95,6 +93,6 @@ SearchBarILS.defaultProps = {
   onChangeHandler: null,
   placeholder: '',
   className: '',
-  responsiveAutofocus: false,
+  focusOnRender: true,
   ref: null,
 };

--- a/src/lib/components/SearchBar/__snapshots__/SearchBarILS.test.js.snap
+++ b/src/lib/components/SearchBar/__snapshots__/SearchBarILS.test.js.snap
@@ -3,13 +3,13 @@
 exports[`SearchBar tests should match snapshot 1`] = `
 <SearchBarILS
   className=""
+  focusOnRender={true}
   onChangeHandler={null}
   onKeyPressHandler={null}
   onPasteHandler={null}
   onSearchHandler={[Function]}
   placeholder="Search"
   ref={null}
-  responsiveAutofocus={false}
 >
   <Input
     action={

--- a/src/lib/modules/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
+++ b/src/lib/modules/Series/SeriesLiteratureSearch/SeriesLiteratureSearch.js
@@ -1,7 +1,6 @@
 import { literatureApi } from '@api/literature';
 import { Media } from '@components/Media';
 import {
-  invenioConfig,
   setReactSearchKitDefaultSortingOnEmptyQueryString,
   setReactSearchKitInitialQueryState,
   setReactSearchKitUrlHandler,
@@ -21,21 +20,16 @@ import {
   ReactSearchKit,
   ResultsLoader,
   ResultsMultiLayout,
-  SearchBar,
+  withState,
 } from 'react-searchkit';
-import { Container, Divider, Loader, Popup, Icon } from 'semantic-ui-react';
+import { Container, Divider, Popup } from 'semantic-ui-react';
 import { SearchBarOverridesMap } from '@components/SearchBar/SearchBarOverrides';
 import { qsBuilderForSeries } from './RequestSerializer';
 import { SeriesLiteratureSearchMobile } from './SeriesLiteratureSearchMobile';
+import { SearchBarILS } from '@components/SearchBar';
 
 export class SeriesLiteratureSearch extends React.Component {
   modelName = 'LITERATURE';
-
-  renderLoader = () => {
-    return (
-      <Loader active size="huge" inline="centered" className="full-height" />
-    );
-  };
 
   render() {
     const { metadata } = this.props;
@@ -72,18 +66,10 @@ export class SeriesLiteratureSearch extends React.Component {
           >
             <>
               <Container className="series-details-search-container">
-                <SearchBar
-                  placeholder="Search for volumes or issues..."
-                  {...invenioConfig.APP.SEARCH_BAR_PROPS}
-                  responsiveAutofocus
-                />
-                <Popup
-                  content="You can search by volume using volume field (e.g., volume:1)"
-                  trigger={<Icon name="question circle outline" size="small" />}
-                />
+                <SeriesDetailsSearch />
               </Container>
               <Media greaterThanOrEqual="computer">
-                <ResultsLoader renderElement={this.renderLoader}>
+                <ResultsLoader>
                   <EmptyResults />
                   <Error />
                   <SearchControls modelName={this.modelName} />
@@ -105,3 +91,25 @@ export class SeriesLiteratureSearch extends React.Component {
 SeriesLiteratureSearch.propTypes = {
   metadata: PropTypes.object.isRequired,
 };
+
+const SeriesDetailsSearch = withState(
+  ({ updateQueryState, currentQueryState }) => {
+    const onBtnSearchClick = (queryString) => {
+      updateQueryState({ ...currentQueryState, queryString: queryString });
+    };
+
+    return (
+      <Popup
+        trigger={
+          <SearchBarILS
+            onSearchHandler={onBtnSearchClick}
+            placeholder="Search for volumes or issues..."
+            focusOnRender={false}
+          />
+        }
+        content="You can search by volume using volume field (e.g., volume:1)"
+        on="focus"
+      />
+    );
+  }
+);

--- a/src/lib/modules/Series/SeriesLiteratureSearch/__snapshots__/SeriesLiteratureSearch.test.js.snap
+++ b/src/lib/modules/Series/SeriesLiteratureSearch/__snapshots__/SeriesLiteratureSearch.test.js.snap
@@ -100,12 +100,11 @@ exports[`SeriesLiteratureSearch tests should load the SeriesLiteratureSearch com
         <Connect(Overridable(ResultsLoader$1))>
           <Connect(Overridable(EmptyResults)) />
           <Connect(Overridable(Error$2)) />
-          <SearchControls
-            defaultLayout="grid"
+          <Connect(WrappedComponent)
             modelName="LITERATURE"
           />
           <Connect(Overridable(ResultsMultiLayout$1)) />
-          <SearchFooter />
+          <Connect(WrappedComponent) />
         </Connect(Overridable(ResultsLoader$1))>
       </Media>
       <Media

--- a/src/lib/modules/Series/SeriesLiteratureSearch/__snapshots__/SeriesLiteratureSearch.test.js.snap
+++ b/src/lib/modules/Series/SeriesLiteratureSearch/__snapshots__/SeriesLiteratureSearch.test.js.snap
@@ -91,61 +91,22 @@ exports[`SeriesLiteratureSearch tests should load the SeriesLiteratureSearch com
       <Container
         className="series-details-search-container"
       >
-        <Connect(Overridable(SearchBarUncontrolled))
-          actionProps={
-            Object {
-              "content": null,
-              "icon": "search",
-            }
-          }
-          autofocus={true}
-          placeholder="Search for volumes or issues..."
-          responsiveAutofocus={true}
-          uiProps={
-            Object {
-              "className": "ils-searchbar",
-              "fluid": true,
-              "size": "big",
-            }
-          }
-        />
-        <Popup
-          content="You can search by volume using volume field (e.g., volume:1)"
-          disabled={false}
-          eventsEnabled={true}
-          on={
-            Array [
-              "click",
-              "hover",
-            ]
-          }
-          pinned={false}
-          popperModifiers={Array []}
-          position="top left"
-          trigger={
-            <Icon
-              as="i"
-              name="question circle outline"
-              size="small"
-            />
-          }
-        />
+        <Connect(WrappedComponent) />
       </Container>
       <Media
         className=""
         greaterThanOrEqual="computer"
       >
-        <Connect(Overridable(ResultsLoader))
-          renderElement={[Function]}
-        >
+        <Connect(Overridable(ResultsLoader$1))>
           <Connect(Overridable(EmptyResults)) />
-          <Connect(Overridable(Error$1)) />
-          <Connect(WrappedComponent)
+          <Connect(Overridable(Error$2)) />
+          <SearchControls
+            defaultLayout="grid"
             modelName="LITERATURE"
           />
-          <Connect(Overridable(ResultsMultiLayout)) />
-          <Connect(WrappedComponent) />
-        </Connect(Overridable(ResultsLoader))>
+          <Connect(Overridable(ResultsMultiLayout$1)) />
+          <SearchFooter />
+        </Connect(Overridable(ResultsLoader$1))>
       </Media>
       <Media
         className=""

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
@@ -194,7 +194,6 @@ class DocumentDetails extends Component {
                 onSearchHandler={this.onSearchClick}
                 placeholder={invenioConfig.APP.HOME_SEARCH_BAR_PLACEHOLDER}
                 className="fs-headline"
-                responsiveAutofocus
               />
             </Container>
           </Container>

--- a/src/lib/pages/frontsite/Home/Headline/HomeSearchBar.js
+++ b/src/lib/pages/frontsite/Home/Headline/HomeSearchBar.js
@@ -17,7 +17,6 @@ export class HomeSearchBar extends Component {
         onSearchHandler={this.onSearchExecute}
         placeholder={invenioConfig.APP.HOME_SEARCH_BAR_PLACEHOLDER}
         className="fs-headline"
-        responsiveAutofocus
       />
     );
   }

--- a/src/lib/pages/frontsite/Literature/LiteratureSearch/LiteratureSearch.js
+++ b/src/lib/pages/frontsite/Literature/LiteratureSearch/LiteratureSearch.js
@@ -23,7 +23,7 @@ import {
   ResultsMultiLayout,
   SearchBar,
 } from 'react-searchkit';
-import { Container, Grid, Loader } from 'semantic-ui-react';
+import { Container, Grid } from 'semantic-ui-react';
 import { SearchBarOverridesMap } from '@components/SearchBar/SearchBarOverrides';
 import LiteratureSearchMobile from './LiteratureSearchMobile';
 import SearchMessage from './SearchMessage/SearchMessage';
@@ -43,12 +43,6 @@ class LiteratureSearch extends Component {
       response: { reject: responseRejectInterceptor },
     },
   });
-
-  renderLoader = () => {
-    return (
-      <Loader active size="huge" inline="centered" className="full-height" />
-    );
-  };
 
   render() {
     const initialState = setReactSearchKitInitialQueryState(this.modelName);
@@ -84,7 +78,6 @@ class LiteratureSearch extends Component {
                         invenioConfig.APP.HOME_SEARCH_BAR_PLACEHOLDER
                       }
                       {...invenioConfig.APP.SEARCH_BAR_PROPS}
-                      responsiveAutofocus
                     />
                     <SearchGuideLink />
                   </Container>
@@ -97,7 +90,7 @@ class LiteratureSearch extends Component {
                       relaxed
                       className="grid-documents-search"
                     >
-                      <ResultsLoader renderElement={this.renderLoader}>
+                      <ResultsLoader>
                         <Grid.Column width={3} className="search-aggregations">
                           <SearchAggregation modelName={this.modelName} />
                         </Grid.Column>

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
@@ -174,7 +174,6 @@ class SeriesDetails extends React.Component {
                 onSearchHandler={this.onSearchClick}
                 placeholder={invenioConfig.APP.HOME_SEARCH_BAR_PLACEHOLDER}
                 className="fs-headline"
-                responsiveAutofocus
               />
             </Container>
           </Overridable>


### PR DESCRIPTION
* improve series search tip popup
* remove autofocus on series details searchbar
* remove autofocus from all searchbars in mobile view
* cleanup the ResultsLoader
* closes https://github.com/inveniosoftware/react-invenio-app-ils/issues/549


Search tip and autofocus preview:
![search tip popup](https://user-images.githubusercontent.com/61321254/188460871-2f2e0c11-9095-43eb-b077-a7308b03d901.gif)
