### PR TITLE
updated edition text position

### DIFF
--- a/src/lib/modules/Literature/LiteratureEdition.js
+++ b/src/lib/modules/Literature/LiteratureEdition.js
@@ -13,10 +13,10 @@ class LiteratureEdition extends Component {
 
     return withLabel ? (
       <>
-        <label>edition</label> {edition}
+        {edition} <label>edition</label>
       </>
     ) : (
-      `ed. ${edition}`
+      `${edition} ed.`
     );
   }
 }

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronCurrentBorrowingRequests/__snapshots__/PatronCurrentBorrowingRequests.test.js.snap
@@ -809,7 +809,7 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 
@@ -1043,7 +1043,7 @@ exports[`PatronCurrentBorrowingRequests tests should render patron borrowing req
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 
@@ -2067,7 +2067,7 @@ exports[`PatronCurrentBorrowingRequests tests should render the see all button w
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPastBorrowingRequests/__snapshots__/PatronPastBorrowingRequests.test.js.snap
@@ -816,7 +816,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 
@@ -1042,7 +1042,7 @@ exports[`PatronPastBorrowingRequests tests should render patron borrowing reques
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 
@@ -2054,7 +2054,7 @@ exports[`PatronPastBorrowingRequests tests should render the see all button when
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 

--- a/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
+++ b/src/lib/pages/backoffice/Patron/PatronDetails/PatronPendingLoans/__snapshots__/PatronPendingLoans.test.js.snap
@@ -711,7 +711,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 
@@ -868,7 +868,7 @@ exports[`PatronLoans tests should render patron loans 1`] = `
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 
@@ -1710,7 +1710,7 @@ exports[`PatronLoans tests should render the see all button when showing only a 
                                                         edition="1"
                                                         withLabel={false}
                                                       >
-                                                        ed. 1
+                                                        1 ed.
                                                       </LiteratureEdition>
                                                     </Overridable(LiteratureEdition)>
                                                      - 


### PR DESCRIPTION
### Description

Changed the order of the edition number and description from "ed 2nd" to "2nd ed", closes #909.

* closes https://github.com/CERNDocumentServer/cds-ils/issues/909