### PR TITLE
routes: Render browser tab title based on literature title

### DIFF
--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentDetails.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentDetails.js
@@ -42,6 +42,13 @@ export default class DocumentDetails extends Component {
     if (!samePidFromRouter) {
       fetchDocumentDetails(documentPid);
     }
+
+    const { renderTabTitle, data } = this.props;
+    if (renderTabTitle) {
+      renderTabTitle({
+        title: data.metadata.title,
+      });
+    }
   }
 
   render() {
@@ -104,8 +111,10 @@ DocumentDetails.propTypes = {
       documentPid: PropTypes.string,
     }),
   }).isRequired,
+  renderTabTitle: PropTypes.func,
 };
 
 DocumentDetails.defaultProps = {
   error: null,
+  renderTabTitle: null,
 };

--- a/src/lib/pages/backoffice/EItem/EItemDetails/EItemDetails.js
+++ b/src/lib/pages/backoffice/EItem/EItemDetails/EItemDetails.js
@@ -27,6 +27,13 @@ export default class EItemDetails extends Component {
     if (!samePidFromRouter) {
       fetchEItemDetails(eitemPid);
     }
+
+    const { renderTabTitle, data } = this.props;
+    if (renderTabTitle) {
+      renderTabTitle({
+        title: data.metadata.title,
+      });
+    }
   }
 
   render() {
@@ -77,8 +84,10 @@ EItemDetails.propTypes = {
       eitemPid: PropTypes.string,
     }),
   }).isRequired,
+  renderTabTitle: PropTypes.func,
 };
 
 EItemDetails.defaultProps = {
   error: null,
+  renderTabTitle: null,
 };

--- a/src/lib/pages/frontsite/DocumentRequests/DocumentRequestForm.js
+++ b/src/lib/pages/frontsite/DocumentRequests/DocumentRequestForm.js
@@ -26,6 +26,11 @@ class DocumentRequestForm extends Component {
         ...props.location.state?.formData,
       },
     };
+
+    // const { renderTabTitle } = this.props;
+    // if (renderTabTitle) {
+    //   document.title = renderTabTitle({ title: 'Request Resources' });
+    // }
   }
 
   onSerializeSubmit = (values) => {
@@ -272,6 +277,7 @@ DocumentRequestForm.propTypes = {
   notes: PropTypes.object,
   publisher: PropTypes.object,
   location: PropTypes.object,
+  // renderTabTitle: PropTypes.func,
 };
 
 DocumentRequestForm.defaultProps = {
@@ -343,6 +349,7 @@ DocumentRequestForm.defaultProps = {
     label: 'Publisher',
     placeholder: 'Publisher',
   },
+  // renderTabTitle: null,
 };
 
 export default Overridable.component(

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/DocumentDetails.js
@@ -148,6 +148,13 @@ class DocumentDetails extends Component {
     if (!samePidFromRouter) {
       this.fetchDocumentsDetails(documentPid);
     }
+
+    const { renderTabTitle, documentDetails } = this.props;
+    if (renderTabTitle) {
+      renderTabTitle({
+        title: documentDetails.metadata.title,
+      });
+    }
   }
 
   fetchDocumentsDetails(documentPid) {
@@ -223,10 +230,12 @@ DocumentDetails.propTypes = {
       documentPid: PropTypes.string,
     }),
   }).isRequired,
+  renderTabTitle: PropTypes.func,
 };
 
 DocumentDetails.defaultProps = {
   error: null,
+  renderTabTitle: null,
 };
 
 export default Overridable.component('DocumentDetails', DocumentDetails);

--- a/src/lib/pages/frontsite/PatronProfile/PatronProfile.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronProfile.js
@@ -18,6 +18,11 @@ class PatronProfile extends Component {
       pendingLoansRef: React.createRef(),
       currentDoqRequestsRef: React.createRef(),
     };
+
+    const { renderTabTitle } = this.props;
+    if (renderTabTitle) {
+      renderTabTitle({ title: 'My Profile' });
+    }
   }
 
   tabs = () => {
@@ -83,6 +88,11 @@ class PatronProfile extends Component {
 
 PatronProfile.propTypes = {
   user: PropTypes.object.isRequired,
+  renderTabTitle: PropTypes.func,
+};
+
+PatronProfile.defaultProps = {
+  renderTabTitle: null,
 };
 
 export default Overridable.component('Patron', PatronProfile);

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesDetails.js
@@ -139,6 +139,10 @@ class SeriesDetails extends React.Component {
     if (!samePidFromRouter) {
       this.fetchSeriesDetails(seriesPid);
     }
+    const { renderTabTitle, series } = this.props;
+    if (renderTabTitle) {
+      renderTabTitle({ title: series.metadata.title });
+    }
   }
 
   fetchSeriesDetails(seriesPid) {
@@ -195,10 +199,12 @@ SeriesDetails.propTypes = {
   }).isRequired,
   hasError: PropTypes.bool.isRequired,
   error: PropTypes.object,
+  renderTabTitle: PropTypes.func,
 };
 
 SeriesDetails.defaultProps = {
   error: null,
+  renderTabTitle: null,
 };
 
 export default Overridable.component('SeriesDetails', SeriesDetails);

--- a/src/lib/routes/backoffice/BackOfficeRoutesSwitch.js
+++ b/src/lib/routes/backoffice/BackOfficeRoutesSwitch.js
@@ -46,10 +46,25 @@ import Overridable from 'react-overridable';
 import { Route, Switch } from 'react-router-dom';
 
 export default class BackOfficeRoutesSwitch extends Component {
+  renderTabTitle = ({
+    title,
+    prefix = 'Admin: ',
+    suffix = ' | CERN Library Catalogue',
+  }) => {
+    document.title = `${prefix}${title}${suffix}`;
+  };
+
   render() {
     return (
       <Switch>
-        <Route exact path={BackOfficeRoutes.home} component={Home} />
+        <Route
+          exact
+          path={BackOfficeRoutes.home}
+          render={(props) => {
+            this.renderTabTitle({ prefix: '', title: 'Admin Panel' });
+            return <Home {...props} />;
+          }}
+        />
         {/* documents */}
         <Route
           exact
@@ -69,7 +84,14 @@ export default class BackOfficeRoutesSwitch extends Component {
         <Route
           exact
           path={BackOfficeRoutes.documentDetails}
-          component={DocumentDetails}
+          render={(props) => {
+            return (
+              <DocumentDetails
+                {...props}
+                renderTabTitle={this.renderTabTitle}
+              />
+            );
+          }}
         />
         {/* eitems */}
         <Route
@@ -90,7 +112,11 @@ export default class BackOfficeRoutesSwitch extends Component {
         <Route
           exact
           path={BackOfficeRoutes.eitemDetails}
-          component={EItemDetails}
+          render={(props) => {
+            return (
+              <EItemDetails {...props} renderTabTitle={this.renderTabTitle} />
+            );
+          }}
         />
         {/*/!* items *!/*/}
         <Route exact path={BackOfficeRoutes.itemsList} component={ItemSearch} />

--- a/src/lib/routes/frontsite/Frontsite.js
+++ b/src/lib/routes/frontsite/Frontsite.js
@@ -26,6 +26,10 @@ export default class FrontSite extends Component {
     customStaticPages();
   };
 
+  renderTabTitle = ({ title, suffix = ' | CERN Library Catalogue' }) => {
+    document.title = `${title}${suffix}`;
+  };
+
   render() {
     const staticPagesRoutes = getStaticPagesRoutes();
     return (
@@ -48,22 +52,38 @@ export default class FrontSite extends Component {
             <Route
               exact
               path={FrontSiteRoutes.documentDetails}
-              component={DocumentDetails}
+              render={(props) => (
+                <DocumentDetails
+                  {...props}
+                  renderTabTitle={this.renderTabTitle}
+                />
+              )}
             />
             <Route
               exact
               path={FrontSiteRoutes.seriesDetails}
-              component={SeriesDetails}
+              render={(props) => (
+                <SeriesDetails
+                  {...props}
+                  renderTabTitle={this.renderTabTitle}
+                />
+              )}
             />
             <Route
               exact
               path={FrontSiteRoutes.documentRequestForm}
-              component={DocumentRequestForm}
+              render={(props) => {
+                this.renderTabTitle({ title: 'Request Resources' });
+                return <DocumentRequestForm {...props} />;
+              }}
             />
             <Route
               exact
               path={FrontSiteRoutes.patronProfile}
-              component={PatronProfile}
+              render={(props) => {
+                this.renderTabTitle({ title: 'Your Loans' });
+                return <PatronProfile {...props} />;
+              }}
             />
             <Route
               exact


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Related: https://github.com/CERNDocumentServer/cds-ils/issues/793

Note: This is just an example PR on how the tab title rendering would look code wise, I have listed down some pain points in this approach would be very happy to get some feedback -

1. All the components that would require a browser title would need to have an extra `renderTabTitle` prop
2. If the function is kept on the top level, when going to another component without a title, the previous title gets retained instead of just showing `CERN Library Catalogue` again as it should, fix is it set the `document.title =` to the components.
