### PR TITLE
backoffice: PatronDetails: Disable enter key in paste event handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+Version 1.0.0-alpha.82 (released 2024-04-02)
+
+- backoffice: fix onPasteHandler for patron details checkout search
+
 Version 1.0.0-alpha.81 (released 2024-04-02)
 
 - backoffice: fix conditional payment info display for ILLs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inveniosoftware/react-invenio-app-ils",
-  "version": "1.0.0-alpha.81",
+  "version": "1.0.0-alpha.82",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inveniosoftware/react-invenio-app-ils",
-  "version": "1.0.0-alpha.81",
+  "version": "1.0.0-alpha.82",
   "description": "Single Page App built with React for InvenioILS",
   "main": "dist/cjs/index.js",
   "browser": "dist/cjs/index.js",

--- a/src/lib/pages/backoffice/Patron/PatronDetails/ItemsSearch/ItemsSearch.js
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/ItemsSearch/ItemsSearch.js
@@ -42,6 +42,9 @@ export default class ItemsSearch extends Component {
     const { prevSearchQuery } = this.state;
     const { patronDetails } = this.props;
 
+    // Disable enter key
+    event.preventDefault();
+
     let queryString = event.clipboardData.getData('Text');
 
     const sameQueryString = prevSearchQuery === queryString;


### PR DESCRIPTION
:heart: Thank you for your contribution!

Disable enter key in paste handler so that when a paste happens and enter is pressed at the same time, both the onPasteHandler and onSearchHandler should not get triggered in parallel.