### PR TITLE
fix(search): stopped filters disappearing when no results

### DIFF
--- a/src/lib/pages/frontsite/Literature/LiteratureSearch/SearchAggregation.js
+++ b/src/lib/pages/frontsite/Literature/LiteratureSearch/SearchAggregation.js
@@ -14,12 +14,12 @@ class SearchAggregation extends Component {
     const { currentResultsState, modelName } = this.props;
     const totalResults = currentResultsState.data.total;
 
-    return totalResults > 0 ? (
+    return (
       <>
         <Header content="Filter by" />
         <SearchAggregationsCards modelName={modelName} />
       </>
-    ) : null;
+    );
   }
 }
 


### PR DESCRIPTION
Stopped filters disappearing when no search results in document search in frontoffice.

* closes https://github.com/inveniosoftware/react-invenio-app-ils/issues/702