### PR TITLE
Improve handling of 'self checkout' action in backoffice loan page

### DIFF
--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanActions/LoanActions.js
@@ -7,7 +7,7 @@ import { ExtendModal } from '@pages/backoffice/Loan/LoanDetails/LoanActions/Exte
 import { CancelLoanModal } from './CancelButton';
 import { omit } from 'lodash/object';
 import _isEmpty from 'lodash/isEmpty';
-import capitalize from 'lodash/capitalize';
+import startCase from 'lodash/startCase';
 
 export default class LoanActions extends Component {
   renderAvailableActions(pid, patronPid, documentPid, itemPid, actions = {}) {
@@ -49,7 +49,7 @@ export default class LoanActions extends Component {
               loading={isLoading}
               disabled={isLoading}
             >
-              {capitalize(action)}
+              {startCase(action)}
             </Button>
           )}
         </List.Item>


### PR DESCRIPTION
Omit option to self_checkout on loan with no items in backoffice. Previously this produced the following error, as the system does not know which item to 'self checkout'.
<img width="421" height="99" alt="Screenshot 2025-08-26 at 11 15 23" src="https://github.com/user-attachments/assets/fadc0929-e9ec-466e-87ba-4a223bf66b54" />

Also changed formatting of the 'self_checkout' action button text from capitalize first letter to [start case](https://en.wikipedia.org/wiki/Letter_case#Stylistic_or_specialised_usage)
<img width="302" height="184" alt="Screenshot 2025-08-26 at 11 16 49" src="https://github.com/user-attachments/assets/7f1bc016-a19a-4880-98d5-12daa0420755" />
