### PR TITLE
Frontsite a11y improvements

### DIFF
--- a/src/lib/components/CopyButton/CopyButton.js
+++ b/src/lib/components/CopyButton/CopyButton.js
@@ -18,7 +18,12 @@ class SimpleCopyButton extends React.Component {
           onCopy(text);
         }}
       >
-        <Button className="copy" basic icon="copy" />
+        <Button
+          className="copy"
+          basic
+          icon="copy"
+          aria-label="Copy to clipboard"
+        />
       </CopyToClipboard>
     );
   }

--- a/src/lib/components/HttpErrors/HttpError.js
+++ b/src/lib/components/HttpErrors/HttpError.js
@@ -5,7 +5,7 @@
 
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { Grid, Button, Icon } from 'semantic-ui-react';
+import { Grid, Button, Icon, Header } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import Overridable from 'react-overridable';
 
@@ -24,8 +24,14 @@ class HttpError extends Component {
             <Grid.Column>
               <Icon name={icon} size="massive" />
               <h1>{title}</h1>
-              <h3>{message}</h3>
-              {errorId ? <h4> Error Id: {errorId}</h4> : null}
+              <Header as="h2" size="small">
+                {message}
+              </Header>
+              {errorId ? (
+                <p>
+                  <strong>Error Id:</strong> {errorId}
+                </p>
+              ) : null}
               {!isBackOffice && (
                 <Link to="/">
                   <Button icon labelPosition="left" primary>

--- a/src/lib/components/ILSMenu/ILSMenu.js
+++ b/src/lib/components/ILSMenu/ILSMenu.js
@@ -163,6 +163,7 @@ class ILSMenu extends Component {
                   <Menu.Item
                     as={Link}
                     to={FrontSiteRoutes.documentsListWithQuery('')}
+                    aria-label="Search"
                   >
                     <Icon name="search" />
                   </Menu.Item>

--- a/src/lib/components/InfoPopup/InfoPopup.js
+++ b/src/lib/components/InfoPopup/InfoPopup.js
@@ -5,26 +5,25 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Popup, Icon } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 
 export const InfoPopup = ({ children, message }) => {
   return (
-    <Popup
-      content={message}
-      wide="very"
-      trigger={
-        <span className="info-popup">
-          {children}
-          <Icon color="grey" name="question circle outline" />
-        </span>
-      }
-    />
+    <span className="info-popup">
+      <PopupIcon
+        content={message}
+        icon="question circle outline"
+        iconProps={{ color: 'grey' }}
+        wide="very"
+        triggerChildren={children}
+      />
+    </span>
   );
 };
 
 InfoPopup.propTypes = {
   children: PropTypes.node,
-  message: PropTypes.node.isRequired,
+  message: PropTypes.string.isRequired,
 };
 
 InfoPopup.defaultProps = {

--- a/src/lib/components/PopupIcon/PopupIcon.js
+++ b/src/lib/components/PopupIcon/PopupIcon.js
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: 2026 CERN.
+ * SPDX-License-Identifier: MIT
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Popup, Icon } from 'semantic-ui-react';
+
+export const PopupIcon = ({
+  content,
+  icon,
+  ariaLabel,
+  iconProps,
+  triggerChildren,
+  ...popupProps
+}) => (
+  <Popup
+    content={content}
+    on={['hover', 'focus']}
+    trigger={
+      <span>
+        {triggerChildren}
+        <Icon
+          name={icon}
+          role="button"
+          tabIndex={0}
+          aria-label={
+            ariaLabel ||
+            (typeof content === 'string' ? content : 'More information')
+          }
+          {...iconProps}
+        />
+      </span>
+    }
+    {...popupProps}
+  />
+);
+
+PopupIcon.propTypes = {
+  content: PropTypes.node.isRequired,
+  icon: PropTypes.string,
+  // required when content is not a plain string
+  ariaLabel: PropTypes.string,
+  iconProps: PropTypes.object,
+  triggerChildren: PropTypes.node,
+};
+
+PopupIcon.defaultProps = {
+  icon: 'info circle',
+  ariaLabel: null,
+  iconProps: {},
+  triggerChildren: null,
+};

--- a/src/lib/components/PopupIcon/index.js
+++ b/src/lib/components/PopupIcon/index.js
@@ -1,0 +1,6 @@
+/*
+ * SPDX-FileCopyrightText: 2026 CERN.
+ * SPDX-License-Identifier: MIT
+ */
+
+export { PopupIcon } from './PopupIcon.js';

--- a/src/lib/components/SearchBar/SearchBarILS.js
+++ b/src/lib/components/SearchBar/SearchBarILS.js
@@ -61,6 +61,7 @@ export class SearchBarILS extends Component {
       <Input
         action={{
           icon: 'search',
+          'aria-label': 'Submit search',
           onClick: () => onSearchHandler(currentValue),
         }}
         onChange={(event, { value }) => {
@@ -73,6 +74,7 @@ export class SearchBarILS extends Component {
         fluid
         size="big"
         placeholder={placeholder}
+        aria-label={placeholder || 'Search'}
         className={`${parentClass} ils-searchbar`}
         ref={this.inputRef}
         {...rest}

--- a/src/lib/components/SearchBar/__snapshots__/SearchBarILS.test.js.snap
+++ b/src/lib/components/SearchBar/__snapshots__/SearchBarILS.test.js.snap
@@ -14,10 +14,12 @@ exports[`SearchBar tests should match snapshot 1`] = `
   <Input
     action={
       Object {
+        "aria-label": "Submit search",
         "icon": "search",
         "onClick": [Function],
       }
     }
+    aria-label="Search"
     className=" ils-searchbar"
     fluid={true}
     onChange={[Function]}
@@ -33,6 +35,7 @@ exports[`SearchBar tests should match snapshot 1`] = `
       onPaste={[Function]}
     >
       <input
+        aria-label="Search"
         onChange={[Function]}
         onKeyPress={[Function]}
         placeholder="Search"
@@ -40,6 +43,7 @@ exports[`SearchBar tests should match snapshot 1`] = `
         value=""
       />
       <Button
+        aria-label="Submit search"
         as="button"
         icon="search"
         onClick={[Function]}
@@ -48,6 +52,7 @@ exports[`SearchBar tests should match snapshot 1`] = `
           innerRef={
             Object {
               "current": <button
+                aria-label="Submit search"
                 class="ui icon button"
               >
                 <i
@@ -62,6 +67,7 @@ exports[`SearchBar tests should match snapshot 1`] = `
             innerRef={
               Object {
                 "current": <button
+                  aria-label="Submit search"
                   class="ui icon button"
                 >
                   <i
@@ -73,6 +79,7 @@ exports[`SearchBar tests should match snapshot 1`] = `
             }
           >
             <button
+              aria-label="Submit search"
               className="ui icon button"
               onClick={[Function]}
             >

--- a/src/lib/components/backoffice/DeleteRecordModal/DeleteButton/DeleteButton.js
+++ b/src/lib/components/backoffice/DeleteRecordModal/DeleteButton/DeleteButton.js
@@ -14,6 +14,7 @@ export default class DeleteButton extends Component {
         icon="trash alternate"
         size="small"
         title="Delete record"
+        aria-label="Delete record"
         {...this.props}
       />
     );

--- a/src/lib/components/backoffice/PaymentInformation/PaymentInformation.js
+++ b/src/lib/components/backoffice/PaymentInformation/PaymentInformation.js
@@ -9,7 +9,8 @@ import { InfoMessage } from '@components/InfoMessage';
 import { invenioConfig } from '@config';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Grid, Icon, Popup } from 'semantic-ui-react';
+import { Grid } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import { max } from 'lodash';
 
 export function leftPaymentTable(order, type = 'acquisition-order') {
@@ -35,9 +36,9 @@ export function leftPaymentTable(order, type = 'acquisition-order') {
       name: (
         <>
           IPR ID{' '}
-          <Popup
+          <PopupIcon
             content="Internal purchase requisition ID"
-            trigger={<Icon name="info circle" size="large" />}
+            iconProps={{ size: 'large' }}
           />
         </>
       ),

--- a/src/lib/components/backoffice/buttons/RemoveItemButton/RemoveItemButton.js
+++ b/src/lib/components/backoffice/buttons/RemoveItemButton/RemoveItemButton.js
@@ -18,6 +18,7 @@ export default class RemoveItemButton extends Component {
         negative
         onClick={() => onClick(dataPid)}
         className="bo-remove-item"
+        aria-label="Remove item"
       />
     );
 

--- a/src/lib/config/defaultConfig.js
+++ b/src/lib/config/defaultConfig.js
@@ -83,11 +83,16 @@ export const APP_CONFIG = {
   ],
   SEARCH_BAR_PROPS: {
     autofocus: true,
-    actionProps: { icon: 'search', content: null },
+    actionProps: {
+      icon: 'search',
+      content: null,
+      'aria-label': 'Submit search',
+    },
     uiProps: {
       className: 'ils-searchbar',
       fluid: true,
       size: 'big',
+      'aria-label': 'Search',
     },
   },
   HOME_SEARCH_BAR_PLACEHOLDER:

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -49,6 +49,7 @@ export { withCancel, recordToPidType } from '@api/utils';
 export { Media } from '@components/Media';
 export { IEFallback } from '@components/Fallbacks/IEFallback';
 export { InfoPopup } from '@components/InfoPopup';
+export { PopupIcon } from '@components/PopupIcon';
 export { Pagination } from '@components/Pagination';
 export { SeparatedList } from '@components/SeparatedList';
 export { SectionServices } from '@pages/frontsite/Home/Sections/SectionServices';

--- a/src/lib/modules/Document/DocumentAuthors.js
+++ b/src/lib/modules/Document/DocumentAuthors.js
@@ -6,7 +6,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Overridable from 'react-overridable';
-import { Icon, List, Popup } from 'semantic-ui-react';
+import { List } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import { invenioConfig } from '@config';
 
 const ET_AL_LABEL = 'et al.';
@@ -132,11 +133,11 @@ class PopUpShowMoreFields extends Component {
     return (
       <>
         {' '}
-        <Popup
+        <PopupIcon
           content={this.renderPopupContent(author)}
+          ariaLabel={`More information about ${author.full_name}`}
           position="top center"
           flowing
-          trigger={<Icon name="info circle" />}
         />
       </>
     );

--- a/src/lib/modules/Document/backoffice/DocumentList/DocumentStats.js
+++ b/src/lib/modules/Document/backoffice/DocumentList/DocumentStats.js
@@ -12,10 +12,10 @@ export default class DocumentStats extends Component {
   render() {
     const { metadata } = this.props;
     return (
-      <List verticalAlign="middle" style={{ color: '#aaa' }}>
+      <List verticalAlign="middle" style={{ color: '#595959' }}>
         <List.Item>
           <List.Content floated="right">
-            <Header style={{ color: '#aaa' }}>
+            <Header style={{ color: '#595959' }}>
               {metadata.loan_extensions}
             </Header>
           </List.Content>

--- a/src/lib/modules/Document/backoffice/DocumentSelectListEntry/DocumentSelectListEntry.js
+++ b/src/lib/modules/Document/backoffice/DocumentSelectListEntry/DocumentSelectListEntry.js
@@ -7,7 +7,7 @@ import DocumentAuthors from '@modules/Document/DocumentAuthors';
 import LiteratureTitle from '@modules/Literature/LiteratureTitle';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Icon, Popup } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 
 export default class DocumentSelectListEntry extends Component {
   render() {
@@ -20,10 +20,7 @@ export default class DocumentSelectListEntry extends Component {
         <div className="price">PID #{document.metadata.pid}</div>
         <div className="title">
           {disabled && (
-            <Popup
-              content="This document was already selected."
-              trigger={<Icon name="info circle" />}
-            />
+            <PopupIcon content="This document was already selected." />
           )}
           <LiteratureTitle
             title={document.metadata.title}

--- a/src/lib/modules/Literature/LiteratureCover.js
+++ b/src/lib/modules/Literature/LiteratureCover.js
@@ -22,8 +22,16 @@ class LiteratureCover extends Component {
   };
 
   render() {
-    const { asItem, isRestricted, linkTo, size, url, isLoading, ...uiProps } =
-      this.props;
+    const {
+      asItem,
+      isRestricted,
+      linkTo,
+      size,
+      url,
+      isLoading,
+      alt,
+      ...uiProps
+    } = this.props;
     const Cmp = asItem ? Item.Image : Image;
     const link = linkTo ? { as: Link, to: linkTo } : {};
     return (
@@ -38,6 +46,7 @@ class LiteratureCover extends Component {
             src={url}
             size={size}
             className="image-cover"
+            alt={alt}
             {...uiProps}
           />
         )}
@@ -53,6 +62,7 @@ LiteratureCover.propTypes = {
   size: PropTypes.string,
   url: PropTypes.string,
   isLoading: PropTypes.bool,
+  alt: PropTypes.string,
 };
 
 LiteratureCover.defaultProps = {
@@ -62,6 +72,7 @@ LiteratureCover.defaultProps = {
   size: 'large',
   url: null,
   isLoading: false,
+  alt: '',
 };
 
 export default Overridable.component('LiteratureCover', LiteratureCover);

--- a/src/lib/modules/Relations/backoffice/components/RelationModal/RelationModal.js
+++ b/src/lib/modules/Relations/backoffice/components/RelationModal/RelationModal.js
@@ -5,7 +5,8 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Icon, Modal, Popup } from 'semantic-ui-react';
+import { Button, Icon, Modal } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 
@@ -88,9 +89,10 @@ export default class RelationModal extends Component {
               {triggerButtonContent}
             </Button>
             {disabled && disabledContent && (
-              <Popup
+              <PopupIcon
                 content={disabledContent}
-                trigger={<Icon size="large" name="info circle" color="grey" />}
+                ariaLabel="Why is this disabled?"
+                iconProps={{ size: 'large', color: 'grey' }}
               />
             )}
           </div>

--- a/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderLines.js
+++ b/src/lib/pages/backoffice/Acquisition/Order/OrderDetails/OrderLines.js
@@ -10,7 +10,8 @@ import { BackOfficeRoutes } from '@routes/urls';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Divider, Grid, Icon, Item, Message, Popup } from 'semantic-ui-react';
+import { Divider, Grid, Item, Message } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import Overridable from 'react-overridable';
 import { renderSubtitle } from '@modules/Document/utils';
 
@@ -65,10 +66,7 @@ const OrderLineMiddleColumn = ({ line }) => {
       <Item.Description>
         <label>IDT ID: </label>
         {line.inter_departmental_transaction_id || '-'}{' '}
-        <Popup
-          content="Inter departmental transaction ID"
-          trigger={<Icon name="info circle" />}
-        />
+        <PopupIcon content="Inter departmental transaction ID" />
       </Item.Description>
     </>
   );

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentStats/DocumentStats.js
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentStats/DocumentStats.js
@@ -4,15 +4,8 @@
  */
 
 import React, { Component } from 'react';
-import {
-  Form,
-  Grid,
-  Header,
-  Icon,
-  Popup,
-  Segment,
-  Table,
-} from 'semantic-ui-react';
+import { Form, Grid, Header, Segment, Table } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import { DatePicker } from '@components/DatePicker';
 import { Error } from '@components/Error';
 import { Loader } from '@components/Loader';
@@ -56,12 +49,12 @@ export default class DocumentStats extends Component {
                 <Table.HeaderCell>renewals</Table.HeaderCell>
                 <Table.HeaderCell>
                   average{' '}
-                  <Popup
+                  <PopupIcon
                     position="top right"
                     content={`This average is computed with the number of past
                     loans on the selected range of dates, and the current number
                     of items (${itemsCount}) of the document.`}
-                    trigger={<Icon name="info circle" size="small" />}
+                    iconProps={{ size: 'small' }}
                   />
                 </Table.HeaderCell>
               </Table.Row>

--- a/src/lib/pages/backoffice/Document/DocumentDetails/DocumentStats/__snapshots__/DocumentStats.test.js.snap
+++ b/src/lib/pages/backoffice/Document/DocumentDetails/DocumentStats/__snapshots__/DocumentStats.test.js.snap
@@ -89,28 +89,19 @@ exports[`DocumentStats tests should load the component 1`] = `
                   >
                     average
                      
-                    <Popup
+                    <PopupIcon
+                      ariaLabel={null}
                       content="This average is computed with the number of past
                     loans on the selected range of dates, and the current number
                     of items (1) of the document."
-                      disabled={false}
-                      eventsEnabled={true}
-                      on={
-                        Array [
-                          "click",
-                          "hover",
-                        ]
+                      icon="info circle"
+                      iconProps={
+                        Object {
+                          "size": "small",
+                        }
                       }
-                      pinned={false}
-                      popperModifiers={Array []}
                       position="top right"
-                      trigger={
-                        <Icon
-                          as="i"
-                          name="info circle"
-                          size="small"
-                        />
-                      }
+                      triggerChildren={null}
                     />
                   </TableHeaderCell>
                 </TableRow>

--- a/src/lib/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
+++ b/src/lib/pages/backoffice/Series/SeriesDetails/SeriesDetails.js
@@ -15,11 +15,11 @@ import {
   Divider,
   Grid,
   Icon,
-  Popup,
   Ref,
   Segment,
   Sticky,
 } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import { SeriesActionMenu } from './SeriesActionMenu';
 import { SeriesDocuments } from './SeriesDocuments';
 import { SeriesMultipartMonographs } from './SeriesMultipartMonographs';
@@ -65,8 +65,9 @@ export default class SeriesDetails extends Component {
       <Accordion.Title>
         <Icon name="dropdown" />
         Documents in this series{docsInSeries}
-        <Popup
-          trigger={<Icon name="help circle" style={{ float: 'right' }} />}
+        <PopupIcon
+          icon="help circle"
+          iconProps={{ style: { float: 'right' } }}
           content="You can add/remove documents to this series by using the series panel in the document details"
           position="top right"
         />
@@ -90,8 +91,9 @@ export default class SeriesDetails extends Component {
       <Accordion.Title>
         <Icon name="dropdown" />
         Multipart monographs in this series{multiMonoInSeries}
-        <Popup
-          trigger={<Icon name="help circle" style={{ float: 'right' }} />}
+        <PopupIcon
+          icon="help circle"
+          iconProps={{ style: { float: 'right' } }}
           content="You can add/remove multipart monograph to this series by using the series panel in the document details"
           position="top right"
         />

--- a/src/lib/pages/frontsite/Documents/DocumentDetails/LoanRequestForm/LoanRequestForm.js
+++ b/src/lib/pages/frontsite/Documents/DocumentDetails/LoanRequestForm/LoanRequestForm.js
@@ -90,6 +90,7 @@ class LoanRequestForm extends Component {
               />
             </label>
           }
+          aria-label={method.text}
           name="deliveryMethodRadioGroup"
           value={method.value}
           checked={deliveryMethod === method.value}
@@ -124,6 +125,7 @@ class LoanRequestForm extends Component {
         <Checkbox
           className="loan-request-delivery-date"
           label="I require it before a certain date."
+          aria-label="I require it before a certain date."
           onClick={() => {
             this.setState({ activeDeliveryDate: !activeDeliveryDate });
           }}

--- a/src/lib/pages/frontsite/Home/Sections/SectionInstallation.js
+++ b/src/lib/pages/frontsite/Home/Sections/SectionInstallation.js
@@ -25,7 +25,8 @@ export class SectionInstallation extends Component {
           <Container fluid className="dot-background">
             <Container className="fs-landing-page-section">
               <Header
-                as="h1"
+                as="h2"
+                size="huge"
                 className="section-header highlight"
                 textAlign="center"
               >

--- a/src/lib/pages/frontsite/Home/Sections/SectionServices.js
+++ b/src/lib/pages/frontsite/Home/Sections/SectionServices.js
@@ -14,7 +14,8 @@ export class SectionServices extends Component {
         <Container fluid className="dot-background">
           <Container className="fs-landing-page-section">
             <Header
-              as="h1"
+              as="h2"
+              size="huge"
               className="section-header highlight"
               textAlign="center"
             >

--- a/src/lib/pages/frontsite/PatronProfile/LoansListEntry.js
+++ b/src/lib/pages/frontsite/PatronProfile/LoansListEntry.js
@@ -58,7 +58,14 @@ export default class LoansListEntry extends Component {
     return (
       <Overridable id="LoansListEntry.layout" {...this.props}>
         <Item className={itemClass} key={loan.pid}>
-          <LiteratureCover asItem size="tiny" url={coverUrl} {...linkToProp} />
+          <LiteratureCover
+            asItem
+            size="tiny"
+            url={coverUrl}
+            {...linkToProp}
+            tabindex="-1"
+            aria-hidden="true"
+          />
           <Item.Content>
             <Item.Header {...toProp}>
               <LiteratureTitle

--- a/src/lib/pages/frontsite/PatronProfile/LoansListEntry.js
+++ b/src/lib/pages/frontsite/PatronProfile/LoansListEntry.js
@@ -47,6 +47,7 @@ export default class LoansListEntry extends Component {
           <div className="float-right">
             <Link
               to={FrontSiteRoutes.documentsListWithQuery(`"${documentTitle}"`)}
+              aria-label="Search for this literature in the catalogue"
             >
               <Icon name="search" />
             </Link>

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/BrwReqLoanExtendButton.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/BrwReqLoanExtendButton.js
@@ -11,7 +11,8 @@ import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Button, Icon, Popup } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import { DateTime } from 'luxon';
 
 const INFO_MESSAGES = {
@@ -87,11 +88,7 @@ const validateLoanExtension = (brwReqLoan) => {
   return {
     isValid: isValid,
     cmp: msg ? (
-      <Popup
-        content={msg}
-        trigger={<Icon name="info" />}
-        position="top right"
-      />
+      <PopupIcon content={msg} icon="info" position="top right" />
     ) : null,
   };
 };

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/LoanExtendButton.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/LoanExtendButton.js
@@ -12,7 +12,8 @@ import _get from 'lodash/get';
 import _has from 'lodash/has';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Button, Icon, Popup } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import { DateTime } from 'luxon';
 
 const INFO_MESSAGES = {
@@ -171,9 +172,9 @@ class LoanExtendButton extends Component {
           />
         )}
         {isDisabled && (
-          <Popup
+          <PopupIcon
             content={validation.msg}
-            trigger={<Icon name="info" />}
+            icon="info"
             position="top right"
           />
         )}

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/LoansListEntry.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/LoansListEntry.js
@@ -44,16 +44,20 @@ export default class LoansListEntry extends Component {
   };
 
   getOverdueLabel = () => (
-    <h4>
-      Your loan is overdue. Please return the literature as soon as possible!
-    </h4>
+    <p className="loan-message" style={{ fontSize: '15px' }}>
+      <strong>
+        Your loan is overdue. Please return the literature as soon as possible!
+      </strong>
+    </p>
   );
 
   getReturnLabel = (endDate) => (
-    <h4>
-      Please return the literature before date
-      <Header size="large">{DateTime.fromISO(endDate).toLocaleString()}</Header>
-    </h4>
+    <p className="loan-message" style={{ fontSize: '15px' }}>
+      <strong>
+        Please return the literature before date{' '}
+        {DateTime.fromISO(endDate).toLocaleString()}
+      </strong>
+    </p>
   );
 
   getOngoingLabel = (startDate, isIllBrwReq) => {

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/LoansListEntry.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/LoansListEntry.js
@@ -5,7 +5,8 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { Header, Icon, Label, Message, Popup } from 'semantic-ui-react';
+import { Header, Label, Message, Popup } from 'semantic-ui-react';
+import { PopupIcon } from '@components/PopupIcon';
 import LoansListItem from '../LoansListEntry';
 import { BrwReqLoanExtendButton } from './BrwReqLoanExtendButton';
 import { LoanExtendButton } from './LoanExtendButton';
@@ -57,9 +58,10 @@ export default class LoansListEntry extends Component {
 
   getOngoingLabel = (startDate, isIllBrwReq) => {
     const illWarningCmp = isIllBrwReq ? (
-      <Popup
+      <PopupIcon
         content="This loan involves third party library, please return on time."
-        trigger={<Icon name="exclamation circle" size="large" color="red" />}
+        icon="exclamation circle"
+        iconProps={{ size: 'large', color: 'red' }}
       />
     ) : null;
     return (

--- a/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/__snapshots__/LoanExtendButton.test.js.snap
+++ b/src/lib/pages/frontsite/PatronProfile/PatronCurrentLoans/__snapshots__/LoanExtendButton.test.js.snap
@@ -35,85 +35,120 @@ exports[`Extend loan button tests should match snapshot 1`] = `
   onError={[Function]}
   onSuccess={[Function]}
 >
-  <Popup
+  <PopupIcon
+    ariaLabel={null}
     content="It is too early for extending the loan. You can request an extension from
     January 25."
-    disabled={false}
-    eventsEnabled={true}
-    on={
-      Array [
-        "click",
-        "hover",
-      ]
-    }
-    pinned={false}
-    popperModifiers={Array []}
+    icon="info"
+    iconProps={Object {}}
     position="top right"
-    trigger={
-      <Icon
-        as="i"
-        name="info"
-      />
-    }
+    triggerChildren={null}
   >
-    <Portal
-      closeOnDocumentClick={true}
-      closeOnEscape={true}
-      closeOnTriggerClick={true}
-      closeOnTriggerMouseLeave={true}
-      eventPool="default"
-      mouseEnterDelay={50}
-      mouseLeaveDelay={70}
-      onClose={[Function]}
-      onMount={[Function]}
-      onOpen={[Function]}
-      onUnmount={[Function]}
-      openOnTriggerClick={true}
-      openOnTriggerMouseEnter={true}
+    <Popup
+      content="It is too early for extending the loan. You can request an extension from
+    January 25."
+      disabled={false}
+      eventsEnabled={true}
+      on={
+        Array [
+          "hover",
+          "focus",
+        ]
+      }
+      pinned={false}
+      popperModifiers={Array []}
+      position="top right"
       trigger={
-        <Icon
-          as="i"
-          name="info"
-        />
-      }
-      triggerRef={
-        Object {
-          "current": <i
-            aria-hidden="true"
-            class="info icon"
-          />,
-        }
-      }
-    >
-      <Ref
-        innerRef={[Function]}
-      >
-        <RefFindNode
-          innerRef={[Function]}
-        >
+        <span>
           <Icon
+            aria-label="It is too early for extending the loan. You can request an extension from
+    January 25."
             as="i"
             name="info"
-            onBlur={[Function]}
-            onClick={[Function]}
-            onFocus={[Function]}
-            onMouseEnter={[Function]}
-            onMouseLeave={[Function]}
+            role="button"
+            tabIndex={0}
+          />
+        </span>
+      }
+    >
+      <Portal
+        closeOnDocumentClick={true}
+        closeOnEscape={true}
+        closeOnTriggerBlur={true}
+        closeOnTriggerClick={false}
+        closeOnTriggerMouseLeave={true}
+        eventPool="default"
+        mouseEnterDelay={50}
+        mouseLeaveDelay={70}
+        onClose={[Function]}
+        onMount={[Function]}
+        onOpen={[Function]}
+        onUnmount={[Function]}
+        openOnTriggerClick={false}
+        openOnTriggerFocus={true}
+        openOnTriggerMouseEnter={true}
+        trigger={
+          <span>
+            <Icon
+              aria-label="It is too early for extending the loan. You can request an extension from
+    January 25."
+              as="i"
+              name="info"
+              role="button"
+              tabIndex={0}
+            />
+          </span>
+        }
+        triggerRef={
+          Object {
+            "current": <span>
+              <i
+                aria-label="It is too early for extending the loan. You can request an extension from
+    January 25."
+                class="info icon"
+                role="button"
+                tabindex="0"
+              />
+            </span>,
+          }
+        }
+      >
+        <Ref
+          innerRef={[Function]}
+        >
+          <RefFindNode
+            innerRef={[Function]}
           >
-            <i
-              aria-hidden="true"
-              className="info icon"
+            <span
               onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
-            />
-          </Icon>
-        </RefFindNode>
-      </Ref>
-    </Portal>
-  </Popup>
+            >
+              <Icon
+                aria-label="It is too early for extending the loan. You can request an extension from
+    January 25."
+                as="i"
+                name="info"
+                role="button"
+                tabIndex={0}
+              >
+                <i
+                  aria-label="It is too early for extending the loan. You can request an extension from
+    January 25."
+                  className="info icon"
+                  onClick={[Function]}
+                  role="button"
+                  tabIndex={0}
+                />
+              </Icon>
+            </span>
+          </RefFindNode>
+        </Ref>
+      </Portal>
+    </Popup>
+  </PopupIcon>
   <Button
     as="button"
     color="blue"

--- a/src/lib/pages/frontsite/PatronProfile/PatronPastDocumentRequests/PatronPastDocumentRequests.js
+++ b/src/lib/pages/frontsite/PatronProfile/PatronPastDocumentRequests/PatronPastDocumentRequests.js
@@ -76,6 +76,7 @@ class PatronPastDocumentRequests extends Component {
             to={FrontSiteRoutes.documentsListWithQuery(
               `"${row.metadata.document.title}"`
             )}
+            aria-label="Search for this literature in the catalogue"
           >
             <Icon name="search" />
           </Link>

--- a/src/semantic-ui/site/globals/site.variables
+++ b/src/semantic-ui/site/globals/site.variables
@@ -49,7 +49,9 @@
 @boSidebarBackgroundColor  : #eee;
 @fsBorderColor             : #c6c4d0;
 @metadataFieldsColor       : rgba(0,0,0,0.6);
-@mutedTextColor            : #aaa;
+@mutedTextColor            : #595959;
+
+@lightTextColor            : rgba(0,0,0,0.6);
 
 @danger                    : @red;
 @success                   : @green;


### PR DESCRIPTION
closes: https://github.com/CERNDocumentServer/cds-ils/issues/863

Note: This PR was only tested with running it through [cds-ils](https://github.com/CERNDocumentServer/cds-ils). The cookiecutter site was not tested.

This PR mainly focuses on making the frontsite more accessible. Some backoffice components/pages also got more accessible by proxy.
More specifically, a focus was put on the pages: /, /profile, /search and /literature/{pid}.
Changes include:
- making Popups more accessible (unfortunately limited by Semantic UI, see below)
- adding aria tags to buttons/inputs
- improving contrast
- fix heading hierarchies
- adding alt tags for images


# PopupIcon
PopupIcon uses `aria-label` instead of `aria-labelledby`/`aria-describedby`:

Semantic UI React imposes limits here:
- Icon renders an `<i>`. so `role="button"` and `tabIndex` are bolted on manually.
- Popup renders its content in a portal that only exists in the DOM while open (I think?), and exposes no API to associate the popup with its trigger (no id on the content element or aria-describedby wiring). Referencing visible sibling text via `aria-labelledby` would be cleaner but requires changes in Semantic UI.

As a fallback the popup text itself is used as the icon's aria-label, so screen reader users get the full content on focus.


