### PR TITLE
wip: fix DatePicker providing broken initial date

### DIFF
--- a/src/lib/components/DatePicker/DatePicker.js
+++ b/src/lib/components/DatePicker/DatePicker.js
@@ -31,16 +31,44 @@ class DatePicker extends Component {
   };
 
   getInitialDate = (initialDate, disable) => {
-    let firstAvailableDay = DateTime.local();
-    let initialDateChecked = initialDate;
+    const { minDate, maxDate } = this.props;
+
+    let startDate = DateTime.local();
+    if (minDate) {
+      const min = DateTime.fromISO(minDate);
+      if (min.isValid && min > startDate) {
+        startDate = min;
+      }
+    }
+
+    // Find first non-disabled day
+    let firstAvailableDay = startDate;
+    const maxDateLimit = maxDate ? DateTime.fromISO(maxDate) : null;
+
     while (disable.includes(toShortDate(firstAvailableDay))) {
-      firstAvailableDay = new DateTime(firstAvailableDay.plus({ days: 1 }));
+      firstAvailableDay = firstAvailableDay.plus({ days: 1 });
+      if (
+        maxDateLimit &&
+        maxDateLimit.isValid &&
+        firstAvailableDay > maxDateLimit
+      ) {
+        firstAvailableDay = startDate;
+        break;
+      }
     }
-    const firstAvailableDayToShortDate = toShortDate(firstAvailableDay);
-    if (initialDate < firstAvailableDayToShortDate) {
-      initialDateChecked = firstAvailableDayToShortDate;
+
+    const firstAvailableDayStr = toShortDate(firstAvailableDay);
+
+    if (!initialDate || initialDate < firstAvailableDayStr) {
+      return firstAvailableDayStr;
     }
-    return initialDateChecked;
+
+    // Clamp initialDate to maxDate
+    if (maxDate && initialDate > maxDate) {
+      return firstAvailableDayStr;
+    }
+
+    return initialDate;
   };
 
   render() {


### PR DESCRIPTION
closes: https://github.com/inveniosoftware/react-invenio-app-ils/issues/675

The entire changes are vibe-coded and I am sure there is a better option :)
Also as far as I can see the only component making use of the `initialDate` property of the `DatePicker` is the usage of the  `LocationDatePicker`  in the `LoanRequestForm`, but the `LocationDatePicker` overwrites the `initialDate` with `""`