### PR TITLE
 linter: allow expressions in JSX fragment 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,12 @@
     "react/jsx-no-comment-textnodes": "error",
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-undef": "error",
-    "react/jsx-no-useless-fragment": "warn",
+    "react/jsx-no-useless-fragment": [
+      "warn",
+      {
+        "allowExpressions": true
+      }
+    ],
     "react/jsx-pascal-case": "error",
     "react/jsx-props-no-multi-spaces": "error",
     "react/jsx-tag-spacing": [

--- a/src/lib/components/Loader/Loader.js
+++ b/src/lib/components/Loader/Loader.js
@@ -11,7 +11,6 @@ class Loader extends Component {
         {isLoading ? (
           <UILoader active size="huge" inline="centered" />
         ) : (
-          // eslint-disable-next-line react/jsx-no-useless-fragment
           <>{children}</>
         )}
       </Overridable>

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderDocumentRequest.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderDocumentRequest.js
@@ -80,13 +80,11 @@ export class OrderDocumentRequest extends React.Component {
   render() {
     const { documentRequest, isLoading, hasError } = this.state;
     return (
-      <>
-        <Loader isLoading={isLoading}>
-          {hasError
-            ? this.renderError()
-            : this.renderResultsOrEmpty(documentRequest)}
-        </Loader>
-      </>
+      <Loader isLoading={isLoading}>
+        {hasError
+          ? this.renderError()
+          : this.renderResultsOrEmpty(documentRequest)}
+      </Loader>
     );
   }
 }

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPurchaseOrders/DocumentPurchaseOrders.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentPurchaseOrders/DocumentPurchaseOrders.js
@@ -126,11 +126,9 @@ export default class DocumentPurchaseOrders extends Component {
   render() {
     const { orders, isLoading, hasError } = this.state;
     return (
-      <>
-        <Loader isLoading={isLoading}>
-          {hasError ? this.renderError() : this.renderResultsOrEmpty(orders)}
-        </Loader>
-      </>
+      <Loader isLoading={isLoading}>
+        {hasError ? this.renderError() : this.renderResultsOrEmpty(orders)}
+      </Loader>
     );
   }
 }

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesPanel/SeriesPanel.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesPanel/SeriesPanel.js
@@ -64,16 +64,14 @@ class SeriesPanel extends Component {
                     />
 
                     {series.metadata.publisher && (
-                      <>
-                        <div>
-                          Published by <b>{series.metadata.publisher}</b>
-                          {series.metadata.publication_year && (
-                            <>
-                              , <b>{series.metadata.publication_year}</b>
-                            </>
-                          )}
-                        </div>
-                      </>
+                      <div>
+                        Published by <b>{series.metadata.publisher}</b>
+                        {series.metadata.publication_year && (
+                          <>
+                            , <b>{series.metadata.publication_year}</b>
+                          </>
+                        )}
+                      </div>
                     )}
                   </ILSParagraphPlaceholder>
                   <ILSParagraphPlaceholder

--- a/src/lib/pages/frontsite/Series/SeriesDetails/SeriesPanel/SeriesPanelMobile.js
+++ b/src/lib/pages/frontsite/Series/SeriesDetails/SeriesPanel/SeriesPanelMobile.js
@@ -43,16 +43,14 @@ class SeriesPanelMobile extends Component {
                   authors={series.metadata.authors}
                 />
                 {series.metadata.publisher && (
-                  <>
-                    <div>
-                      Published by <b>{series.metadata.publisher}</b>
-                      {series.metadata.publication_year && (
-                        <>
-                          , <b>{series.metadata.publication_year}</b>
-                        </>
-                      )}
-                    </div>
-                  </>
+                  <div>
+                    Published by <b>{series.metadata.publisher}</b>
+                    {series.metadata.publication_year && (
+                      <>
+                        , <b>{series.metadata.publication_year}</b>
+                      </>
+                    )}
+                  </div>
                 )}
               </ILSParagraphPlaceholder>
               <ILSParagraphPlaceholder linesNumber={1} isLoading={isLoading}>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

We get quite a lot of ESLint warnings across `inveniosoftware` repositories for following the pattern `<>{foo}</>`.
There are a few places were we explicitly inline-disable the check, and other places were we ignore the warning.

This pull request proposes to relax this ESLint rule to allow this pattern (see the [`react/jsx-no-useless-fragment` documentation](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md#rule-options)).
If you agree with it, I will apply this change to:
* `inveniosoftware/eslint-config-invenio` (https://github.com/inveniosoftware/eslint-config-invenio/pull/16)
* as well as `inveniosoftware/demo-invenioils` (https://github.com/inveniosoftware/demo-invenioils/pull/17)
* and `inveniosoftware/cookiecutter-invenio-ils` (https://github.com/inveniosoftware/cookiecutter-invenio-ils/pull/3)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
