### PR TITLE
update(notifications): added links to notifications for mentioned documents

### DIFF
--- a/src/lib/components/Notifications/Notifications.js
+++ b/src/lib/components/Notifications/Notifications.js
@@ -18,7 +18,7 @@ export default class Notifications extends Component {
         <>
           {before}
           <a
-            style={{ textDecoration: 'underline' }}
+            className="notification-link"
             href={notification.link}
             target="_blank"
             rel="noopener noreferrer"

--- a/src/lib/components/Notifications/Notifications.js
+++ b/src/lib/components/Notifications/Notifications.js
@@ -8,6 +8,27 @@ import PropTypes from 'prop-types';
 import { ErrorMessage, SuccessMessage, WarningMessage } from './messages';
 
 export default class Notifications extends Component {
+  renderMessageContent = (notification) => {
+    const [before, after] = notification.content.split(notification.linkDisplayName);
+
+    if (notification.link) {
+      return (
+        <>
+          {before}
+            <a 
+              style={{ textDecoration: 'underline' }} 
+              href={notification.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {notification.linkDisplayName}
+            </a>
+          {after}
+        </>
+      );
+    } else return notification.content;
+  };
+
   renderNotification(notification) {
     const { removeNotification } = this.props;
 
@@ -23,7 +44,7 @@ export default class Notifications extends Component {
         id={notification.id}
         key={notification.id}
         header={notification.title}
-        content={notification.content}
+        content={this.renderMessageContent(notification)}
         removeNotification={removeNotification}
       />
     );

--- a/src/lib/components/Notifications/Notifications.js
+++ b/src/lib/components/Notifications/Notifications.js
@@ -9,20 +9,22 @@ import { ErrorMessage, SuccessMessage, WarningMessage } from './messages';
 
 export default class Notifications extends Component {
   renderMessageContent = (notification) => {
-    const [before, after] = notification.content.split(notification.linkDisplayName);
+    const [before, after] = notification.content.split(
+      notification.linkDisplayName
+    );
 
     if (notification.link && notification.linkDisplayName) {
       return (
         <>
           {before}
-            <a 
-              style={{ textDecoration: 'underline' }} 
-              href={notification.link}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {notification.linkDisplayName}
-            </a>
+          <a
+            style={{ textDecoration: 'underline' }}
+            href={notification.link}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {notification.linkDisplayName}
+          </a>
           {after}
         </>
       );

--- a/src/lib/components/Notifications/Notifications.js
+++ b/src/lib/components/Notifications/Notifications.js
@@ -11,7 +11,7 @@ export default class Notifications extends Component {
   renderMessageContent = (notification) => {
     const [before, after] = notification.content.split(notification.linkDisplayName);
 
-    if (notification.link) {
+    if (notification.link && notification.linkDisplayName) {
       return (
         <>
           {before}

--- a/src/lib/components/Notifications/actions.js
+++ b/src/lib/components/Notifications/actions.js
@@ -35,13 +35,21 @@ export const sendWarningNotification = (title, content) => {
   return addNotification(title, content, 'warning');
 };
 
-export const addNotification = (title, content, type) => {
+export const addNotification = (
+  title,
+  content,
+  type,
+  link = undefined,
+  linkDisplayName = undefined
+) => {
   return {
     type: ADD,
     payload: {
       type: type,
       title: title,
       content: content,
+      link: link,
+      linkDisplayName: linkDisplayName,
     },
   };
 };

--- a/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/state/actions.js
+++ b/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/state/actions.js
@@ -62,7 +62,7 @@ export const checkin = (barcode, onSuccess) => {
             `No item or no loan for barcode ${barcode}`,
             'error',
             `/backoffice/documents?q=${barcode}`,
-            barcode,
+            barcode
           )
         );
       }

--- a/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/state/actions.js
+++ b/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/state/actions.js
@@ -61,7 +61,7 @@ export const checkin = (barcode, onSuccess) => {
             'Error',
             `No item or no loan for barcode ${barcode}`,
             'error',
-            `/backoffice/documents?q=${barcode}`,
+            `/backoffice/items?q=${barcode}`,
             barcode
           )
         );

--- a/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/state/actions.js
+++ b/src/lib/pages/backoffice/Actions/CheckIn/ItemsSearch/state/actions.js
@@ -60,7 +60,9 @@ export const checkin = (barcode, onSuccess) => {
           addNotification(
             'Error',
             `No item or no loan for barcode ${barcode}`,
-            'error'
+            'error',
+            `/backoffice/documents?q=${barcode}`,
+            barcode,
           )
         );
       }

--- a/src/semantic-ui/site/globals/site.overrides
+++ b/src/semantic-ui/site/globals/site.overrides
@@ -485,6 +485,10 @@ a {
     .message {
       padding-right: 2.5em;
     }
+
+    .notification-link {
+      text-decoration: underline;
+    }
   }
 
   .bo-sidebar {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -4,7 +4,7 @@
  */
 
 import { configure } from 'enzyme';
-// Enzyme has no support for React 18. 
+// Enzyme has no support for React 18.
 // To keep the tests working we added a React 18 adapter for now.
 // The adapter is unofficial and the project should move to a different testing library.
 import Adapter from '@cfaester/enzyme-adapter-react-18';


### PR DESCRIPTION
### Description
* Added generic support for notifications to now have links but left params undefined by default to ensure existing notifications are unaffected. 
* Updated check-in item not on loan/found to have a link to the search for the entered barcode in the backoffice. 
* Left other notifications as they are as none particularly looked like they needed a link to elsewhere but will be a simple future fix if needed.

Error message with link:
<img width="1555" height="577" alt="image" src="https://github.com/user-attachments/assets/350b4ee9-20a5-4c89-995d-c4c59d4fdcf2" />

Link clicked with item not existing (opens in new tab): 
<img width="3098" height="717" alt="image" src="https://github.com/user-attachments/assets/5acb2aa7-63d1-49f9-a2a0-5f1ab424f822" />

Link clicked with item existing (opens in new tab):
<img width="3098" height="717" alt="image" src="https://github.com/user-attachments/assets/5f07ae28-8b02-4dd3-b966-095e21affb19" />

* closes https://github.com/CERNDocumentServer/cds-ils/issues/833