### PR TITLE
fixed broken contents display

### DIFF
--- a/src/semantic-ui/site/elements/list.overrides
+++ b/src/semantic-ui/site/elements/list.overrides
@@ -140,3 +140,14 @@ ul.ui.list.no-list-margin {
     padding-left: 0em;
   }
 }
+
+.ui.ordered.list,
+ol.ui.list {
+  margin-left: 2.25rem;
+}
+
+.ui.ordered.list {
+  .item::before {
+    margin-left: 2.25rem;
+  }
+}

--- a/src/semantic-ui/site/elements/list.overrides
+++ b/src/semantic-ui/site/elements/list.overrides
@@ -148,6 +148,6 @@ ol.ui.list {
 
 .ui.ordered.list {
   .item::before {
-    margin-left: 2.25rem;
+    margin-left: -2.25rem;
   }
 }


### PR DESCRIPTION
### Description
Fixed the broken contents display by adding space for three digit contents numbers, did not extend to four as it would be unnecessary and would make the spacing look unnatural for lower numbers so would require custom JS to accommodate for this.

<img width="1447" height="355" alt="image" src="https://github.com/user-attachments/assets/bb0b590c-f441-400d-89a7-291fc1569674" />

<img width="1447" height="355" alt="image" src="https://github.com/user-attachments/assets/8957c1d1-d53b-4f72-918b-d5807e754909" />

* closes https://github.com/CERNDocumentServer/cds-ils/issues/912

