### PR TITLE
edit(loans): loan dates now only editable when active or pending

### DIFF
--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanUpdateDates/LoanUpdateDates.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanUpdateDates/LoanUpdateDates.js
@@ -35,29 +35,33 @@ export default class LoanUpdateDates extends Component {
     return metadata.state === 'CANCELLED';
   };
 
-  isActiveOrCompleted = () => {
+  isReturned = () => {
     const {
       loan: { metadata },
     } = this.props;
-    return (
-      invenioConfig.CIRCULATION.loanActiveStates.includes(metadata.state) ||
-      metadata.state === 'ITEM_RETURNED'
-    );
+    return metadata.state === 'ITEM_RETURNED';
+  };
+
+  isActive = () => {
+    const {
+      loan: { metadata },
+    } = this.props;
+    return invenioConfig.CIRCULATION.loanActiveStates.includes(metadata.state);
+  };
+
+  isEditable = () => {
+    return !this.isCancelled() && !this.isReturned();
   };
 
   handleStartDateChange = (value) => {
     this.setState(
-      this.isActiveOrCompleted()
-        ? { startDate: value }
-        : { requestStartDate: value }
+      this.isActive() ? { startDate: value } : { requestStartDate: value }
     );
   };
 
   handleEndDateChange = (value) => {
     this.setState(
-      this.isActiveOrCompleted()
-        ? { endDate: value }
-        : { requestExpireDate: value }
+      this.isActive() ? { endDate: value } : { requestExpireDate: value }
     );
   };
 
@@ -84,7 +88,7 @@ export default class LoanUpdateDates extends Component {
   isSelectionValid = () => {
     const { startDate, endDate, requestStartDate, requestExpireDate } =
       this.state;
-    const active = this.isActiveOrCompleted();
+    const active = this.isActive();
     const start = active ? startDate : requestStartDate;
     const end = active ? endDate : requestExpireDate;
     return start && end && DateTime.fromISO(start) < DateTime.fromISO(end);
@@ -99,7 +103,7 @@ export default class LoanUpdateDates extends Component {
     } = this.props;
     const { startDate, endDate, requestStartDate, requestExpireDate } =
       this.state;
-    const data = this.isActiveOrCompleted()
+    const data = this.isActive()
       ? {
           startDate: startDate,
           endDate: endDate,
@@ -124,6 +128,19 @@ export default class LoanUpdateDates extends Component {
     );
   };
 
+  renderNotEditableMessage = () => {
+    const reason = this.isCancelled()
+      ? 'This loan has been cancelled.'
+      : 'This loan has already been returned.';
+    return (
+      <Message
+        info
+        header="Dates cannot be edited"
+        content={`${reason} Loan dates can only be edited while a loan is active or pending.`}
+      />
+    );
+  };
+
   render() {
     const { isLoading, hasError, error } = this.props;
     const {
@@ -134,17 +151,15 @@ export default class LoanUpdateDates extends Component {
       requestExpireDate,
     } = this.state;
 
-    const active = this.isActiveOrCompleted();
+    const editable = this.isEditable();
+    const active = this.isActive();
 
     const title = active ? 'Edit loan dates' : 'Edit period of interest';
     const startLabel = active ? 'Start date' : 'Period of interest starts';
     const endLabel = active ? 'End date' : 'Period of interest ends';
 
     const warning =
-      !active &&
-      !this.isCancelled() &&
-      requestStartDate &&
-      requestStartDate < this.today()
+      editable && !active && requestStartDate && requestStartDate < this.today()
         ? 'The requested start date is in the past, the loan will be cancelled.'
         : null;
 
@@ -166,7 +181,9 @@ export default class LoanUpdateDates extends Component {
         <Modal open={modalOpen}>
           <Modal.Header>{title}</Modal.Header>
           <Modal.Content>
-            {hasError && (
+            {!editable && this.renderNotEditableMessage()}
+
+            {editable && hasError && (
               <Message
                 error
                 header="Something went wrong"
@@ -174,50 +191,54 @@ export default class LoanUpdateDates extends Component {
               />
             )}
 
-            {warning && this.renderWarning(warning)}
+            {editable && warning && this.renderWarning(warning)}
 
-            <Form>
-              <Form.Group>
-                <Form.Field inline required>
-                  <label>{startLabel}</label>
-                  <LocationDatePicker
-                    maxDate={active ? this.today() : null}
-                    defaultValue={active ? startDate : requestStartDate}
-                    locationPid={sessionManager.user.locationPid}
-                    placeholder={startLabel}
-                    handleDateChange={(value) =>
-                      this.handleStartDateChange(value)
-                    }
-                  />
-                </Form.Field>
-                <Form.Field inline required>
-                  <label>{endLabel}</label>
-                  <LocationDatePicker
-                    defaultValue={active ? endDate : requestExpireDate}
-                    locationPid={sessionManager.user.locationPid}
-                    placeholder={endLabel}
-                    handleDateChange={(value) =>
-                      this.handleEndDateChange(value)
-                    }
-                  />
-                </Form.Field>
-              </Form.Group>
-              {hint && this.renderHint(hint)}
-            </Form>
+            {editable && (
+              <Form>
+                <Form.Group>
+                  <Form.Field inline required>
+                    <label>{startLabel}</label>
+                    <LocationDatePicker
+                      maxDate={active ? this.today() : null}
+                      defaultValue={active ? startDate : requestStartDate}
+                      locationPid={sessionManager.user.locationPid}
+                      placeholder={startLabel}
+                      handleDateChange={(value) =>
+                        this.handleStartDateChange(value)
+                      }
+                    />
+                  </Form.Field>
+                  <Form.Field inline required>
+                    <label>{endLabel}</label>
+                    <LocationDatePicker
+                      defaultValue={active ? endDate : requestExpireDate}
+                      locationPid={sessionManager.user.locationPid}
+                      placeholder={endLabel}
+                      handleDateChange={(value) =>
+                        this.handleEndDateChange(value)
+                      }
+                    />
+                  </Form.Field>
+                </Form.Group>
+                {hint && this.renderHint(hint)}
+              </Form>
+            )}
           </Modal.Content>
           <Modal.Actions key="modalActions">
             <Button onClick={this.handleCloseModal} disabled={isLoading}>
-              Cancel
+              {editable ? 'Cancel' : 'Close'}
             </Button>
-            <Button
-              primary
-              disabled={!this.isSelectionValid() || isLoading}
-              loading={isLoading}
-              icon="checkmark"
-              labelPosition="left"
-              content="Submit"
-              onClick={this.handleUpdateLoanDates}
-            />
+            {editable && (
+              <Button
+                primary
+                disabled={!this.isSelectionValid() || isLoading}
+                loading={isLoading}
+                icon="checkmark"
+                labelPosition="left"
+                content="Submit"
+                onClick={this.handleUpdateLoanDates}
+              />
+            )}
           </Modal.Actions>
         </Modal>
       </>

--- a/src/lib/pages/backoffice/Loan/LoanDetails/LoanUpdateDates/LoanUpdateDates.js
+++ b/src/lib/pages/backoffice/Loan/LoanDetails/LoanUpdateDates/LoanUpdateDates.js
@@ -8,7 +8,15 @@ import { invenioConfig } from '@config';
 import { DateTime } from 'luxon';
 import { PropTypes } from 'prop-types';
 import React, { Component } from 'react';
-import { Button, Divider, Form, Icon, Message, Modal } from 'semantic-ui-react';
+import {
+  Button,
+  Divider,
+  Form,
+  Icon,
+  Message,
+  Modal,
+  Popup,
+} from 'semantic-ui-react';
 import { sessionManager } from '@authentication/services/SessionManager';
 import { LocationDatePicker } from '@modules/Location';
 
@@ -165,25 +173,39 @@ export default class LoanUpdateDates extends Component {
 
     const hint = active ? 'The loan start date cannot be in the future.' : null;
 
+    const notEditableReason = this.isCancelled()
+      ? 'This loan has been cancelled.'
+      : 'This loan has already been returned.';
+
+    const editButton = (
+      <Button
+        icon
+        primary
+        labelPosition="left"
+        fluid
+        onClick={this.handleOpenModal}
+        disabled={!editable}
+      >
+        <Icon name="edit" />
+        {title}
+      </Button>
+    );
+
     return (
       <>
-        <Button
-          icon
-          primary
-          labelPosition="left"
-          fluid
-          onClick={this.handleOpenModal}
-        >
-          <Icon name="edit" />
-          {title}
-        </Button>
+        {editable ? (
+          editButton
+        ) : (
+          <Popup
+            content={`${notEditableReason} Loan dates can only be edited while a loan is active or pending.`}
+            trigger={<span>{editButton}</span>}
+          />
+        )}
 
         <Modal open={modalOpen}>
           <Modal.Header>{title}</Modal.Header>
           <Modal.Content>
-            {!editable && this.renderNotEditableMessage()}
-
-            {editable && hasError && (
+            {hasError && (
               <Message
                 error
                 header="Something went wrong"
@@ -191,54 +213,50 @@ export default class LoanUpdateDates extends Component {
               />
             )}
 
-            {editable && warning && this.renderWarning(warning)}
+            {warning && this.renderWarning(warning)}
 
-            {editable && (
-              <Form>
-                <Form.Group>
-                  <Form.Field inline required>
-                    <label>{startLabel}</label>
-                    <LocationDatePicker
-                      maxDate={active ? this.today() : null}
-                      defaultValue={active ? startDate : requestStartDate}
-                      locationPid={sessionManager.user.locationPid}
-                      placeholder={startLabel}
-                      handleDateChange={(value) =>
-                        this.handleStartDateChange(value)
-                      }
-                    />
-                  </Form.Field>
-                  <Form.Field inline required>
-                    <label>{endLabel}</label>
-                    <LocationDatePicker
-                      defaultValue={active ? endDate : requestExpireDate}
-                      locationPid={sessionManager.user.locationPid}
-                      placeholder={endLabel}
-                      handleDateChange={(value) =>
-                        this.handleEndDateChange(value)
-                      }
-                    />
-                  </Form.Field>
-                </Form.Group>
-                {hint && this.renderHint(hint)}
-              </Form>
-            )}
+            <Form>
+              <Form.Group>
+                <Form.Field inline required>
+                  <label>{startLabel}</label>
+                  <LocationDatePicker
+                    maxDate={active ? this.today() : null}
+                    defaultValue={active ? startDate : requestStartDate}
+                    locationPid={sessionManager.user.locationPid}
+                    placeholder={startLabel}
+                    handleDateChange={(value) =>
+                      this.handleStartDateChange(value)
+                    }
+                  />
+                </Form.Field>
+                <Form.Field inline required>
+                  <label>{endLabel}</label>
+                  <LocationDatePicker
+                    defaultValue={active ? endDate : requestExpireDate}
+                    locationPid={sessionManager.user.locationPid}
+                    placeholder={endLabel}
+                    handleDateChange={(value) =>
+                      this.handleEndDateChange(value)
+                    }
+                  />
+                </Form.Field>
+              </Form.Group>
+              {hint && this.renderHint(hint)}
+            </Form>
           </Modal.Content>
           <Modal.Actions key="modalActions">
             <Button onClick={this.handleCloseModal} disabled={isLoading}>
-              {editable ? 'Cancel' : 'Close'}
+              Cancel
             </Button>
-            {editable && (
-              <Button
-                primary
-                disabled={!this.isSelectionValid() || isLoading}
-                loading={isLoading}
-                icon="checkmark"
-                labelPosition="left"
-                content="Submit"
-                onClick={this.handleUpdateLoanDates}
-              />
-            )}
+            <Button
+              primary
+              disabled={!this.isSelectionValid() || isLoading}
+              loading={isLoading}
+              icon="checkmark"
+              labelPosition="left"
+              content="Submit"
+              onClick={this.handleUpdateLoanDates}
+            />
           </Modal.Actions>
         </Modal>
       </>


### PR DESCRIPTION
Loans dates can now only be edited if the loan is active or pending. When the edit button is clicked a popup appears with an error message if the loan is returned or cancelled.

UI after clicking the edit dates return button for each type of loan:

Pending loan:
<img width="3101" height="1587" alt="image" src="https://github.com/user-attachments/assets/e25aacdd-200f-427a-b533-30434c5bed58" />

Cancelled loan:
<img width="3101" height="1587" alt="image" src="https://github.com/user-attachments/assets/23f7427c-3053-477d-b1b5-20a7939dd83a" />

Item on loan (active):
<img width="3101" height="1587" alt="image" src="https://github.com/user-attachments/assets/57ded570-baa5-49cc-9fd2-06ccda2533b5" />

Returned:
<img width="3101" height="1587" alt="image" src="https://github.com/user-attachments/assets/da91fcca-21b1-402e-8925-59cbe45c0c1e" />


* closes https://github.com/CERNDocumentServer/cds-ils/issues/1004