### PR TITLE
feat: add overbooked confirm modal for librarians

### DIFF
--- a/src/lib/components/OverbookedConfirmModal/OverbookedConfirmModal.js
+++ b/src/lib/components/OverbookedConfirmModal/OverbookedConfirmModal.js
@@ -1,0 +1,65 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button, Modal } from 'semantic-ui-react';
+
+const OverbookedConfirmModal = ({
+  open,
+  onClose,
+  onConfirm,
+  overbookedDocuments,
+}) => {
+  const isMultiple = overbookedDocuments.length > 1;
+
+  return (
+    <Modal size="small" open={open} onClose={onClose}>
+      <Modal.Header>Item in high demand!</Modal.Header>
+
+      <Modal.Content>
+        {overbookedDocuments.map((doc, index) => (
+          <p key={doc.loanRequestId || doc.title || index}>
+            There is another patron waiting for "<strong>{doc.title}</strong>"{' '}
+            {doc.loanRequestId && (
+              <>
+                (
+                <a href={`/backoffice/loans/${doc.loanRequestId}`}>
+                  See loan request
+                </a>
+                )
+              </>
+            )}
+            .
+          </p>
+        ))}
+
+        <p>
+          <strong>
+            Do you still want to extend your {isMultiple ? 'loans' : 'loan'}?
+          </strong>
+        </p>
+      </Modal.Content>
+
+      <Modal.Actions>
+        <Button secondary onClick={onClose}>
+          Cancel
+        </Button>
+        <Button primary onClick={onConfirm}>
+          Extend
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+};
+
+OverbookedConfirmModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  overbookedDocuments: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      loanRequestId: PropTypes.string,
+    })
+  ).isRequired,
+};
+
+export default OverbookedConfirmModal;

--- a/src/lib/components/OverbookedConfirmModal/index.js
+++ b/src/lib/components/OverbookedConfirmModal/index.js
@@ -1,0 +1,1 @@
+export { default as OverbookedConfirmModal } from './OverbookedConfirmModal';

--- a/src/lib/components/utils.js
+++ b/src/lib/components/utils.js
@@ -1,7 +1,21 @@
+import { documentApi } from '@api/documents';
+import { sessionManager } from '@authentication/services/SessionManager';
+import _get from 'lodash/get';
+
 export const prettyPrintBooleanValue = (value) => {
   return value ? 'Yes' : 'No';
 };
 
 export const screenIsWiderThan = (pixels) => {
   return window.matchMedia(`(max-width: ${pixels}px)`).matches ? false : true;
+};
+
+export const isPrivilegedUser = () => {
+  const roles = _get(sessionManager, 'user.roles', []);
+  return roles.includes('admin') || roles.includes('librarian');
+};
+
+export const isDocumentOverbooked = async (documentPid) => {
+  const response = await documentApi.get(documentPid);
+  return _get(response, 'data.metadata.circulation.overbooked', false);
 };

--- a/src/lib/modules/Patron/PatronBulkExtendLoans/PatronBulkExtendLoans.js
+++ b/src/lib/modules/Patron/PatronBulkExtendLoans/PatronBulkExtendLoans.js
@@ -1,15 +1,90 @@
+import { loanApi } from '@api/loans';
 import { invenioConfig } from '@config/index';
+import { OverbookedConfirmModal } from '@components/OverbookedConfirmModal';
+import { isDocumentOverbooked, isPrivilegedUser } from '@components/utils';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Button, Icon, List, Modal } from 'semantic-ui-react';
+import _get from 'lodash/get';
 
 export default class PatronBulkExtendLoans extends Component {
-  state = { open: false };
+  state = {
+    open: false,
+    showOverbookedConfirm: false,
+    overbookedDocuments: [],
+    isChecking: false,
+  };
 
-  open = () => this.setState({ open: true });
-  close = () => this.setState({ open: false });
+  open = async () => {
+    this.setState({ open: true });
+
+    if (!isPrivilegedUser()) return;
+
+    this.setState({ isChecking: true });
+
+    try {
+      const { patronPid } = this.props;
+      // Get all active loans for the patron
+      const query = loanApi
+        .query()
+        .withPatronPid(patronPid)
+        .withState(invenioConfig.CIRCULATION.loanActiveStates)
+        .withSize(invenioConfig.APP.PATRON_PROFILE_MAX_RESULTS_SIZE)
+        .sortByNewest()
+        .qs();
+
+      const response = await loanApi.list(query);
+      const loans = response.data.hits;
+
+      const checks = loans.map(async (loan) => {
+        const documentPid = _get(loan, 'metadata.document.pid');
+        const isOverbooked = await isDocumentOverbooked(documentPid);
+
+        if (isOverbooked) {
+          return {
+            title: loan.metadata.document.title,
+            loanRequestId: loan.id,
+          };
+        }
+        return null;
+      });
+
+      const results = await Promise.all(checks);
+      const overbookedDocuments = results.filter(Boolean);
+
+      this.setState({
+        overbookedDocuments,
+        isChecking: false,
+      });
+    } catch (error) {
+      console.error('Failed to fetch overbooked documents', error);
+      this.setState({ isChecking: false });
+    }
+  };
+
+  close = () => {
+    this.setState({
+      open: false,
+      showOverbookedConfirm: false,
+      overbookedDocuments: [],
+    });
+  };
 
   handleSubmitExtend = () => {
+    const { bulkLoanExtension, patronPid } = this.props;
+    const { overbookedDocuments } = this.state;
+
+    // If the user is privileged and there are overbooked docs
+    if (isPrivilegedUser() && overbookedDocuments.length > 0) {
+      this.setState({ showOverbookedConfirm: true });
+      return;
+    }
+    // Otherwise extend directly
+    bulkLoanExtension(patronPid);
+    this.close();
+  };
+
+  confirmBulkExtension = () => {
     const { bulkLoanExtension, patronPid } = this.props;
 
     bulkLoanExtension(patronPid);
@@ -17,56 +92,71 @@ export default class PatronBulkExtendLoans extends Component {
   };
 
   render() {
-    const { patronPid, bulkLoanExtension, isLoading, disabled, ...uiProps } =
+    const { isLoading, disabled, patronPid, bulkLoanExtension, ...uiProps } =
       this.props;
-    const { open } = this.state;
+    const { open, showOverbookedConfirm, overbookedDocuments, isChecking } =
+      this.state;
+
     return (
-      <Modal
-        open={open}
-        onClose={this.close}
-        onOpen={this.open}
-        trigger={
-          <Button
-            labelPosition="left"
-            fluid
-            icon
-            primary
-            loading={isLoading}
-            disabled={disabled}
-            {...uiProps}
-          >
-            <Icon name="refresh" />
-            Extend all loans
-          </Button>
-        }
-      >
-        <Modal.Header>Confirm extension action</Modal.Header>
-        <Modal.Content>
-          <Modal.Description>
-            The loan duration will be extended for:{' '}
-            <List bulleted>
-              <List.Item>
-                loans that will have to be returned in next{' '}
-                <b>{invenioConfig.CIRCULATION.loanWillExpireDays} days,</b>
-              </List.Item>
-              <List.Item>
-                loans that do not involve third party libraries (Interlibrary
-                Loans),
-              </List.Item>
-              <List.Item>
-                loans for <b>literature not in high demand by other users.</b>
-              </List.Item>
-            </List>
-            Do you want to continue?
-          </Modal.Description>
-        </Modal.Content>
-        <Modal.Actions>
-          <Button onClick={this.close}>Cancel</Button>
-          <Button onClick={this.handleSubmitExtend} primary>
-            Extend the loans
-          </Button>
-        </Modal.Actions>
-      </Modal>
+      <>
+        <OverbookedConfirmModal
+          open={showOverbookedConfirm}
+          onClose={() => this.setState({ showOverbookedConfirm: false })}
+          onConfirm={this.confirmBulkExtension}
+          overbookedDocuments={overbookedDocuments}
+        />
+
+        <Modal
+          open={open}
+          onClose={this.close}
+          onOpen={this.open}
+          trigger={
+            <Button
+              labelPosition="left"
+              fluid
+              icon
+              primary
+              loading={isLoading}
+              disabled={disabled}
+              {...uiProps}
+            >
+              <Icon name="refresh" />
+              Extend all loans
+            </Button>
+          }
+        >
+          <Modal.Header>Confirm extension action</Modal.Header>
+          <Modal.Content>
+            <Modal.Description>
+              The loan duration will be extended for:{' '}
+              <List bulleted>
+                <List.Item>
+                  loans that will have to be returned in next{' '}
+                  <b>{invenioConfig.CIRCULATION.loanWillExpireDays} days,</b>
+                </List.Item>
+                <List.Item>
+                  loans that do not involve third party libraries (Interlibrary
+                  Loans),
+                </List.Item>
+                <List.Item>
+                  loans for <b>literature not in high demand by other users.</b>
+                </List.Item>
+              </List>
+              Do you want to continue?
+            </Modal.Description>
+          </Modal.Content>
+          <Modal.Actions>
+            <Button onClick={this.close}>Cancel</Button>
+            <Button
+              onClick={this.handleSubmitExtend}
+              primary
+              loading={isChecking}
+            >
+              Extend the loans
+            </Button>
+          </Modal.Actions>
+        </Modal>
+      </>
     );
   }
 }


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Librarians and admins can be able to extend their documents without being notified if the document is overbooked.

Added a new modal to warn about overbook:
- `Request extension` warning for extending one document:
<img width="1359" height="748" alt="Screenshot 2026-02-11 at 13 16 23" src="https://github.com/user-attachments/assets/16b4cc1a-88d7-4cc4-a033-cffe49129972" />
- `Extend all loans` warning for extending all
<img width="1217" height="694" alt="Screenshot 2026-02-11 at 13 17 06" src="https://github.com/user-attachments/assets/90c1a912-fec7-4142-9e47-046082f92ef8" />

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
