### PR TITLE
LocationDatePicker: Disable only non-closure days set in config

### DIFF
--- a/src/lib/modules/Location/LocationDatePicker.js
+++ b/src/lib/modules/Location/LocationDatePicker.js
@@ -4,6 +4,7 @@ import _isEmpty from 'lodash/isEmpty';
 import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { invenioConfig } from '@config';
 
 export class LocationDatePicker extends Component {
   constructor(props) {
@@ -51,6 +52,21 @@ export class LocationDatePicker extends Component {
       });
       if (!isOpen) {
         disabled.push(dateISO);
+      }
+      date = date.plus({ days: 1 });
+    }
+
+    // Disable recent X days including current date as set in the config
+    date = DateTime.fromISO(minDate);
+    let workingDaysToOffset = invenioConfig.CIRCULATION.requestStartOffset;
+    let i = 0;
+    while (workingDaysToOffset > 0) {
+      const dateISO = date.toISODate();
+      if (dateISO === disabled[i]) {
+        i++;
+      } else {
+        disabled.push(dateISO);
+        workingDaysToOffset--;
       }
       date = date.plus({ days: 1 });
     }


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Fixes: https://github.com/CERNDocumentServer/cds-ils/issues/835

Current Date set to 15th Friday
Exception days added as 18th and 19th
Offset is 2 days, resulting in 15th and 20th being disabled.
![Screenshot 2024-03-12 at 17 25 43](https://github.com/inveniosoftware/react-invenio-app-ils/assets/50872172/59a988fb-6fff-4f96-986a-5a7c75212744)
