### PR TITLE
frontsite: Show Edition and Publication year on Literature page

### DIFF
--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentTitle.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentTitle.js
@@ -2,6 +2,7 @@ import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Header } from 'semantic-ui-react';
+import LiteratureTitle from '@modules/Literature/LiteratureTitle';
 
 export class DocumentTitle extends Component {
   subtitle() {
@@ -22,7 +23,12 @@ export class DocumentTitle extends Component {
       <>
         {metadata.document_type}
         <Header as="h2" className="document-title">
-          {metadata.title}
+          <LiteratureTitle
+            title={metadata.title}
+            edition={metadata.edition}
+            publicationYear={metadata.publication_year}
+            truncate={false}
+          />
           {this.subtitle()}
         </Header>
       </>


### PR DESCRIPTION
#Closes: https://github.com/CERNDocumentServer/cds-ils/issues/830

Before:
![Screenshot 2024-02-06 at 15 40 41](https://github.com/inveniosoftware/react-invenio-app-ils/assets/50872172/4b18dd34-26a7-44fa-9b43-969e54663c4d)

After:
![Screenshot 2024-02-06 at 15 39 26](https://github.com/inveniosoftware/react-invenio-app-ils/assets/50872172/bcb78639-e6c5-45da-ba25-53e3022f9f3b)
