### PR TITLE
frontsite: DocumentDetails: Display volume number near title

### DIFF
--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentTitle.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentPanel/DocumentTitle.js
@@ -1,7 +1,8 @@
 import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
+import _get from 'lodash/get';
 import React, { Component } from 'react';
-import { Header } from 'semantic-ui-react';
+import { Grid, Header, Label } from 'semantic-ui-react';
 import LiteratureTitle from '@modules/Literature/LiteratureTitle';
 
 export class DocumentTitle extends Component {
@@ -19,9 +20,26 @@ export class DocumentTitle extends Component {
 
   render() {
     const { metadata } = this.props;
+    const volume = _get(metadata, 'relations.multipart_monograph[0].volume');
+
     return (
       <>
-        {metadata.document_type}
+        <Grid columns={2}>
+          <Grid.Row>
+            <Grid.Column textAlign="left" only="tablet computer">
+              {metadata.document_type}
+            </Grid.Column>
+            <Grid.Column textAlign="right" only="tablet computer">
+              {volume && <Label>{'Volume ' + volume}</Label>}
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+        <Grid rows={2} textAlign="center">
+          <Grid.Row only="mobile">{metadata.document_type}</Grid.Row>
+          <Grid.Row only="mobile">
+            {volume && <Label>{'Volume ' + volume}</Label>}
+          </Grid.Row>
+        </Grid>
         <Header as="h2" className="document-title">
           <LiteratureTitle
             title={metadata.title}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes: https://github.com/CERNDocumentServer/cds-ils/issues/734

Desktop:
![Screenshot 2024-02-27 at 10 47 57](https://github.com/inveniosoftware/react-invenio-app-ils/assets/50872172/f9bcbbaa-068e-4660-b2c6-0447528a6864)

Mobile:
<img width="735" alt="Screenshot 2024-02-27 at 10 47 30" src="https://github.com/inveniosoftware/react-invenio-app-ils/assets/50872172/ac350d9c-c7a7-4ad8-8a32-b999c54e5a7f">
